### PR TITLE
fix: keep the user and service during package upgrades

### DIFF
--- a/scripts/post-remove.sh
+++ b/scripts/post-remove.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
-userdel -f nvidia_gpu_exporter || true
-
-systemctl daemon-reload
+# Only remove the user on a real removal, not during an upgrade. Otherwise an
+# "rpm -U" upgrade, which cleans up the old package after installing the new
+# one, would delete the user the new version still needs.
+# rpm passes the number of remaining installs ("0" on removal); deb passes an
+# action word ("remove"/"purge" on removal, "upgrade" while upgrading).
+case "$1" in
+  0 | remove | purge)
+    userdel -f nvidia_gpu_exporter || true
+    systemctl daemon-reload
+    ;;
+esac

--- a/scripts/pre-remove.sh
+++ b/scripts/pre-remove.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 set -e
 
-systemctl stop nvidia_gpu_exporter.service || true
-systemctl disable nvidia_gpu_exporter.service || true
-
-systemctl daemon-reload
+# Only stop and disable the service on a real removal, not during an upgrade.
+# Otherwise the old package's cleanup would disable the service that the new
+# version just enabled, leaving it disabled after the upgrade.
+# rpm passes the number of remaining installs ("0" on removal); deb passes an
+# action word ("remove"/"purge" on removal, "upgrade" while upgrading).
+case "$1" in
+  0 | remove | purge)
+    systemctl stop nvidia_gpu_exporter.service || true
+    systemctl disable nvidia_gpu_exporter.service || true
+    systemctl daemon-reload
+    ;;
+esac


### PR DESCRIPTION
The deb/rpm remove scripts stopped the service, disabled it and deleted the `nvidia_gpu_exporter` user **unconditionally**. On an `rpm -U` upgrade, the package manager installs the new version and then cleans up the old one, so those removal steps ran mid-upgrade and deleted the user the new version needs. The service then failed to start with "Failed to determine user credentials".

Fix: guard the pre-remove and post-remove scripts so they only stop/disable the service and remove the user on an actual removal, not during an upgrade, using the argument the package manager passes (remaining-install count on rpm, action word on deb).

Reproduced and verified on a Fedora (rpm) host:
- **Before:** install 1.4.0 then `rpm -U` 1.4.1 → user deleted, service disabled.
- **After (this fix):** install fixed vA then `rpm -U` vB → user preserved, service stays enabled and active. A real `rpm -e` removal still removes the user as expected.

Closes #324.