### PR TITLE
feat: add --query-field-names-exclude flag

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -21,6 +21,8 @@ Flags:
       --query-field-names="AUTO"
                             Comma-separated list of the query fields. You can find out possible fields by running `nvidia-smi --help-query-gpus`. The value `AUTO` will
                             automatically detect the fields to query.
+      --query-field-names-exclude=""
+                            Comma-separated list of query fields to exclude from being queried. Names match literally, with `*` as a wildcard for any sequence of characters (e.g. `remapped_rows.histogram.*`). Useful to drop fields that are slow or unsupported on a given setup.
       --[no-]web.enable-pprof
                             Enable pprof endpoints for profiling under /debug/pprof/. Only enable this on a trusted network, as it exposes runtime internals.
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
@@ -43,3 +45,23 @@ Simply override the `--nvidia-smi-command` command-line argument (replace `SSH_U
 ```bash
 nvidia_gpu_exporter --nvidia-smi-command "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null SSH_USER@SSH_HOST nvidia-smi"
 ```
+
+## Excluding query fields
+
+By default (`--query-field-names=AUTO`) the exporter queries every field
+`nvidia-smi` reports. On some setups a few fields are slow to read or trigger
+warnings, and you may want to skip them while keeping everything else on `AUTO`.
+
+Use `--query-field-names-exclude` for that. Names match literally, and `*` is a
+wildcard for any sequence of characters.
+
+```bash
+# Skip the remapped_rows.histogram.* fields, which trigger kernel warnings in some vGPU guests
+nvidia_gpu_exporter --query-field-names-exclude "remapped_rows.histogram.*"
+
+# Exclude multiple specific fields
+nvidia_gpu_exporter --query-field-names-exclude "inforom.checksum_validation,fan.speed"
+```
+
+Fields backing the `nvidia_smi_gpu_info` metric (such as `uuid` and `name`)
+cannot be excluded, since the rest of the metrics are labeled by GPU UUID.

--- a/cmd/nvidia_gpu_exporter/main.go
+++ b/cmd/nvidia_gpu_exporter/main.go
@@ -96,6 +96,12 @@ func run() error {
 				"You can find out possible fields by running `nvidia-smi --help-query-gpu`. "+
 				"The value `%s` will automatically detect the fields to query.", exporter.DefaultQField)).
 			Default(exporter.DefaultQField).String()
+		qFieldsExclude = kingpin.Flag("query-field-names-exclude",
+			"Comma-separated list of query fields to exclude from being queried. "+
+				"Names match literally, with `*` as a wildcard for any sequence of characters "+
+				"(for example `remapped_rows.histogram.*`). Useful to drop fields that are slow "+
+				"or unsupported on a given setup.").
+			Default("").String()
 		shutdownOnErr = kingpin.Flag("shutdown-on-error",
 			"Shut down the exporter if there is an error querying nvidia-smi. "+
 				"When false, exporter will simply log this error and export it as a metric, but will not crash.").
@@ -134,6 +140,7 @@ func run() error {
 		exporter.DefaultPrefix,
 		*nvidiaSmiCommand,
 		*qFields,
+		*qFieldsExclude,
 		logger,
 	)
 	if err != nil {

--- a/internal/exporter/exclude_test.go
+++ b/internal/exporter/exclude_test.go
@@ -1,0 +1,110 @@
+//nolint:testpackage // exercises unexported field-exclusion helpers directly
+package exporter
+
+import (
+	"log/slog"
+	"slices"
+	"testing"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func TestMatchesAnyPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		exclude string
+		field   string
+		want    bool
+	}{
+		{name: "exact match", exclude: "alpha.beta", field: "alpha.beta", want: true},
+		{name: "exact non-match", exclude: "alpha.beta", field: "alpha.gamma", want: false},
+		{
+			name:    "trailing wildcard matches family",
+			exclude: "alpha.histogram.*",
+			field:   "alpha.histogram.max",
+			want:    true,
+		},
+		{name: "trailing wildcard non-match", exclude: "alpha.histogram.*", field: "alpha.correctable", want: false},
+		{name: "mid wildcard", exclude: "alpha.*.total", field: "alpha.volatile.total", want: true},
+		{name: "dot is literal not any-char", exclude: "alpha.beta", field: "alphaXbeta", want: false},
+		{name: "one of several patterns", exclude: "one,two,alpha.beta", field: "alpha.beta", want: true},
+		{name: "whitespace is trimmed", exclude: " alpha.beta , gamma.delta ", field: "gamma.delta", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			patterns := parseFieldExcludePatterns(tt.exclude)
+			if got := matchesAnyPattern(tt.field, patterns); got != tt.want {
+				t.Errorf("matchesAnyPattern(%q, %q) = %v, want %v", tt.field, tt.exclude, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterExcludedQFields(t *testing.T) {
+	t.Parallel()
+
+	// uuidQField/nameQField/driverVersionQField are required fields (they back the
+	// gpu_info metric) and must never be dropped. The rest are arbitrary.
+	in := []QField{
+		uuidQField, nameQField, driverVersionQField,
+		"alpha.one", "alpha.two",
+		"beta.histogram.max", "beta.histogram.low",
+	}
+
+	tests := []struct {
+		name    string
+		exclude string
+		want    []QField
+	}{
+		{
+			name:    "empty exclude keeps everything",
+			exclude: "",
+			want:    in,
+		},
+		{
+			name:    "exact field removed",
+			exclude: "alpha.one",
+			want: []QField{
+				uuidQField, nameQField, driverVersionQField,
+				"alpha.two",
+				"beta.histogram.max", "beta.histogram.low",
+			},
+		},
+		{
+			name:    "wildcard removes whole family",
+			exclude: "beta.histogram.*",
+			want: []QField{
+				uuidQField, nameQField, driverVersionQField,
+				"alpha.one", "alpha.two",
+			},
+		},
+		{
+			name:    "required fields are never excluded",
+			exclude: string(uuidQField) + "," + string(nameQField) + "," + string(driverVersionQField),
+			want:    in,
+		},
+		{
+			name:    "wildcard does not drop protected fields it happens to match",
+			exclude: "*",
+			want:    []QField{uuidQField, nameQField, driverVersionQField},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterExcludedQFields(slices.Clone(in), tt.exclude, discardLogger())
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("filterExcludedQFields(exclude=%q) =\n  %v\nwant\n  %v", tt.exclude, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -75,12 +75,13 @@ type GPUExporter struct {
 }
 
 func New(ctx context.Context, shutdownOnErrorFunc context.CancelCauseFunc, prefix string,
-	nvidiaSmiCommand string, qFieldsRaw string, logger *slog.Logger,
+	nvidiaSmiCommand string, qFieldsRaw string, qFieldsExcludeRaw string, logger *slog.Logger,
 ) (*GPUExporter, error) {
 	qFieldsOrdered, qFieldToRFieldMap, err := buildQFieldToRFieldMap(
 		ctx,
 		logger,
 		qFieldsRaw,
+		qFieldsExcludeRaw,
 		nvidiaSmiCommand,
 		defaultRunCmd,
 	)
@@ -125,6 +126,7 @@ func buildQFieldToRFieldMap(
 	ctx context.Context,
 	logger *slog.Logger,
 	qFieldsRaw string,
+	qFieldsExcludeRaw string,
 	nvidiaSmiCommand string,
 	command runCmd,
 ) ([]QField, map[QField]RField, error) {
@@ -146,13 +148,15 @@ func buildQFieldToRFieldMap(
 				err,
 			)
 
-			keys := slices.Collect(maps.Keys(fallbackQFieldToRFieldMap))
+			keys, rFieldMap := fallbackQFieldToRFieldMapExcluding(qFieldsExcludeRaw, logger)
 
-			return keys, fallbackQFieldToRFieldMap, nil
+			return keys, rFieldMap, nil
 		}
 
 		qFields = parsed
 	}
+
+	qFields = filterExcludedQFields(qFields, qFieldsExcludeRaw, logger)
 
 	_, resultTable, err := scrape(ctx, qFields, nvidiaSmiCommand, command)
 
@@ -489,6 +493,74 @@ func getLabels(reqFields []requiredField) []string {
 	}
 
 	return r
+}
+
+// filterExcludedQFields drops query fields matching any of the exclude patterns.
+// Required fields backing the gpu_info metric are never dropped: excluding one
+// is ignored with a warning so the metric and the uuid label stay intact.
+func filterExcludedQFields(qFields []QField, excludeRaw string, logger *slog.Logger) []QField {
+	patterns := parseFieldExcludePatterns(excludeRaw)
+	if len(patterns) == 0 {
+		return qFields
+	}
+
+	required := make(map[QField]struct{}, len(requiredFields))
+	for _, reqField := range requiredFields {
+		required[reqField.qField] = struct{}{}
+	}
+
+	kept := make([]QField, 0, len(qFields))
+
+	var excluded []string
+
+	for _, qField := range qFields {
+		if !matchesAnyPattern(string(qField), patterns) {
+			kept = append(kept, qField)
+
+			continue
+		}
+
+		if _, isRequired := required[qField]; isRequired {
+			logger.Warn("ignoring exclusion of required query field", "field", qField)
+			kept = append(kept, qField)
+
+			continue
+		}
+
+		excluded = append(excluded, string(qField))
+	}
+
+	if len(excluded) > 0 {
+		logger.Info("excluding query fields", "fields", strings.Join(excluded, ", "))
+	}
+
+	return kept
+}
+
+// fallbackQFieldToRFieldMapExcluding returns the built-in fallback field mapping
+// with the excluded fields removed, used when nvidia-smi cannot be queried for
+// the available fields.
+func fallbackQFieldToRFieldMapExcluding(
+	excludeRaw string,
+	logger *slog.Logger,
+) ([]QField, map[QField]RField) {
+	keys := slices.Collect(maps.Keys(fallbackQFieldToRFieldMap))
+	keys = filterExcludedQFields(keys, excludeRaw, logger)
+
+	return keys, subsetRFieldMap(fallbackQFieldToRFieldMap, keys)
+}
+
+// subsetRFieldMap returns the entries of full whose keys appear in keys.
+func subsetRFieldMap(full map[QField]RField, keys []QField) map[QField]RField {
+	subset := make(map[QField]RField, len(keys))
+
+	for _, key := range keys {
+		if rField, ok := full[key]; ok {
+			subset[key] = rField
+		}
+	}
+
+	return subset
 }
 
 type requiredField struct {

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -226,7 +226,7 @@ func TestNewUnknownField(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
 
-	_, err := exporter.New(ctx, nil, "aaa", "bbb", "a", logger)
+	_, err := exporter.New(ctx, nil, "aaa", "bbb", "a", "", logger)
 
 	require.Error(t, err)
 }
@@ -241,7 +241,7 @@ func TestDescribe(t *testing.T) {
 
 	const prefix = "aaa"
 
-	exp, err := exporter.New(ctx, nil, prefix, "bbb", "fan.speed,memory.used", logger)
+	exp, err := exporter.New(ctx, nil, prefix, "bbb", "fan.speed,memory.used", "", logger)
 
 	require.NoError(t, err)
 
@@ -309,6 +309,7 @@ func TestCollect(t *testing.T) {
 		"bbb",
 		"uuid,name,driver_model.current,driver_model.pending,"+
 			"vbios_version,driver_version,fan.speed,memory.used,pci.bus_id",
+		"",
 		logger,
 	)
 
@@ -359,7 +360,7 @@ func TestCollectError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
 
-	exp, err := exporter.New(ctx, nil, "aaa", "bbb", "fan.speed,memory.used", logger)
+	exp, err := exporter.New(ctx, nil, "aaa", "bbb", "fan.speed,memory.used", "", logger)
 
 	require.NoError(t, err)
 

--- a/internal/exporter/fields.go
+++ b/internal/exporter/fields.go
@@ -198,6 +198,36 @@ func ParseAutoQFields(
 	return fields, nil
 }
 
+// parseFieldExcludePatterns turns a comma-separated list of field name globs
+// into matchers. Names match literally except for "*", which matches any
+// sequence of characters (for example "remapped_rows.histogram.*").
+func parseFieldExcludePatterns(raw string) []*regexp.Regexp {
+	parts := strings.Split(raw, ",")
+	patterns := make([]*regexp.Regexp, 0, len(parts))
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		expr := "^" + strings.ReplaceAll(regexp.QuoteMeta(part), `\*`, ".*") + "$"
+		patterns = append(patterns, regexp.MustCompile(expr))
+	}
+
+	return patterns
+}
+
+func matchesAnyPattern(s string, patterns []*regexp.Regexp) bool {
+	for _, pattern := range patterns {
+		if pattern.MatchString(s) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func ExtractQFields(text string) []QField {
 	found := fieldRegex.FindAllStringSubmatch(text, -1)
 


### PR DESCRIPTION
Adds a `--query-field-names-exclude` flag to drop specific fields from being queried while keeping the rest on `AUTO`. Field names match literally, with `*` as a wildcard for any sequence of characters (e.g. `remapped_rows.histogram.*`).

This is for setups where some fields are slow or trigger driver warnings: querying `remapped_rows.histogram.*` in certain vGPU guests spams the kernel log, and `inforom.checksum_validation` can be slow under load on recent drivers. Fields backing `nvidia_smi_gpu_info` (`uuid`, `name`, etc.) are protected and cannot be excluded.

Documented in CONFIGURE.md, with unit tests for the glob matching and the required-field protection.

Closes #384.