### PR TITLE
fix: ship the matching architecture binary in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:26.04
 
-ARG TARGETPLATFORM=linux/amd64
+ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/nvidia_gpu_exporter /usr/bin/nvidia_gpu_exporter
 
 EXPOSE 9835


### PR DESCRIPTION
## Problem

The multi-arch Docker images for `1.5.0` and `1.6.0` shipped the **amd64 binary inside the `linux/arm64` image**, so on arm64 hosts the container crash-loops with `exec /usr/bin/nvidia_gpu_exporter: exec format error` (reported in #418). `1.4.1` and earlier are unaffected.

## Root cause

The `Dockerfile` declared `ARG TARGETPLATFORM=linux/amd64`. That explicit default **shadows** the value BuildKit injects per platform, so the arm64 build also resolved `TARGETPLATFORM` to `linux/amd64` and copied `linux/amd64/nvidia_gpu_exporter`. This started with the `dockers_v2` switch in 1.5.0.

## Fix

Drop the default (`ARG TARGETPLATFORM`), matching goreleaser's documented `dockers_v2` Dockerfile example. BuildKit then sets the real target platform for each architecture.

## Verification

Reproduced and verified with OrbStack/buildx and a goreleaser `dockers_v2` snapshot. After the fix, the binary architecture inside each image is correct:

| image | binary |
|---|---|
| linux/amd64 | x86-64 (unchanged) |
| linux/arm64 | ARM aarch64 |

The corrected `1.5.0` and `1.6.0` images (plus `latest`) are republished separately, rebuilt from the original release archive binaries (byte-for-byte identical to what goreleaser produced at tag time, only the arm64 image's binary changes).

Closes #418.
