### PR TITLE
ci: harden workflows and fix renovate go version updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@
 name: build
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -12,7 +13,7 @@ on:
       - "samples/**"
       - "grafana/**"
       - "systemd/**"
-      - "renovate.json"
+      - ".renovaterc.json"
   pull_request:
     branches:
       - main
@@ -22,11 +23,15 @@ on:
       - "samples/**"
       - "grafana/**"
       - "systemd/**"
-      - "renovate.json"
+      - ".renovaterc.json"
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euox pipefail {0}
 
 jobs:
   build:
@@ -38,14 +43,15 @@ jobs:
         uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
-      - name: Ensure go.mod is already tidied
-        run: go mod tidy && git diff --no-patch --exit-code
+      - name: Tidy go.mod
+        run: go mod tidy
       - name: Run linters
         uses: golangci/golangci-lint-action@v9.2.1
         with:
           # renovate: depName=golangci/golangci-lint datasource=github-releases
           version: v2.12.2
           args: --timeout=3m0s
+          install-mode: goinstall
       - name: Run tests
         run: go test -v -race -coverprofile ./coverage.out -covermode=atomic -timeout 20m ./...
       - name: Print coverage results
@@ -63,3 +69,5 @@ jobs:
           args: build --snapshot --clean --single-target
         env:
           PRIVATE_ACCESS_TOKEN: placeholder
+      - name: Check for dirty files
+        run: git diff --exit-code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*.*.*"
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euox pipefail {0}
+
 jobs:
   release:
     runs-on: ubuntu-24.04

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -36,7 +36,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/\\.github\\/workflows\\/.*/"
+        "/\\.github\\/workflows\\/.*/",
+        "/Taskfile\\.yml/"
       ],
       "matchStrings": [
         "# renovate: depName=(?<depName>[^\\s]+)( datasource=(?<datasource>[^\\s]+))?( registryUrl=(?<registryUrl>\\S+))?\\n[^\\n]*?(?<currentValue>v?\\d+\\.\\d+\\.\\d+(-[\\S]+)?)"
@@ -54,7 +55,8 @@
         "(#|\\/\\/) renovate: go\\n[^\\n]*?(?<currentValue>v?\\d+\\.\\d+(\\.\\d+(-[\\S]+)?)?)"
       ],
       "depNameTemplate": "golang/go",
-      "datasourceTemplate": "golang-version"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^go(?<version>\\d+\\.\\d+\\.\\d+)$"
     }
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/utkuozdemir/nvidia_gpu_exporter
 
+// renovate: go
 go 1.26.4
 
 require (


### PR DESCRIPTION
## What

- **Fix the go.mod version not updating.** Renovate's custom manager keys off a `// renovate: go` marker comment above the `go` directive, which was missing here, so the directive was never bumped. Added the marker and aligned the go custom manager to the `github-tags` datasource with a version extraction template, matching the working setup in pv-migrate. Also added `Taskfile.yml` to the renovate-comment file patterns for future tool pins.
- **Modernize the dirtiness check.** It was `git diff --no-patch --exit-code` (hides the diff on failure) run as the only check. Now `go mod tidy` runs early and a single `git diff --exit-code` runs at the end, printing the real diff and catching anything the pipeline dirties.
- **Workflow hardening:** strict bash shell defaults (`-euox pipefail`), a `workflow_dispatch` trigger, `install-mode: goinstall` so golangci-lint builds against the project's Go toolchain, and a fix to `paths-ignore` which referenced `renovate.json` instead of the actual `.renovaterc.json`.

## Verification

- `.renovaterc.json` parses; the go custom-manager regex matches `1.26.4` from go.mod, and the extraction template pulls `1.26.4` from a `go1.26.4` tag while rejecting RC tags.
- `go mod edit` confirms go.mod still parses with the marker comment.
- govulncheck reports 0 reachable vulnerabilities.