### PR TITLE
feat: add stable identity labels to gpu_info

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -186,9 +186,9 @@ nvidia_smi_enforced_power_limit_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="471.11",name="NVIDIA GeForce RTX 2080 SUPER",uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa",vbios_version="90.04.7a.40.73",pci_bus_id="00000000:71:00.0"} 1
+nvidia_smi_gpu_info{driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="471.11",name="NVIDIA GeForce RTX 2080 SUPER",uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa",vbios_version="90.04.7a.40.73",pci_bus_id="00000000:71:00.0",serial="[N/A]",compute_cap="7.5",pci_sub_device_id="0x40051458",index="0"} 1
 # HELP nvidia_smi_index index
 # TYPE nvidia_smi_index gauge
 nvidia_smi_index{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -45,6 +45,10 @@ var (
 		{qField: vBiosVersionQField, label: "vbios_version"},
 		{qField: driverVersionQField, label: "driver_version"},
 		{qField: pciBusIDQField, label: "pci_bus_id"},
+		{qField: serialQField, label: "serial"},
+		{qField: computeCapQField, label: "compute_cap"},
+		{qField: pciSubDeviceIDQField, label: "pci_sub_device_id"},
+		{qField: indexQField, label: "index"},
 	}
 
 	defaultRunCmd = func(cmd *exec.Cmd) error {
@@ -238,10 +242,15 @@ func (e *GPUExporter) Collect(metricCh chan<- prometheus.Metric) {
 		vBiosVersion := currentRow.QFieldToCells[vBiosVersionQField].RawValue
 		driverVersion := currentRow.QFieldToCells[driverVersionQField].RawValue
 		pciBusID := currentRow.QFieldToCells[pciBusIDQField].RawValue
+		serial := currentRow.QFieldToCells[serialQField].RawValue
+		computeCap := currentRow.QFieldToCells[computeCapQField].RawValue
+		pciSubDeviceID := currentRow.QFieldToCells[pciSubDeviceIDQField].RawValue
+		index := currentRow.QFieldToCells[indexQField].RawValue
 
 		infoMetric, infoMetricErr := prometheus.NewConstMetric(e.gpuInfoDesc, prometheus.GaugeValue,
 			1, uuid, name, driverModelCurrent,
-			driverModelPending, vBiosVersion, driverVersion, pciBusID)
+			driverModelPending, vBiosVersion, driverVersion, pciBusID,
+			serial, computeCap, pciSubDeviceID, index)
 		if infoMetricErr != nil {
 			e.logger.Error("failed to create info metric", "err", infoMetricErr)
 

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -269,18 +269,10 @@ end:
 	slices.Sort(descStrs)
 
 	expectedMetrics := []string{
-		"fan_speed_ratio",
-		"memory_used_bytes",
-		"failed_scrapes_total",
-		"gpu_info",
-		"uuid",
-		"name",
-		"driver_model_current",
-		"driver_model_pending",
-		"vbios_version",
-		"driver_version",
-		"pci_bus_id",
-		"command_exit_code",
+		"fan_speed_ratio", "memory_used_bytes", "failed_scrapes_total", "gpu_info",
+		"uuid", "name", "driver_model_current", "driver_model_pending",
+		"vbios_version", "driver_version", "pci_bus_id", "serial",
+		"compute_cap", "pci_sub_device_id", "index", "command_exit_code",
 	}
 
 	slices.Sort(expectedMetrics)
@@ -344,12 +336,16 @@ end:
 
 	metricsJoined := strings.Join(metrics, "\n")
 
-	assert.Len(t, metrics, 10)
+	assert.Len(t, metrics, 16)
 	assert.Contains(t, metricsJoined, "aaa_gpu_info")
 	assert.Contains(t, metricsJoined, "command_exit_code")
 	assert.Contains(t, metricsJoined, "aaa_name")
 	assert.Contains(t, metricsJoined, "aaa_fan_speed_ratio")
 	assert.Contains(t, metricsJoined, "aaa_memory_used_bytes")
+	assert.Contains(t, metricsJoined, "aaa_compute_cap")
+	assert.Contains(t, metricsJoined, "serial")
+	assert.Contains(t, metricsJoined, "pci_sub_device_id")
+	assert.Contains(t, metricsJoined, "index")
 }
 
 func TestCollectError(t *testing.T) {

--- a/internal/exporter/fields.go
+++ b/internal/exporter/fields.go
@@ -18,6 +18,10 @@ const (
 	vBiosVersionQField       QField = "vbios_version"
 	driverVersionQField      QField = "driver_version"
 	pciBusIDQField           QField = "pci.bus_id"
+	serialQField             QField = "serial"
+	computeCapQField         QField = "compute_cap"
+	pciSubDeviceIDQField     QField = "pci.sub_device_id"
+	indexQField              QField = "index"
 	qFieldsAuto                     = "AUTO"
 	DefaultQField                   = qFieldsAuto
 )
@@ -74,6 +78,7 @@ var (
 		"memory.used":                                         "memory.used [MiB]",
 		"memory.free":                                         "memory.free [MiB]",
 		"compute_mode":                                        "compute_mode",
+		"compute_cap":                                         "compute_cap",
 		"utilization.gpu":                                     "utilization.gpu [%]",
 		"utilization.memory":                                  "utilization.memory [%]",
 		"encoder.stats.sessionCount":                          "encoder.stats.sessionCount",

--- a/internal/exporter/testdata/query.txt
+++ b/internal/exporter/testdata/query.txt
@@ -1,3 +1,3 @@
-uuid, name, driver_model.current, driver_model.pending, vbios_version, driver_version, fan.speed [%], memory.used [MiB], pci.bus_id
-GPU-df6e7a7c-7314-46f8-abc4-b88b36dcf3aa, NVIDIA GeForce RTX 2080 SUPER, WDDM, WDDM, 90.04.7a.40.73, 466.63, 38 %, 575 MiB, 00000000:01:00.0
-GPU-04757e3e-3077-4e2e-b988-7e2d647b52e9, Some Other GPU, DoesntMatter, DoesntMatter, 1a.2b.3c.4d, 123.45, 50 %, 1234 MiB, 00000000:02:00.0
+uuid, name, driver_model.current, driver_model.pending, vbios_version, driver_version, fan.speed [%], memory.used [MiB], pci.bus_id, serial, compute_cap, pci.sub_device_id, index
+GPU-df6e7a7c-7314-46f8-abc4-b88b36dcf3aa, NVIDIA GeForce RTX 2080 SUPER, WDDM, WDDM, 90.04.7a.40.73, 466.63, 38 %, 575 MiB, 00000000:01:00.0, [N/A], 7.5, 0x40051458, 0
+GPU-04757e3e-3077-4e2e-b988-7e2d647b52e9, Some Other GPU, DoesntMatter, DoesntMatter, 1a.2b.3c.4d, 123.45, 50 %, 1234 MiB, 00000000:02:00.0, [N/A], 8.6, 0x12345678, 1


### PR DESCRIPTION
Adds four identity labels to `nvidia_smi_gpu_info`: `serial`, `compute_cap`, `pci_sub_device_id`, and `index`. This is the answer to #156 (expose the GPU index for identification).

- `serial` — globally unique, immutable per-board value (`[N/A]` on consumer GeForce, populated on datacenter cards).
- `compute_cap` — CUDA compute capability (e.g. `7.5`). Also exposed as its own numeric metric `nvidia_smi_compute_cap`.
- `pci_sub_device_id` — identifies the add-in board partner, which `name` doesn't carry.
- `index` — the GPU's position.

On `index` stability: it can change across reboots, but it lives on the **info metric**, which is the idiomatic Prometheus home for mutable metadata (just like `driver_version` or `name`). The real per-GPU metrics stay keyed by the stable `uuid`, so a reboot reordering GPUs doesn't break their continuity. This is also what NVIDIA's own DCGM exporter does (it labels every metric by GPU index). Cardinality is bounded (number of GPUs), so it's not a concern.

`pci_device_id` was left out as redundant with `name` (both just identify the GPU model).

Verified live against a real RTX 2080 Super. METRICS.md and tests updated.

Closes #156.