### PR TITLE
feat: publish to winget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ Temporary Items
 # End of https://www.toptal.com/developers/gitignore/api/go,macos,jetbrains+all
 
 /dist
+/_work

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -156,3 +156,39 @@ scoops:
     homepage: https://github.com/utkuozdemir/nvidia_gpu_exporter
     description: Nvidia GPU exporter for prometheus using nvidia-smi binary
     license: MIT
+
+winget:
+  - name: nvidia_gpu_exporter
+    publisher: utkuozdemir
+    package_identifier: utkuozdemir.nvidia_gpu_exporter
+    package_name: Nvidia GPU Exporter
+    short_description: Nvidia GPU exporter for prometheus using nvidia-smi binary
+    description: >-
+      Nvidia GPU exporter for prometheus, using the nvidia-smi binary to collect,
+      parse and export GPU metrics. Supports running as a native Windows service.
+    license: MIT
+    license_url: https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/LICENSE
+    homepage: https://github.com/utkuozdemir/nvidia_gpu_exporter
+    publisher_url: https://github.com/utkuozdemir
+    publisher_support_url: https://github.com/utkuozdemir/nvidia_gpu_exporter/issues
+    # Built from the Windows zip archive (nested portable exe).
+    ids:
+      - nvidia_gpu_exporter-archive
+    release_notes: "{{ .Changelog }}"
+    tags:
+      - prometheus
+      - nvidia
+      - gpu
+      - exporter
+      - monitoring
+    repository:
+      owner: utkuozdemir
+      name: winget-pkgs
+      branch: "nvidia_gpu_exporter-{{ .Version }}"
+      token: "{{ .Env.PRIVATE_ACCESS_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,14 +54,38 @@ mv nvidia_gpu_exporter /usr/bin
 nvidia_gpu_exporter --help
 ```
 
+## Installing with winget (Windows)
+
+On Windows the exporter is also available through
+[winget](https://learn.microsoft.com/windows/package-manager/):
+
+```PowerShell
+winget install utkuozdemir.nvidia_gpu_exporter
+```
+
+That puts `nvidia_gpu_exporter` on your `PATH`, so you can run it directly.
+
+If you instead want to run it as a service, use the machine-wide install (not the
+per-user one above, so the service account can reach the binary and it keeps
+working across upgrades), then register it as shown in
+[Installing as a Windows Service](#installing-as-a-windows-service):
+
+```PowerShell
+winget install --scope machine utkuozdemir.nvidia_gpu_exporter
+nvidia_gpu_exporter install
+```
+
+Use one or the other, not both.
+
 ## Installing as a Windows Service
 
 The exporter speaks the Windows Service Control Manager protocol natively, so it
 runs as a normal Windows service registered with its own `install` command. No
 third-party service wrapper (such as NSSM) is required.
 
-Get the binary with [Scoop](https://scoop.sh) (recommended) or download it by
-hand.
+Get the binary with [Scoop](https://scoop.sh) or
+[winget](#installing-with-winget-windows), or download it by hand. The steps
+below use Scoop.
 
 > [!NOTE]
 > Earlier versions of this guide used [NSSM](https://nssm.cc) to run the exporter
@@ -95,8 +119,11 @@ hand.
    # Register the service. It starts automatically on boot and restarts on failure.
    & 'C:\ProgramData\scoop\apps\nvidia_gpu_exporter\current\nvidia_gpu_exporter.exe' install
 
-   # Allow the metrics port through the firewall.
-   New-NetFirewallRule -DisplayName "Nvidia GPU Exporter" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 9835
+   # Allow the metrics port through the firewall, scoped to the local network.
+   # Only needed if Prometheus scrapes from another machine. If Prometheus runs
+   # on this same box, loopback is never firewalled and you can skip this.
+   # Drop -RemoteAddress (or widen it) if your Prometheus is on another subnet.
+   New-NetFirewallRule -DisplayName "Nvidia GPU Exporter" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 9835 -Profile Private,Domain -RemoteAddress LocalSubnet
 
    # Start it.
    Start-Service nvidia_gpu_exporter
@@ -118,6 +145,11 @@ no flags it listens on `:9835`. For example, to use a different port:
 
 Running `install` again reconfigures the existing service in place, so to change
 the flags later just re-run it with the new ones (no need to uninstall first).
+Restart the service afterwards for the new command line to take effect:
+
+```PowerShell
+Restart-Service nvidia_gpu_exporter
+```
 
 The service writes its logs to the Windows Event Log (the `Application` log,
 under the source `nvidia_gpu_exporter`).
@@ -130,10 +162,21 @@ Get-Service nvidia_gpu_exporter
 Stop-Service nvidia_gpu_exporter
 Start-Service nvidia_gpu_exporter
 
-# Uninstall (stop it first)
+# Uninstall the service (stop it first). When the binary is on your PATH
+# (Scoop or winget both put it there) you can call it by name; if you
+# installed it by hand and it is not on your PATH, use the full path instead
+# (for example .\nvidia_gpu_exporter.exe uninstall).
 Stop-Service nvidia_gpu_exporter
-& 'C:\ProgramData\scoop\apps\nvidia_gpu_exporter\current\nvidia_gpu_exporter.exe' uninstall
+nvidia_gpu_exporter uninstall
+
+# Remove the firewall rule if you added one.
+Remove-NetFirewallRule -DisplayName "Nvidia GPU Exporter"
 ```
+
+If you installed the binary with winget, remove it afterwards with
+`winget uninstall utkuozdemir.nvidia_gpu_exporter`. With Scoop, use
+`scoop uninstall nvidia_gpu_exporter --global` (the same `--global` scope it
+was installed with).
 
 ## Installing as a Linux (Systemd) Service
 


### PR DESCRIPTION
Publishes the Windows binary to winget in addition to scoop.

On a release, goreleaser builds the three winget manifests from the Windows zip (a portable exe inside a zip installer) and opens a pull request to the winget community repository.

Verified on a real Windows box: `winget validate` passes, winget downloads and hash-verifies the artifact, and `winget install --scope machine` followed by `nvidia_gpu_exporter install` registers the service with a binary path that survives winget upgrades.

INSTALL.md gains a winget section, and the Windows service section is refined alongside it: the firewall rule is scoped to the local network, a restart step is documented after reconfiguring the service, and the uninstall instructions also remove the firewall rule and the winget or scoop package.

**No MSI:** we evaluated shipping an MSI so `winget install` could register the service in one step and decided against it. goreleaser's MSI and winget-MSI builders are paid-only, and a hand-built MSI adds significant brittle surface for the sole benefit of collapsing two commands into one. So winget stays portable; the documented service setup is `winget install` then `nvidia_gpu_exporter install`, the same two steps windows_exporter's non-MSI users take.

**All-in-one installer:** the rework moved to #417 (WIP). It depends on a release with native-service support and is being redesigned to drop scoop, so it lands after this PR and a `1.6.0` release.

**Before the first winget release:** fork `microsoft/winget-pkgs` to `utkuozdemir/winget-pkgs` and make sure `PRIVATE_ACCESS_TOKEN` (a classic PAT with `public_repo` scope) can push there — goreleaser pushes a branch there and opens the upstream PR.
