### PR TITLE
[feature] Change the docker base image to `nvidia/cuda`, add `docker-compose.yml`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM nvidia/cuda:11.6.2-base-ubuntu20.04
 
 COPY nvidia_gpu_exporter /usr/bin/nvidia_gpu_exporter
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,26 +97,23 @@ You can run the exporter in a Docker container.
 
 For it to work, you will need to ensure the following:
 
-- The `nvidia-smi` binary is bind-mounted from the host to the container under its `PATH`
-- The devices `/dev/nvidiaX` (depends on the number of GPUs you have) and `/dev/nvidiactl` are mounted into the container
-- The library files `libnvidia-ml.so` and `libnvidia-ml.so.1` are mounted inside the container.
-  They are typically found under `/usr/lib/x86_64-linux-gnu/` or `/usr/lib/i386-linux-gnu/`.
-  Locate them in your host to ensure you are mounting them from the correct path.
+- [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed.
+- execute `docker run --rm --gpus all nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi` can get the expected `nvidia-smi` response.
 
-A working example with all these combined (tested in `Ubuntu 20.04`):
+A working example with all these combined (tested in `Debian 11`):
 
 ```bash
-$ docker run -d \
---name nvidia_smi_exporter \
---restart unless-stopped \
---device /dev/nvidiactl:/dev/nvidiactl \
---device /dev/nvidia0:/dev/nvidia0 \
--v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so \
--v /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 \
--v /usr/bin/nvidia-smi:/usr/bin/nvidia-smi \
--p 9835:9835 \
-utkuozdemir/nvidia_gpu_exporter:1.1.0
+docker run -d \
+  --name nvidia_smi_exporter \
+  --restart unless-stopped \
+  --gpus all \
+  -p 9835:9835 \
+  utkuozdemir/nvidia_gpu_exporter:1.3.0
 ```
+
+### Docker Compose
+
+As shown in [docker-compose.yml](./docker-compose.yml), download it and execute `docker compose up -d`.
 
 ## Running in Kubernetes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  nvidia-smi-exporter:
+    image: utkuozdemir/nvidia_gpu_exporter:1.3.0
+    container_name: nvidia-smi-exporter
+    ports:
+      - 9835:9835
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+    restart: unless-stopped


### PR DESCRIPTION
Hi @utkuozdemir, thanks for your great work!

I noticed #110 #112 talking about how docker accessing the gpu, I thought using `nvidia/cuda` as the base image might be a good choice for less configuration to run in the docker, to I made this PR.

I added a file named `docker-compose.yml` and updated the document so that everyone can make everything fine and easy.

And also remote accessing from `arm64` like `rapberrypi-3b` or later would still work because `nvidia/cuda` support `arm64`. (but not tested because I don't have such a device)

Feel free if there is any question or something wrong. :)

Best regards!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
