### PR TITLE
feat: add per-process GPU metrics

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -52,9 +52,17 @@ Flags:
                                 background, with scrapes serving the most recent
                                 result. When 0, nvidia-smi runs synchronously on
                                 each scrape instead.
-      --collect.timeout=10s     Maximum duration a single nvidia-smi run may
-                                take, including the runs at startup. 0 disables
-                                the bound.
+      --collect.timeout=10s     Maximum duration a single collection cycle may
+                                take, including all nvidia-smi runs within it
+                                and the runs at startup. 0 disables the bound.
+      --[no-]collect.compute-apps
+                                Also export per-process GPU metrics
+                                from `nvidia-smi --query-compute-apps`.
+                                Adds one nvidia-smi run per collection cycle.
+                                When the exporter runs in a container, seeing
+                                other workloads' processes requires sharing
+                                the host PID namespace (hostPID in Kubernetes,
+                                --pid=host in Docker).
       --[no-]shutdown-on-error  Shut down the exporter if there is an error
                                 querying nvidia-smi. When false, exporter will
                                 simply log this error and export it as a metric,
@@ -139,9 +147,11 @@ Two things to keep in mind in this mode:
 
 ## Collection timeout
 
-Every `nvidia-smi` run, including the field discovery runs at startup, is
-bounded by `--collect.timeout` (default `10s`). A run that exceeds it counts
-as a failed collection instead of hanging the scrape or the exporter startup.
+Every collection cycle, including the field discovery runs at startup, is
+bounded by `--collect.timeout` (default `10s`). All `nvidia-smi` runs within
+one cycle share the budget (with `--collect.compute-apps` there are two). A
+cycle that exceeds it counts as a failed collection instead of hanging the
+scrape or the exporter startup.
 This matters on setups where `nvidia-smi` can wedge on a driver issue.
 Cleaning up a killed process that refuses to die can take a couple of seconds
 on top of the timeout itself.
@@ -157,3 +167,45 @@ a slow run fails at the HTTP or Prometheus layer first. Background mode is
 mostly unaffected since scrapes only read the cached result, with one
 exception: a scrape arriving before the very first collection completes
 waits for it, so it can take up to `--collect.timeout` once at startup.
+
+## Per-process GPU metrics
+
+`--collect.compute-apps` additionally exports one set of metrics per process
+holding a compute context on a GPU, read from `nvidia-smi
+--query-compute-apps`. The main use case is a machine running several
+workloads on one GPU, where you want to see which process uses what.
+
+```text
+nvidia_smi_compute_app_info{uuid="...",pid="1234",process_name="/usr/bin/python3"} 1
+nvidia_smi_compute_app_used_memory_bytes{uuid="...",pid="1234",process_name="/usr/bin/python3"} 2.690646016e+09
+nvidia_smi_compute_apps{uuid="..."} 3
+nvidia_smi_compute_apps_last_collect_success 1
+```
+
+`nvidia_smi_compute_apps` reports an explicit `0` for an idle GPU. When the
+per-process query itself fails, all per-process series disappear and
+`nvidia_smi_compute_apps_last_collect_success` reads `0`, so a query failure
+never looks like an idle GPU.
+
+Things to keep in mind:
+
+- **Containers see only their own processes.** Process visibility follows the
+  PID namespace: an exporter container without host PID sharing sees no other
+  workloads. Run with `--pid=host` (Docker) or `hostPID: true` (Kubernetes,
+  exposed as the `hostPID` value in the Helm chart) to see everything. The
+  tradeoff is that the exporter pod can then see all host process names,
+  which some security policies forbid.
+- **Windows in WDDM mode reports no per-process memory.** The driver does not
+  manage the memory there, so `used_gpu_memory` is not available: the
+  `compute_app_info` and `compute_apps` metrics still work, the
+  `used_memory_bytes` metric is absent.
+- **MIG limits both attribution and container access.** Processes are
+  attributed to the parent GPU's UUID, not to MIG instances. A containerized
+  exporter on a MIG-enabled GPU additionally needs to run privileged with the
+  `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable (plus host PID
+  sharing), otherwise the per-process list and even some GPU-level fields
+  read `[Insufficient Permissions]`.
+- **The `pid` label churns.** Every new process creates new series, and they
+  disappear with the process. On machines with high process turnover this
+  can bloat the time series database, which is one of the reasons the
+  feature is opt-in.

--- a/METRICS.md
+++ b/METRICS.md
@@ -288,3 +288,27 @@ promhttp_metric_handler_requests_total{code="200"} 0
 promhttp_metric_handler_requests_total{code="500"} 0
 promhttp_metric_handler_requests_total{code="503"} 0
 ```
+
+## Per-process metrics (opt-in)
+
+With `--collect.compute-apps` enabled, the exporter additionally emits one set
+of series per process holding a compute context on a GPU (see the
+[configuration reference](CONFIGURE.md#per-process-gpu-metrics) for the
+caveats around containers, Windows and MIG):
+
+```text
+# HELP nvidia_smi_compute_app_info A metric with a constant '1' value labeled by the identity of a process with a compute context on a GPU.
+# TYPE nvidia_smi_compute_app_info gauge
+nvidia_smi_compute_app_info{pid="10291",process_name="/root/tools/memhog",uuid="00000000-0000-0000-0000-000000000000"} 1
+nvidia_smi_compute_app_info{pid="10309",process_name="./gpu_burn",uuid="00000000-0000-0000-0000-000000000000"} 1
+# HELP nvidia_smi_compute_app_used_memory_bytes GPU memory used by the process. Absent when the driver cannot report it (e.g. Windows WDDM).
+# TYPE nvidia_smi_compute_app_used_memory_bytes gauge
+nvidia_smi_compute_app_used_memory_bytes{pid="10291",process_name="/root/tools/memhog",uuid="00000000-0000-0000-0000-000000000000"} 2.690646016e+09
+nvidia_smi_compute_app_used_memory_bytes{pid="10309",process_name="./gpu_burn",uuid="00000000-0000-0000-0000-000000000000"} 2.9605494784e+10
+# HELP nvidia_smi_compute_apps Number of processes with a compute context on the GPU.
+# TYPE nvidia_smi_compute_apps gauge
+nvidia_smi_compute_apps{uuid="00000000-0000-0000-0000-000000000000"} 2
+# HELP nvidia_smi_compute_apps_last_collect_success Whether the most recent per-process collection succeeded (1) or not (0)
+# TYPE nvidia_smi_compute_apps_last_collect_success gauge
+nvidia_smi_compute_apps_last_collect_success 1
+```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ However, this one is written in Go to produce a single, static binary.
 - Doesn't even need to run the monitored machine: can be configured to execute `nvidia-smi` command remotely
 - No need for a Docker or Kubernetes environment
 - Auto-discovery of the metric fields `nvidia-smi` can expose (future-compatible)
+- Optional per-process GPU metrics: see which process uses how much GPU memory
 - Comes with its own [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
 
 ## Visualization

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -30,6 +30,28 @@ helm install nvidia-gpu-exporter nvidia-gpu-exporter/nvidia-gpu-exporter \
   --set runtimeClassName=nvidia
 ```
 
+## Per-process GPU metrics
+
+Enable `computeApps.enabled` to also export per-process GPU metrics
+(`nvidia_smi_compute_app_*`). Process visibility follows the PID namespace:
+without `hostPID` the exporter only sees GPU processes visible inside its own
+container, so it normally will not report processes from other pods or
+containers. Enable `hostPID` along with it. Note that `hostPID` lets the
+exporter pod see all host process names, which some security policies forbid.
+
+```bash
+helm upgrade nvidia-gpu-exporter oci://ghcr.io/utkuozdemir/charts/nvidia-gpu-exporter \
+  --set runtimeClassName=nvidia \
+  --set computeApps.enabled=true \
+  --set hostPID=true
+```
+
+On MIG-enabled GPUs the requirements are steeper: the exporter container must
+run privileged with the `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable
+(via `securityContext` and `extraEnv`) on top of `hostPID`, otherwise even
+GPU-level memory fields read `[Insufficient Permissions]`. Processes are
+attributed to the parent GPU's UUID, not to individual MIG instances.
+
 ## Upgrading from chart 1.x
 
 Chart 1.x lived in a [separate repository](https://github.com/utkuozdemir/helm-charts)
@@ -65,6 +87,7 @@ as a ConfigMap labeled for the Grafana sidecar.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the pods |
+| computeApps.enabled | bool | `false` | Also export per-process GPU metrics (`nvidia_smi_compute_app_*`). To see processes of other pods and containers, the exporter must share the host PID namespace: enable `hostPID` along with this. Note that the pid label churns with the processes, creating short-lived series. |
 | extraArgs | list | `[]` | Extra command line arguments for the exporter, e.g. `--collect.interval=30s` |
 | extraEnv | list | `[]` | Extra environment variables for the exporter container |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
@@ -73,6 +96,7 @@ as a ConfigMap labeled for the Grafana sidecar.
 | grafanaDashboard.label | string | `"grafana_dashboard"` | Label that the Grafana sidecar watches for |
 | grafanaDashboard.labelValue | string | `"1"` | Value of the sidecar label |
 | hostNetwork | bool | `false` | Use the host network for the pods |
+| hostPID | bool | `false` | Share the host PID namespace with the pods. Required for computeApps to see processes of other pods and containers, but it also lets the exporter pod see all host process names, which some security policies forbid. |
 | hostPort.enabled | bool | `false` | Expose the metrics port on the host |
 | hostPort.port | int | `9835` | The host port to expose the metrics on |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -30,6 +30,28 @@ helm install nvidia-gpu-exporter nvidia-gpu-exporter/nvidia-gpu-exporter \
   --set runtimeClassName=nvidia
 ```
 
+## Per-process GPU metrics
+
+Enable `computeApps.enabled` to also export per-process GPU metrics
+(`nvidia_smi_compute_app_*`). Process visibility follows the PID namespace:
+without `hostPID` the exporter only sees GPU processes visible inside its own
+container, so it normally will not report processes from other pods or
+containers. Enable `hostPID` along with it. Note that `hostPID` lets the
+exporter pod see all host process names, which some security policies forbid.
+
+```bash
+helm upgrade nvidia-gpu-exporter oci://ghcr.io/utkuozdemir/charts/nvidia-gpu-exporter \
+  --set runtimeClassName=nvidia \
+  --set computeApps.enabled=true \
+  --set hostPID=true
+```
+
+On MIG-enabled GPUs the requirements are steeper: the exporter container must
+run privileged with the `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable
+(via `securityContext` and `extraEnv`) on top of `hostPID`, otherwise even
+GPU-level memory fields read `[Insufficient Permissions]`. Processes are
+attributed to the parent GPU's UUID, not to individual MIG instances.
+
 ## Upgrading from chart 1.x
 
 Chart 1.x lived in a [separate repository](https://github.com/utkuozdemir/helm-charts)

--- a/charts/nvidia-gpu-exporter/templates/NOTES.txt
+++ b/charts/nvidia-gpu-exporter/templates/NOTES.txt
@@ -17,6 +17,14 @@ NVIDIA runtime:
   nvidia_smi_last_collect_success 0.
 {{- end }}
 
+{{- if and .Values.computeApps.enabled (not .Values.hostPID) }}
+
+WARNING: computeApps is enabled but hostPID is not. Without the host PID
+namespace the exporter only sees GPU processes visible inside its own
+container, so it will normally not report the processes of other pods and
+containers. Set hostPID=true to see them.
+{{- end }}
+
 Check the metrics:
 
   kubectl port-forward -n {{ .Release.Namespace }} ds/{{ include "nvidia-gpu-exporter.fullname" . }} {{ .Values.port }}:{{ .Values.port }}

--- a/charts/nvidia-gpu-exporter/templates/daemonset.yaml
+++ b/charts/nvidia-gpu-exporter/templates/daemonset.yaml
@@ -61,6 +61,9 @@ spec:
             - --query-field-names-exclude
             - {{ join "," . }}
             {{- end }}
+            {{- if .Values.computeApps.enabled }}
+            - --collect.compute-apps
+            {{- end }}
             - --log.level
             - {{ .Values.log.level }}
             - --log.format
@@ -108,3 +111,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      hostPID: {{ .Values.hostPID }}

--- a/charts/nvidia-gpu-exporter/values.schema.json
+++ b/charts/nvidia-gpu-exporter/values.schema.json
@@ -63,6 +63,15 @@
         "type": "string"
       }
     },
+    "computeApps": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "log": {
       "type": "object",
       "properties": {
@@ -92,6 +101,9 @@
       }
     },
     "hostNetwork": {
+      "type": "boolean"
+    },
+    "hostPID": {
       "type": "boolean"
     },
     "hostPort": {

--- a/charts/nvidia-gpu-exporter/values.yaml
+++ b/charts/nvidia-gpu-exporter/values.yaml
@@ -41,6 +41,13 @@ queryFieldNames:
 # with `*` as a wildcard for any sequence of characters.
 queryFieldNamesExclude: []
 
+computeApps:
+  # -- Also export per-process GPU metrics (`nvidia_smi_compute_app_*`). To
+  # see processes of other pods and containers, the exporter must share the
+  # host PID namespace: enable `hostPID` along with this. Note that the pid
+  # label churns with the processes, creating short-lived series.
+  enabled: false
+
 log:
   # -- Log level: debug, info, warn, error
   level: info
@@ -52,6 +59,11 @@ extraArgs: []
 
 # -- Use the host network for the pods
 hostNetwork: false
+
+# -- Share the host PID namespace with the pods. Required for computeApps to
+# see processes of other pods and containers, but it also lets the exporter
+# pod see all host process names, which some security policies forbid.
+hostPID: false
 
 hostPort:
   # -- Expose the metrics port on the host

--- a/cmd/nvidia_gpu_exporter/main.go
+++ b/cmd/nvidia_gpu_exporter/main.go
@@ -123,9 +123,15 @@ func run(ctx context.Context, extraHandler slog.Handler) error {
 				"recent result. When 0, nvidia-smi runs synchronously on each scrape instead.").
 			Default("0").Duration()
 		collectTimeout = kingpin.Flag("collect.timeout",
-			"Maximum duration a single nvidia-smi run may take, including the runs at startup. "+
-				"0 disables the bound.").
+			"Maximum duration a single collection cycle may take, including all nvidia-smi runs "+
+				"within it and the runs at startup. 0 disables the bound.").
 			Default("10s").Duration()
+		collectComputeApps = kingpin.Flag("collect.compute-apps",
+			"Also export per-process GPU metrics from `nvidia-smi --query-compute-apps`. "+
+				"Adds one nvidia-smi run per collection cycle. When the exporter runs in a "+
+				"container, seeing other workloads' processes requires sharing the host PID "+
+				"namespace (hostPID in Kubernetes, --pid=host in Docker).").
+			Default("false").Bool()
 		shutdownOnErr = kingpin.Flag("shutdown-on-error",
 			"Shut down the exporter if there is an error querying nvidia-smi. "+
 				"When false, exporter will simply log this error and export it as a metric, but will not crash.").
@@ -171,6 +177,7 @@ func run(ctx context.Context, extraHandler slog.Handler) error {
 		qFieldsExclude:   *qFieldsExclude,
 		interval:         *collectInterval,
 		timeout:          *collectTimeout,
+		computeApps:      *collectComputeApps,
 		onFatal:          onFatal,
 	}
 
@@ -237,6 +244,7 @@ type collectConfig struct {
 	qFieldsExclude   string
 	interval         time.Duration
 	timeout          time.Duration
+	computeApps      bool
 	onFatal          func(error)
 }
 
@@ -262,9 +270,7 @@ func setupExporter(
 		return fmt.Errorf("failed to resolve query fields: %w", err)
 	}
 
-	query := func(queryCtx context.Context) (*nvidiasmi.Table, int, error) {
-		return nvidiasmi.Query(queryCtx, cfg.nvidiaSmiCommand, resolved.Query, nvidiasmi.DefaultRunFunc)
-	}
+	query := buildQueryFunc(cfg, resolved, logger)
 
 	var src collect.Source
 
@@ -279,7 +285,7 @@ func setupExporter(
 		src = collect.NewLive(query, cfg.timeout, cfg.onFatal, logger)
 	}
 
-	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, logger)
+	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, cfg.computeApps, logger)
 
 	if err = prometheus.Register(exp); err != nil {
 		return fmt.Errorf("failed to register exporter: %w", err)
@@ -290,6 +296,41 @@ func setupExporter(
 	}
 
 	return nil
+}
+
+// buildQueryFunc builds the collection cycle: the GPU query, plus the
+// per-process query when enabled. The returned error and exit code describe
+// the GPU query alone; the per-process query fails softly inside the Reading,
+// per the contract on collect.QueryFunc.
+func buildQueryFunc(
+	cfg collectConfig,
+	resolved nvidiasmi.ResolvedFields,
+	logger *slog.Logger,
+) collect.QueryFunc {
+	return func(queryCtx context.Context) (collect.Reading, int, error) {
+		table, exitCode, err := nvidiasmi.Query(
+			queryCtx, cfg.nvidiaSmiCommand, resolved.Query, nvidiasmi.DefaultRunFunc)
+		if err != nil {
+			return collect.Reading{}, exitCode, fmt.Errorf("failed to query gpus: %w", err)
+		}
+
+		reading := collect.Reading{Table: table}
+
+		if cfg.computeApps {
+			reading.AppsAttempted = true
+
+			apps, appsErr := nvidiasmi.QueryComputeApps(
+				queryCtx, cfg.nvidiaSmiCommand, nvidiasmi.DefaultRunFunc, logger)
+			if appsErr != nil {
+				reading.AppsErr = appsErr
+			} else {
+				reading.Apps = apps
+				reading.AppsSuccess = true
+			}
+		}
+
+		return reading, exitCode, nil
+	}
 }
 
 type RootHandler struct {

--- a/internal/collect/cached_test.go
+++ b/internal/collect/cached_test.go
@@ -39,10 +39,10 @@ func TestCachedServesCacheWithoutRecollecting(t *testing.T) {
 
 	var calls atomic.Int64
 
-	query := func(_ context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(_ context.Context) (collect.Reading, int, error) {
 		calls.Add(1)
 
-		return table, 0, nil
+		return collect.Reading{Table: table}, 0, nil
 	}
 
 	cached := collect.NewCached(query, time.Hour, 0, nil, slogt.New(t))
@@ -85,10 +85,10 @@ func TestCachedCollectsOnTicks(t *testing.T) {
 
 	var calls atomic.Int64
 
-	query := func(_ context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(_ context.Context) (collect.Reading, int, error) {
 		calls.Add(1)
 
-		return &nvidiasmi.Table{}, 0, nil
+		return collect.Reading{Table: &nvidiasmi.Table{}}, 0, nil
 	}
 
 	cached := collect.NewCached(query, 10*time.Millisecond, 0, nil, slogt.New(t))
@@ -103,12 +103,12 @@ func TestCachedFirstScrapeBlocksUntilFirstCollection(t *testing.T) {
 	t.Parallel()
 
 	release := make(chan struct{})
-	query := func(ctx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(ctx context.Context) (collect.Reading, int, error) {
 		select {
 		case <-release:
-			return &nvidiasmi.Table{}, 0, nil
+			return collect.Reading{Table: &nvidiasmi.Table{}}, 0, nil
 		case <-ctx.Done():
-			return nil, -1, ctx.Err()
+			return collect.Reading{}, -1, ctx.Err()
 		}
 	}
 
@@ -137,11 +137,11 @@ func TestCachedFirstScrapeBlocksUntilFirstCollection(t *testing.T) {
 func TestCachedNotReadyWhenScrapeWinsTheRace(t *testing.T) {
 	t.Parallel()
 
-	query := func(ctx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(ctx context.Context) (collect.Reading, int, error) {
 		// never completes on its own; unblocked only by shutdown cancellation
 		<-ctx.Done()
 
-		return nil, -1, ctx.Err()
+		return collect.Reading{}, -1, ctx.Err()
 	}
 
 	cached := collect.NewCached(query, time.Hour, 0, nil, slogt.New(t))
@@ -200,10 +200,10 @@ func TestCachedRunStopsOnCancel(t *testing.T) {
 func TestCachedTimeoutBoundsCollection(t *testing.T) {
 	t.Parallel()
 
-	query := func(ctx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(ctx context.Context) (collect.Reading, int, error) {
 		<-ctx.Done()
 
-		return nil, -1, ctx.Err()
+		return collect.Reading{}, -1, ctx.Err()
 	}
 
 	cached := collect.NewCached(query, time.Hour, 50*time.Millisecond, nil, slogt.New(t))

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -21,6 +21,13 @@ type Snapshot struct {
 	Success bool
 	// Table holds the GPU data of the most recent collection, nil on failure.
 	Table *nvidiasmi.Table
+	// Apps holds the per-process data, nil when disabled or failed.
+	Apps []nvidiasmi.ComputeApp
+	// AppsAttempted reports whether the collection included a per-process query.
+	AppsAttempted bool
+	// AppsSuccess reports whether that per-process query succeeded, valid only
+	// when AppsAttempted.
+	AppsSuccess bool
 	// ExitCode is the exit code of the most recent attempt, valid only when Attempted.
 	ExitCode int
 	// Duration is how long the most recent attempt took, valid only when Attempted.
@@ -38,9 +45,30 @@ type Source interface {
 	Latest(ctx context.Context) Snapshot
 }
 
-// QueryFunc runs nvidia-smi once. It is injected so the timing and staleness
-// logic can be tested without spawning a process or parsing CSV.
-type QueryFunc func(ctx context.Context) (*nvidiasmi.Table, int, error)
+// Reading is what one collection cycle produced. The GPU table is the primary
+// result: the error and exit code returned alongside a Reading belong to the
+// GPU query alone and drive all collection health (failure counting, exit
+// code, shutdown-on-error). The per-process query is secondary and fails
+// softly: its outcome lives in the Apps fields and must never fail the
+// collection.
+type Reading struct {
+	// Table holds the GPU data.
+	Table *nvidiasmi.Table
+	// Apps holds the per-process data, nil when disabled or failed.
+	Apps []nvidiasmi.ComputeApp
+	// AppsAttempted reports whether a per-process query ran (the feature is on).
+	AppsAttempted bool
+	// AppsSuccess reports whether that query succeeded, valid only when AppsAttempted.
+	AppsSuccess bool
+	// AppsErr is the per-process query's error, for source-owned logging only.
+	AppsErr error
+}
+
+// QueryFunc runs one collection cycle: the nvidia-smi GPU query, plus the
+// per-process query when enabled. It is injected so the timing and staleness
+// logic can be tested without spawning a process or parsing CSV. The returned
+// error and exit code describe the GPU query only, per the Reading contract.
+type QueryFunc func(ctx context.Context) (Reading, int, error)
 
 // collectOnce runs one collection bounded by timeout and folds the outcome
 // into a Snapshot, updating the cumulative failure count and last-success
@@ -61,7 +89,7 @@ func collectOnce(
 	defer cancel()
 
 	start := time.Now()
-	table, exitCode, err := query(callCtx)
+	reading, exitCode, err := query(callCtx)
 	now := time.Now()
 
 	snapshot := Snapshot{
@@ -89,10 +117,20 @@ func collectOnce(
 		return snapshot
 	}
 
+	// The per-process query fails softly: it is logged here (once per attempt,
+	// like a primary failure), but it does not count as a failed collection
+	// and never triggers shutdown-on-error.
+	if reading.AppsAttempted && !reading.AppsSuccess {
+		logger.Warn("failed to collect per-process data", "err", reading.AppsErr)
+	}
+
 	*lastOK = now
 
 	snapshot.Success = true
-	snapshot.Table = table
+	snapshot.Table = reading.Table
+	snapshot.Apps = reading.Apps
+	snapshot.AppsAttempted = reading.AppsAttempted
+	snapshot.AppsSuccess = reading.AppsSuccess
 	snapshot.LastSuccess = now
 	snapshot.Failures = *failures
 

--- a/internal/collect/live_test.go
+++ b/internal/collect/live_test.go
@@ -19,8 +19,8 @@ import (
 var errQueryFailed = errors.New("query failed")
 
 func staticQuery(table *nvidiasmi.Table, exitCode int, err error) collect.QueryFunc {
-	return func(_ context.Context) (*nvidiasmi.Table, int, error) {
-		return table, exitCode, err
+	return func(_ context.Context) (collect.Reading, int, error) {
+		return collect.Reading{Table: table}, exitCode, err
 	}
 }
 
@@ -75,13 +75,13 @@ func TestLiveFailuresAccumulateAndLastSuccessSticks(t *testing.T) {
 
 	table := &nvidiasmi.Table{}
 	calls := 0
-	query := func(_ context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(_ context.Context) (collect.Reading, int, error) {
 		calls++
 		if calls == 1 {
-			return table, 0, nil
+			return collect.Reading{Table: table}, 0, nil
 		}
 
-		return nil, -1, errQueryFailed
+		return collect.Reading{}, -1, errQueryFailed
 	}
 
 	live := collect.NewLive(query, 0, nil, slogt.New(t))
@@ -103,10 +103,10 @@ func TestLiveFailuresAccumulateAndLastSuccessSticks(t *testing.T) {
 func TestLiveTimeoutBecomesFailure(t *testing.T) {
 	t.Parallel()
 
-	query := func(ctx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(ctx context.Context) (collect.Reading, int, error) {
 		<-ctx.Done()
 
-		return nil, -1, ctx.Err()
+		return collect.Reading{}, -1, ctx.Err()
 	}
 
 	live := collect.NewLive(query, 50*time.Millisecond, nil, slogt.New(t))
@@ -122,7 +122,7 @@ func TestLiveTimeoutBecomesFailure(t *testing.T) {
 func TestLiveZeroTimeoutDisablesDeadline(t *testing.T) {
 	t.Parallel()
 
-	query := func(ctx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(ctx context.Context) (collect.Reading, int, error) {
 		// with a zero timeout the context must not carry a deadline; a plain
 		// context.WithTimeout(ctx, 0) would be expired already
 		_, hasDeadline := ctx.Deadline()
@@ -130,7 +130,7 @@ func TestLiveZeroTimeoutDisablesDeadline(t *testing.T) {
 
 		require.NoError(t, ctx.Err())
 
-		return &nvidiasmi.Table{}, 0, nil
+		return collect.Reading{Table: &nvidiasmi.Table{}}, 0, nil
 	}
 
 	live := collect.NewLive(query, 0, nil, slogt.New(t))
@@ -185,10 +185,10 @@ func TestLiveOnFatalNotFiredOnTimeout(t *testing.T) {
 
 	// the query returns an exit error, but only after the collection timeout
 	// fired: the kill is ours, so shutdown-on-error must not trigger
-	query := func(ctx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(ctx context.Context) (collect.Reading, int, error) {
 		<-ctx.Done()
 
-		return nil, 3, exitErr
+		return collect.Reading{}, 3, exitErr
 	}
 
 	live := collect.NewLive(query, 50*time.Millisecond, onFatal, slogt.New(t))
@@ -198,6 +198,61 @@ func TestLiveOnFatalNotFiredOnTimeout(t *testing.T) {
 	require.NoError(t, gotFatal)
 }
 
+func TestLiveAppsSoftFailure(t *testing.T) {
+	t.Parallel()
+
+	// the per-process query failing must not fail the collection: no failure
+	// counted, shutdown-on-error not fired, GPU data still served
+	table := &nvidiasmi.Table{}
+	exitErr := realExitError(t)
+	query := func(_ context.Context) (collect.Reading, int, error) {
+		return collect.Reading{
+			Table:         table,
+			AppsAttempted: true,
+			AppsSuccess:   false,
+			AppsErr:       exitErr,
+		}, 0, nil
+	}
+
+	var gotFatal error
+
+	live := collect.NewLive(query, 0, func(err error) { gotFatal = err }, slogt.New(t))
+
+	snapshot := live.Latest(t.Context())
+
+	assert.True(t, snapshot.Success)
+	assert.Same(t, table, snapshot.Table)
+	assert.Equal(t, uint64(0), snapshot.Failures)
+	assert.True(t, snapshot.AppsAttempted)
+	assert.False(t, snapshot.AppsSuccess)
+	assert.Nil(t, snapshot.Apps)
+	require.NoError(t, snapshot.Err)
+	require.NoError(t, gotFatal)
+}
+
+func TestLiveAppsSuccessCarriesApps(t *testing.T) {
+	t.Parallel()
+
+	apps := []nvidiasmi.ComputeApp{{GPUUUID: "abc", PID: "42", ProcessName: "./gpu_burn", UsedMemory: "10 MiB"}}
+	query := func(_ context.Context) (collect.Reading, int, error) {
+		return collect.Reading{
+			Table:         &nvidiasmi.Table{},
+			Apps:          apps,
+			AppsAttempted: true,
+			AppsSuccess:   true,
+		}, 0, nil
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	snapshot := live.Latest(t.Context())
+
+	assert.True(t, snapshot.Success)
+	assert.True(t, snapshot.AppsAttempted)
+	assert.True(t, snapshot.AppsSuccess)
+	assert.Equal(t, apps, snapshot.Apps)
+}
+
 func TestLiveSerializesConcurrentCalls(t *testing.T) {
 	t.Parallel()
 
@@ -205,7 +260,7 @@ func TestLiveSerializesConcurrentCalls(t *testing.T) {
 
 	firstIn := make(chan struct{}, 1)
 	release := make(chan struct{})
-	query := func(_ context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(_ context.Context) (collect.Reading, int, error) {
 		if inFlight.Add(1) > 1 {
 			overlaps.Add(1)
 		}
@@ -219,7 +274,7 @@ func TestLiveSerializesConcurrentCalls(t *testing.T) {
 
 		inFlight.Add(-1)
 
-		return &nvidiasmi.Table{}, 0, nil
+		return collect.Reading{Table: &nvidiasmi.Table{}}, 0, nil
 	}
 
 	live := collect.NewLive(query, 0, nil, slogt.New(t))

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -15,6 +15,9 @@ import (
 
 const DefaultPrefix = "nvidia_smi"
 
+// computeAppLabels is the label set on the per-process metrics.
+var computeAppLabels = []string{"uuid", "pid", "process_name"}
+
 // GPUExporter renders the latest collection as Prometheus metrics. It is
 // agnostic to how the reading is produced: the source may collect inline on
 // each scrape or serve a cached result from background collection.
@@ -29,15 +32,23 @@ type GPUExporter struct {
 	collectTimestampDesc  *prometheus.Desc
 	collectDurationDesc   *prometheus.Desc
 	gpuInfoDesc           *prometheus.Desc
+	appInfoDesc           *prometheus.Desc
+	appMemoryDesc         *prometheus.Desc
+	appCountDesc          *prometheus.Desc
+	appsSuccessDesc       *prometheus.Desc
 	logger                *slog.Logger
 	ctx                   context.Context //nolint:containedctx
 }
 
+// New builds the exporter. The per-process descriptors exist only when
+// computeApps is set: with the feature off they stay nil and the exporter
+// neither describes nor emits any per-process series.
 func New(
 	ctx context.Context,
 	prefix string,
 	fields nvidiasmi.ResolvedFields,
 	source collect.Source,
+	computeApps bool,
 	logger *slog.Logger,
 ) *GPUExporter {
 	qFieldToMetricInfoMap := BuildQFieldToMetricInfoMap(prefix, fields.Returned, logger)
@@ -47,12 +58,18 @@ func New(
 		infoLabels[i] = infoField.Label
 	}
 
+	appInfoDesc, appMemoryDesc, appCountDesc, appsSuccessDesc := newComputeAppDescs(prefix, computeApps)
+
 	return &GPUExporter{
 		ctx:                   ctx,
 		prefix:                prefix,
 		fields:                fields,
 		qFieldToMetricInfoMap: qFieldToMetricInfoMap,
 		source:                source,
+		appInfoDesc:           appInfoDesc,
+		appMemoryDesc:         appMemoryDesc,
+		appCountDesc:          appCountDesc,
+		appsSuccessDesc:       appsSuccessDesc,
 		logger:                logger,
 		failedScrapesDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, "", "failed_scrapes_total"),
@@ -88,6 +105,40 @@ func New(
 	}
 }
 
+// newComputeAppDescs builds the per-process metric descriptors (info, memory,
+// count, success), all nil when the feature is disabled.
+func newComputeAppDescs(
+	prefix string,
+	enabled bool,
+) (*prometheus.Desc, *prometheus.Desc, *prometheus.Desc, *prometheus.Desc) {
+	if !enabled {
+		return nil, nil, nil, nil
+	}
+
+	info := prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "compute_app_info"),
+		"A metric with a constant '1' value labeled by the identity of a process with a compute context on a GPU.",
+		computeAppLabels,
+		nil)
+	memory := prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "compute_app_used_memory_bytes"),
+		"GPU memory used by the process. Absent when the driver cannot report it (e.g. Windows WDDM).",
+		computeAppLabels,
+		nil)
+	count := prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "compute_apps"),
+		"Number of processes with a compute context on the GPU.",
+		[]string{"uuid"},
+		nil)
+	success := prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "compute_apps_last_collect_success"),
+		"Whether the most recent per-process collection succeeded (1) or not (0)",
+		nil,
+		nil)
+
+	return info, memory, count, success
+}
+
 // Describe describes all the metrics ever exported by the exporter. It
 // implements prometheus.Collector.
 func (e *GPUExporter) Describe(descCh chan<- *prometheus.Desc) {
@@ -101,6 +152,13 @@ func (e *GPUExporter) Describe(descCh chan<- *prometheus.Desc) {
 	e.sendDesc(descCh, e.collectTimestampDesc)
 	e.sendDesc(descCh, e.collectDurationDesc)
 	e.sendDesc(descCh, e.gpuInfoDesc)
+
+	if e.appInfoDesc != nil {
+		e.sendDesc(descCh, e.appInfoDesc)
+		e.sendDesc(descCh, e.appMemoryDesc)
+		e.sendDesc(descCh, e.appCountDesc)
+		e.sendDesc(descCh, e.appsSuccessDesc)
+	}
 }
 
 // Collect fetches the latest reading from the source and delivers it as
@@ -117,6 +175,94 @@ func (e *GPUExporter) Collect(metricCh chan<- prometheus.Metric) {
 	for _, currentRow := range snapshot.Table.Rows {
 		e.renderRow(metricCh, currentRow)
 	}
+
+	e.renderApps(metricCh, snapshot)
+}
+
+// renderApps emits the per-process metrics. Failure must not look like idle:
+// when the per-process query failed, only the success gauge (0) is emitted and
+// every per-process series is suppressed, including the zero-filled per-GPU
+// count, so "no processes" (count 0, success 1) stays distinguishable from
+// "could not observe the process list" (no count series, success 0).
+func (e *GPUExporter) renderApps(metricCh chan<- prometheus.Metric, snapshot collect.Snapshot) {
+	if e.appInfoDesc == nil || !snapshot.AppsAttempted {
+		return
+	}
+
+	success := 0.0
+	if snapshot.AppsSuccess {
+		success = 1
+	}
+
+	e.sendConst(metricCh, e.appsSuccessDesc, prometheus.GaugeValue, success)
+
+	if !snapshot.AppsSuccess {
+		return
+	}
+
+	// zero-fill the per-GPU count from the GPU table, so an idle GPU reports
+	// an explicit 0 instead of a missing series
+	counts := make(map[string]float64, len(snapshot.Table.Rows))
+	for _, row := range snapshot.Table.Rows {
+		counts[nvidiasmi.NormalizeUUID(row.QFieldToCells[nvidiasmi.UUIDQField].RawValue)] = 0
+	}
+
+	for _, app := range snapshot.Apps {
+		counts[app.GPUUUID]++
+
+		e.renderApp(metricCh, app)
+	}
+
+	for uuid, count := range counts {
+		metric, err := prometheus.NewConstMetric(e.appCountDesc, prometheus.GaugeValue, count, uuid)
+		if err != nil {
+			e.logger.Error("failed to create compute apps count metric", "err", err, "uuid", uuid)
+
+			continue
+		}
+
+		e.sendMetric(metricCh, metric)
+	}
+}
+
+// renderApp emits the info and memory metrics for a single process.
+func (e *GPUExporter) renderApp(metricCh chan<- prometheus.Metric, app nvidiasmi.ComputeApp) {
+	e.sendAppMetric(metricCh, e.appInfoDesc, 1, app)
+
+	if nvidiasmi.IsKnownAbsentValue(app.UsedMemory) {
+		// an expected state ("[N/A]" on Windows WDDM, "[Insufficient
+		// Permissions]" in restricted containers), reported for every
+		// process on every collection: skip without logging
+		return
+	}
+
+	num, err := nvidiasmi.TransformRawValue(app.UsedMemory, nvidiasmi.UsedMemoryMultiplier)
+	if err != nil {
+		e.logger.Debug("failed to transform per-process memory value",
+			"err", err, "raw_value", app.UsedMemory, "pid", app.PID)
+
+		return
+	}
+
+	e.sendAppMetric(metricCh, e.appMemoryDesc, num, app)
+}
+
+// sendAppMetric emits one per-process gauge carrying the compute app labels.
+func (e *GPUExporter) sendAppMetric(
+	metricCh chan<- prometheus.Metric,
+	desc *prometheus.Desc,
+	value float64,
+	app nvidiasmi.ComputeApp,
+) {
+	metric, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, value,
+		app.GPUUUID, app.PID, app.ProcessName)
+	if err != nil {
+		e.logger.Error("failed to create per-process metric", "err", err, "pid", app.PID)
+
+		return
+	}
+
+	e.sendMetric(metricCh, metric)
 }
 
 // renderHealth emits the collection health metrics from the snapshot's
@@ -166,10 +312,7 @@ func (e *GPUExporter) sendConst(
 // renderRow emits the gpu_info metric and one metric per queried field for a
 // single GPU row.
 func (e *GPUExporter) renderRow(metricCh chan<- prometheus.Metric, row nvidiasmi.Row) {
-	uuid := strings.TrimPrefix(
-		strings.ToLower(row.QFieldToCells[nvidiasmi.UUIDQField].RawValue),
-		"gpu-",
-	)
+	uuid := nvidiasmi.NormalizeUUID(row.QFieldToCells[nvidiasmi.UUIDQField].RawValue)
 
 	labelValues := make([]string, len(e.fields.Info))
 

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -183,13 +183,53 @@ func newTestExporter(
 	resolved, err := nvidiasmi.ResolveFields(ctx, "bbb", qFieldsRaw, "", 0, nvidiasmi.DefaultRunFunc, logger)
 	require.NoError(t, err)
 
-	query := func(queryCtx context.Context) (*nvidiasmi.Table, int, error) {
-		return nvidiasmi.Query(queryCtx, "bbb", resolved.Query, run)
+	query := func(queryCtx context.Context) (collect.Reading, int, error) {
+		table, exitCode, err := nvidiasmi.Query(queryCtx, "bbb", resolved.Query, run)
+		if err != nil {
+			return collect.Reading{}, exitCode, fmt.Errorf("query failed: %w", err)
+		}
+
+		return collect.Reading{Table: table}, exitCode, nil
 	}
 
 	source := collect.NewLive(query, 0, nil, logger)
 
-	return exporter.New(ctx, prefix, resolved, source, logger)
+	return exporter.New(ctx, prefix, resolved, source, false, logger)
+}
+
+// staticSource serves a fixed snapshot, for driving the render paths directly.
+type staticSource struct {
+	snapshot collect.Snapshot
+}
+
+func (s *staticSource) Latest(_ context.Context) collect.Snapshot {
+	return s.snapshot
+}
+
+// newAppsExporter wires an exporter with per-process metrics enabled to a
+// fixed snapshot.
+func newAppsExporter(t *testing.T, snapshot collect.Snapshot) *exporter.GPUExporter {
+	t.Helper()
+
+	logger := slogt.New(t)
+
+	resolved, err := nvidiasmi.ResolveFields(
+		t.Context(), "bbb", "fan.speed", "", 0, nvidiasmi.DefaultRunFunc, logger)
+	require.NoError(t, err)
+
+	return exporter.New(t.Context(), "aaa", resolved, &staticSource{snapshot: snapshot}, true, logger)
+}
+
+// gpuTable builds a minimal one-GPU table carrying just the uuid cell.
+func gpuTable(uuid string) *nvidiasmi.Table {
+	cell := nvidiasmi.Cell{QField: nvidiasmi.UUIDQField, RField: "uuid", RawValue: uuid}
+
+	return &nvidiasmi.Table{
+		Rows: []nvidiasmi.Row{{
+			QFieldToCells: map[nvidiasmi.QField]nvidiasmi.Cell{nvidiasmi.UUIDQField: cell},
+			Cells:         []nvidiasmi.Cell{cell},
+		}},
+	}
 }
 
 func TestDescribe(t *testing.T) {
@@ -382,14 +422,14 @@ func TestCollectDeliversMetricsOnFatalError(t *testing.T) {
 	require.NoError(t, err)
 
 	// a real non-zero exit, so the shutdown callback fires
-	query := func(queryCtx context.Context) (*nvidiasmi.Table, int, error) {
+	query := func(queryCtx context.Context) (collect.Reading, int, error) {
 		runErr := exec.CommandContext(queryCtx, "sh", "-c", "exit 3").Run()
 
-		return nil, 3, fmt.Errorf("query failed: %w", runErr)
+		return collect.Reading{}, 3, fmt.Errorf("query failed: %w", runErr)
 	}
 
 	source := collect.NewLive(query, 0, func(fatalErr error) { cancel(fatalErr) }, logger)
-	exp := exporter.New(ctx, "aaa", resolved, source, logger)
+	exp := exporter.New(ctx, "aaa", resolved, source, false, logger)
 
 	families := gatherFamilies(t, exp)
 
@@ -401,4 +441,101 @@ func TestCollectDeliversMetricsOnFatalError(t *testing.T) {
 	assertFloat(t, 1, failed.GetMetric()[0].GetCounter().GetValue())
 	assertFloat(t, 0, gaugeValue(t, families, "aaa_last_collect_success"))
 	assertFloat(t, 3, gaugeValue(t, families, "aaa_command_exit_code"))
+}
+
+func appsSnapshot(table *nvidiasmi.Table, apps []nvidiasmi.ComputeApp, appsSuccess bool) collect.Snapshot {
+	return collect.Snapshot{
+		Attempted:     true,
+		Success:       true,
+		Table:         table,
+		Apps:          apps,
+		AppsAttempted: true,
+		AppsSuccess:   appsSuccess,
+		LastSuccess:   time.Now(),
+	}
+}
+
+func TestCollectComputeApps(t *testing.T) {
+	t.Parallel()
+
+	apps := []nvidiasmi.ComputeApp{
+		{GPUUUID: "abc", PID: "42", ProcessName: "/usr/bin/burn", UsedMemory: "10 MiB"},
+		{GPUUUID: "abc", PID: "43", ProcessName: `C:\Windows\System32\dwm.exe`, UsedMemory: "[N/A]"},
+	}
+
+	exp := newAppsExporter(t, appsSnapshot(gpuTable("GPU-ABC"), apps, true))
+	families := gatherFamilies(t, exp)
+
+	assertFloat(t, 1, gaugeValue(t, families, "aaa_compute_apps_last_collect_success"))
+
+	info, ok := families["aaa_compute_app_info"]
+	require.True(t, ok)
+	require.Len(t, info.GetMetric(), 2)
+
+	// the [N/A] memory value is an expected state: info present, memory absent
+	memory, ok := families["aaa_compute_app_used_memory_bytes"]
+	require.True(t, ok)
+	require.Len(t, memory.GetMetric(), 1)
+	assertFloat(t, 10*1024*1024, memory.GetMetric()[0].GetGauge().GetValue())
+
+	labels := map[string]string{}
+	for _, pair := range memory.GetMetric()[0].GetLabel() {
+		labels[pair.GetName()] = pair.GetValue()
+	}
+
+	assert.Equal(t, map[string]string{
+		"uuid": "abc", "pid": "42", "process_name": "/usr/bin/burn",
+	}, labels)
+
+	assertFloat(t, 2, gaugeValue(t, families, "aaa_compute_apps"))
+}
+
+func TestCollectComputeAppsZeroProcesses(t *testing.T) {
+	t.Parallel()
+
+	exp := newAppsExporter(t, appsSnapshot(gpuTable("GPU-DEF"), nil, true))
+	families := gatherFamilies(t, exp)
+
+	// an idle GPU reports an explicit 0, distinguishable from a failed query
+	assertFloat(t, 1, gaugeValue(t, families, "aaa_compute_apps_last_collect_success"))
+	assertFloat(t, 0, gaugeValue(t, families, "aaa_compute_apps"))
+	assert.NotContains(t, families, "aaa_compute_app_info")
+	assert.NotContains(t, families, "aaa_compute_app_used_memory_bytes")
+}
+
+func TestCollectComputeAppsFailureSuppressesSeries(t *testing.T) {
+	t.Parallel()
+
+	// a failed per-process query must not look like an idle GPU: only the
+	// success gauge is emitted, and no count series reads 0
+	exp := newAppsExporter(t, appsSnapshot(gpuTable("GPU-ABC"), nil, false))
+	families := gatherFamilies(t, exp)
+
+	assertFloat(t, 0, gaugeValue(t, families, "aaa_compute_apps_last_collect_success"))
+	assert.NotContains(t, families, "aaa_compute_apps")
+	assert.NotContains(t, families, "aaa_compute_app_info")
+	assert.NotContains(t, families, "aaa_compute_app_used_memory_bytes")
+}
+
+func TestCollectComputeAppsDisabled(t *testing.T) {
+	t.Parallel()
+
+	logger := slogt.New(t)
+
+	resolved, err := nvidiasmi.ResolveFields(
+		t.Context(), "bbb", "fan.speed", "", 0, nvidiasmi.DefaultRunFunc, logger)
+	require.NoError(t, err)
+
+	// even a snapshot carrying apps data produces no per-process series when
+	// the feature is off
+	apps := []nvidiasmi.ComputeApp{{GPUUUID: "abc", PID: "42", ProcessName: "x", UsedMemory: "1 MiB"}}
+	source := &staticSource{snapshot: appsSnapshot(gpuTable("GPU-ABC"), apps, true)}
+	exp := exporter.New(t.Context(), "aaa", resolved, source, false, logger)
+
+	families := gatherFamilies(t, exp)
+
+	assert.NotContains(t, families, "aaa_compute_apps_last_collect_success")
+	assert.NotContains(t, families, "aaa_compute_apps")
+	assert.NotContains(t, families, "aaa_compute_app_info")
+	assert.NotContains(t, families, "aaa_compute_app_used_memory_bytes")
 }

--- a/internal/nvidiasmi/computeapps.go
+++ b/internal/nvidiasmi/computeapps.go
@@ -1,0 +1,153 @@
+package nvidiasmi
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+)
+
+// computeAppsQFields is the field set queried from --query-compute-apps. It is
+// fixed: these four fields have existed for many driver generations, and they
+// are the complete per-process identity plus the one per-process measurement
+// nvidia-smi offers. No auto-detection, no configuration.
+const computeAppsQFields = "gpu_uuid,pid,process_name,used_gpu_memory"
+
+// computeAppsNumCols is the column count computeAppsQFields produces.
+const computeAppsNumCols = 4
+
+// UsedMemoryMultiplier converts the used_gpu_memory value (reported in MiB,
+// per --help-query-compute-apps) to bytes.
+const UsedMemoryMultiplier = 1024 * 1024
+
+// ComputeApp is one process holding a compute context on a GPU, as reported by
+// nvidia-smi --query-compute-apps.
+type ComputeApp struct {
+	// GPUUUID is normalized the same way as the uuid label on all GPU metrics
+	// (lowercase, "gpu-" prefix stripped), so per-process series join with
+	// them. Under MIG this is the parent GPU's uuid: nvidia-smi does not
+	// attribute processes to MIG instances in this output.
+	GPUUUID string
+	// PID is kept as a string: it is only ever a label, never a value.
+	PID         string
+	ProcessName string
+	// UsedMemory is the raw reported value (e.g. "40960 MiB"). It stays raw
+	// because it is not always a number: "[N/A]" on Windows WDDM,
+	// "[Insufficient Permissions]" in restricted containers.
+	UsedMemory string
+}
+
+// QueryComputeApps runs nvidia-smi --query-compute-apps and parses the CSV
+// output, returning one entry per process with a compute context.
+func QueryComputeApps(
+	ctx context.Context,
+	command string,
+	run RunFunc,
+	logger *slog.Logger,
+) ([]ComputeApp, error) {
+	stdout, _, err := execQuery(ctx, command, run,
+		"--query-compute-apps="+computeAppsQFields, "--format=csv")
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseComputeApps(stdout, logger)
+}
+
+// ParseComputeApps parses --query-compute-apps CSV output. A header-only
+// output (no processes) parses to an empty result.
+//
+// Rows are parsed positionally from the outside in: gpu_uuid and pid from the
+// left, used_gpu_memory from the right, and everything in between rejoined as
+// the process name. Process names are workload-controlled and may contain
+// commas on drivers that do not sanitize them (modern drivers replace a comma
+// with "?" in CSV output, but that is not assumed here). A malformed or
+// unreadable row is skipped so that one weird process cannot take down all
+// per-process metrics.
+func ParseComputeApps(output string, logger *slog.Logger) ([]ComputeApp, error) {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+
+	if numCols := len(parseCSVLine(lines[0])); numCols != computeAppsNumCols {
+		return nil, fmt.Errorf(
+			"unexpected compute apps header: expected %d columns, got %d: %q",
+			computeAppsNumCols, numCols, strings.TrimSpace(lines[0]),
+		)
+	}
+
+	apps := make([]ComputeApp, 0, len(lines)-1)
+
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		app, ok := parseComputeAppRow(line, logger)
+		if !ok {
+			continue
+		}
+
+		apps = append(apps, app)
+	}
+
+	return apps, nil
+}
+
+// parseComputeAppRow parses one data row, reporting whether the row is usable.
+func parseComputeAppRow(line string, logger *slog.Logger) (ComputeApp, bool) {
+	fields := strings.Split(line, ",")
+	if len(fields) < computeAppsNumCols {
+		logger.Warn("skipping malformed compute apps row", "row", strings.TrimSpace(line))
+
+		return ComputeApp{}, false
+	}
+
+	pid := strings.TrimSpace(fields[1])
+	if _, err := strconv.ParseUint(pid, 10, 64); err != nil {
+		// A non-numeric pid means the whole row is unreadable, most commonly
+		// "[Insufficient Permissions]" under MIG in a restricted container.
+		// That is an expected state reported for every process on every
+		// collection, so a known token is skipped without logging.
+		if !IsKnownAbsentValue(pid) {
+			logger.Warn("skipping compute apps row with unparseable pid",
+				"pid", pid, "row", strings.TrimSpace(line))
+		}
+
+		return ComputeApp{}, false
+	}
+
+	name := strings.TrimSpace(strings.Join(fields[2:len(fields)-1], ","))
+
+	return ComputeApp{
+		GPUUUID:     NormalizeUUID(fields[0]),
+		PID:         pid,
+		ProcessName: name,
+		UsedMemory:  strings.TrimSpace(fields[len(fields)-1]),
+	}, true
+}
+
+// NormalizeUUID normalizes a GPU uuid the way all metric labels carry it:
+// lowercase, without the "GPU-" prefix.
+func NormalizeUUID(raw string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(raw)), "gpu-")
+}
+
+// IsKnownAbsentValue reports whether a raw value is one of the tokens
+// nvidia-smi uses for "this field exists but cannot be read right now":
+// "[N/A]" (e.g. per-process memory on Windows WDDM), "[Insufficient
+// Permissions]" (restricted containers, especially under MIG),
+// "[Not Supported]", or an empty value. These are expected states reported on
+// every collection, so callers skip them without logging.
+func IsKnownAbsentValue(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "n/a", "[n/a]", "[not supported]", "[insufficient permissions]", "[unknown error]":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/nvidiasmi/computeapps_test.go
+++ b/internal/nvidiasmi/computeapps_test.go
@@ -1,0 +1,187 @@
+package nvidiasmi_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+const computeAppsHeader = "gpu_uuid, pid, process_name, used_gpu_memory [MiB]"
+
+func TestParseComputeApps(t *testing.T) {
+	t.Parallel()
+
+	// from the H200 capture: normal rows, including names with quotes, unicode
+	// and the "?" a modern driver substitutes for a comma
+	output := computeAppsHeader + "\n" +
+		"GPU-ae3738d5-9aa2-e1c9-53be-65b6d373d3d9, 10525, /root/tools/memhog, 1542 MiB\n" +
+		"GPU-ae3738d5-9aa2-e1c9-53be-65b6d373d3d9, 10529, /root/tools/memhög ünïcode, 818 MiB\n" +
+		"GPU-ae3738d5-9aa2-e1c9-53be-65b6d373d3d9, 10526, /root/tools/mem? hog, 818 MiB\n" +
+		`GPU-ae3738d5-9aa2-e1c9-53be-65b6d373d3d9, 10528, /root/tools/mem "q" hog, 818 MiB` + "\n" +
+		"GPU-ae3738d5-9aa2-e1c9-53be-65b6d373d3d9, 10550, ./gpu_burn, 14410 MiB"
+
+	apps, err := nvidiasmi.ParseComputeApps(output, slogt.New(t))
+
+	require.NoError(t, err)
+	require.Len(t, apps, 5)
+
+	assert.Equal(t, nvidiasmi.ComputeApp{
+		GPUUUID:     "ae3738d5-9aa2-e1c9-53be-65b6d373d3d9",
+		PID:         "10525",
+		ProcessName: "/root/tools/memhog",
+		UsedMemory:  "1542 MiB",
+	}, apps[0])
+	assert.Equal(t, "/root/tools/memhög ünïcode", apps[1].ProcessName)
+	assert.Equal(t, "/root/tools/mem? hog", apps[2].ProcessName)
+	assert.Equal(t, `/root/tools/mem "q" hog`, apps[3].ProcessName)
+	assert.Equal(t, "./gpu_burn", apps[4].ProcessName)
+}
+
+func TestParseComputeAppsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{name: "header only", output: computeAppsHeader + "\n"},
+		{name: "blank output", output: "\n\n"},
+		{name: "empty output", output: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apps, err := nvidiasmi.ParseComputeApps(tt.output, slogt.New(t))
+
+			require.NoError(t, err)
+			assert.Empty(t, apps)
+		})
+	}
+}
+
+func TestParseComputeAppsWDDMNAMemory(t *testing.T) {
+	t.Parallel()
+
+	// from the Windows WDDM captures: memory reads [N/A] but the row is valid
+	output := computeAppsHeader + "\n" +
+		`GPU-00000000-0000-0000-0000-000000000000, 2056, C:\Windows\System32\dwm.exe, [N/A]`
+
+	apps, err := nvidiasmi.ParseComputeApps(output, slogt.New(t))
+
+	require.NoError(t, err)
+	require.Len(t, apps, 1)
+	assert.Equal(t, "2056", apps[0].PID)
+	assert.Equal(t, `C:\Windows\System32\dwm.exe`, apps[0].ProcessName)
+	assert.Equal(t, "[N/A]", apps[0].UsedMemory)
+}
+
+func TestParseComputeAppsCommaInName(t *testing.T) {
+	t.Parallel()
+
+	// defense for drivers that do not sanitize commas: the name is everything
+	// between pid and memory, rejoined
+	output := computeAppsHeader + "\n" +
+		"GPU-abc, 42, /root/tools/mem, hog, 818 MiB\n" +
+		"GPU-abc, 43, /a, b, c, d, 12 MiB"
+
+	apps, err := nvidiasmi.ParseComputeApps(output, slogt.New(t))
+
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+	assert.Equal(t, "/root/tools/mem, hog", apps[0].ProcessName)
+	assert.Equal(t, "/a, b, c, d", apps[1].ProcessName)
+	assert.Equal(t, "12 MiB", apps[1].UsedMemory)
+}
+
+func TestParseComputeAppsSkipsUnusableRows(t *testing.T) {
+	t.Parallel()
+
+	// from the MIG-in-container capture: a fully unreadable row, plus a
+	// malformed short row; both are skipped and the surrounding rows survive
+	unreadableRow := "GPU-ae3738d5-9aa2-e1c9-53be-65b6d373d3d9, [Insufficient Permissions], " +
+		"[Insufficient Permissions], [Insufficient Permissions]"
+	output := computeAppsHeader + "\n" +
+		"GPU-abc, 41, ./before, 10 MiB\n" +
+		unreadableRow + "\n" +
+		"GPU-abc, 42\n" +
+		"GPU-abc, not-a-pid, ./bogus, 5 MiB\n" +
+		"GPU-abc, 43, ./after, 20 MiB"
+
+	apps, err := nvidiasmi.ParseComputeApps(output, slogt.New(t))
+
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+	assert.Equal(t, "./before", apps[0].ProcessName)
+	assert.Equal(t, "./after", apps[1].ProcessName)
+}
+
+func TestParseComputeAppsHeaderMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := nvidiasmi.ParseComputeApps("pid, process_name\n1, foo", slogt.New(t))
+
+	require.ErrorContains(t, err, "unexpected compute apps header")
+}
+
+func TestNormalizeUUID(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ae3738d5-9aa2", nvidiasmi.NormalizeUUID(" GPU-AE3738D5-9aa2 "))
+	assert.Equal(t, "ae3738d5", nvidiasmi.NormalizeUUID("ae3738d5"))
+}
+
+func TestIsKnownAbsentValue(t *testing.T) {
+	t.Parallel()
+
+	absentValues := []string{
+		"[N/A]", "N/A", "[Not Supported]", "[Insufficient Permissions]", "[Unknown Error]", "", " ",
+	}
+	for _, absent := range absentValues {
+		assert.True(t, nvidiasmi.IsKnownAbsentValue(absent), absent)
+	}
+
+	for _, present := range []string{"1542 MiB", "0", "[Requested functionality has been deprecated]"} {
+		assert.False(t, nvidiasmi.IsKnownAbsentValue(present), present)
+	}
+}
+
+func TestQueryComputeApps(t *testing.T) {
+	t.Parallel()
+
+	output := computeAppsHeader + "\n" +
+		"GPU-abc, 42, ./gpu_burn, 14410 MiB\n"
+
+	apps, err := nvidiasmi.QueryComputeApps(t.Context(), "nvsmi", func(cmd *exec.Cmd) error {
+		assert.Contains(t, cmd.Args, "--query-compute-apps=gpu_uuid,pid,process_name,used_gpu_memory")
+		assert.Contains(t, cmd.Args, "--format=csv")
+
+		_, _ = cmd.Stdout.Write([]byte(output))
+
+		return nil
+	}, slogt.New(t))
+
+	require.NoError(t, err)
+	require.Len(t, apps, 1)
+	assert.Equal(t, "abc", apps[0].GPUUUID)
+	assert.Equal(t, "./gpu_burn", apps[0].ProcessName)
+}
+
+func TestQueryComputeAppsCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	_, err := nvidiasmi.QueryComputeApps(
+		t.Context(),
+		"definitely-not-nvidia-smi-xyz",
+		nvidiasmi.DefaultRunFunc,
+		slogt.New(t),
+	)
+
+	require.Error(t, err)
+}

--- a/internal/nvidiasmi/query.go
+++ b/internal/nvidiasmi/query.go
@@ -37,9 +37,24 @@ func DefaultRunFunc(cmd *exec.Cmd) error {
 func Query(ctx context.Context, command string, qFields []QField, run RunFunc) (*Table, int, error) {
 	qFieldsJoined := strings.Join(QFieldSliceToStringSlice(qFields), ",")
 
+	stdout, exitCode, err := execQuery(ctx, command, run, "--query-gpu="+qFieldsJoined, "--format=csv")
+	if err != nil {
+		return nil, exitCode, err
+	}
+
+	table, err := ParseCSVIntoTable(strings.TrimSpace(stdout), qFields)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	return &table, 0, nil
+}
+
+// execQuery runs the nvidia-smi command with the given arguments appended,
+// returning its stdout and exit code.
+func execQuery(ctx context.Context, command string, run RunFunc, args ...string) (string, int, error) {
 	cmdAndArgs := strings.Fields(command)
-	cmdAndArgs = append(cmdAndArgs, "--query-gpu="+qFieldsJoined)
-	cmdAndArgs = append(cmdAndArgs, "--format=csv")
+	cmdAndArgs = append(cmdAndArgs, args...)
 
 	var stdout bytes.Buffer
 
@@ -59,7 +74,7 @@ func Query(ctx context.Context, command string, qFields []QField, run RunFunc) (
 			exitCode = exitError.ExitCode()
 		}
 
-		return nil, exitCode, fmt.Errorf(
+		return "", exitCode, fmt.Errorf(
 			"command failed: code: %d | command: %s | stdout: %s | stderr: %s: %w",
 			exitCode,
 			strings.Join(cmdAndArgs, " "),
@@ -69,10 +84,5 @@ func Query(ctx context.Context, command string, qFields []QField, run RunFunc) (
 		)
 	}
 
-	table, err := ParseCSVIntoTable(strings.TrimSpace(stdout.String()), qFields)
-	if err != nil {
-		return nil, -1, err
-	}
-
-	return &table, 0, nil
+	return stdout.String(), 0, nil
 }


### PR DESCRIPTION
Adds opt-in per-process GPU metrics behind a new `--collect.compute-apps` flag, read from `nvidia-smi --query-compute-apps`. The main use case is a machine running several workloads on one GPU, where you want to see which process uses what.

New metrics (all labeled with `uuid`, `pid`, `process_name` where applicable):

- `nvidia_smi_compute_app_info` — process identity, constant 1
- `nvidia_smi_compute_app_used_memory_bytes` — per-process GPU memory (absent where the driver cannot report it, e.g. Windows WDDM)
- `nvidia_smi_compute_apps` — per-GPU process count, explicit 0 when idle
- `nvidia_smi_compute_apps_last_collect_success` — health of the per-process query

Design points:

- The per-process query is a second nvidia-smi run in the same collection cycle and **fails softly**: on failure all per-process series are suppressed (a failed query never looks like an idle GPU) and only the success gauge reads 0. It never increments `failed_scrapes_total` and never triggers `--shutdown-on-error`.
- Defensive CSV parsing: process names are workload-controlled, so the name column is parsed outside-in (uuid/pid from the left, memory from the right), malformed or permission-restricted rows are skipped individually, and known `[N/A]`-style tokens skip silently to avoid per-scrape log spam.
- `--collect.timeout` now bounds the whole collection cycle (both runs share the budget); flag help updated.
- Helm chart: new `computeApps.enabled` and `hostPID` values. They are separate on purpose (hostPID is security-relevant); NOTES.txt warns when computeApps is enabled without hostPID, since a containerized exporter without host PID sharing only sees its own container's processes.

Caveats documented in CONFIGURE.md: container PID-namespace visibility, Windows WDDM (no per-process memory), MIG (processes attribute to the parent GPU; containerized monitoring under MIG needs privileged + `NVIDIA_MIG_MONITOR_DEVICES=all`), and pid label churn / series cardinality.

Tested with unit tests derived from the real captures in `testdata/captures/` (including the H200 and Windows WDDM ones), plus an end-to-end run of the built binary against a fake nvidia-smi replaying the H200 capture.

Closes #190.