### PR TITLE
fix: convert millisecond fields to seconds in metric names

### DIFF
--- a/charts/nvidia-gpu-exporter/templates/tests/test-connection.yaml
+++ b/charts/nvidia-gpu-exporter/templates/tests/test-connection.yaml
@@ -15,9 +15,19 @@ spec:
     - name: wget
       image: busybox
       command:
-        - wget
+        - sh
+        - -c
+      # retried because the test can start before the exporter finishes its
+      # startup field detection and begins listening
       args:
-        - -qO-
-        - http://{{ include "nvidia-gpu-exporter.fullname" . }}:{{ .Values.service.port }}{{ .Values.telemetryPath }}
+        - |
+          url="http://{{ include "nvidia-gpu-exporter.fullname" . }}:{{ .Values.service.port }}{{ .Values.telemetryPath }}"
+          for attempt in $(seq 1 30); do
+            wget -qO- "$url" && exit 0
+            echo "attempt $attempt failed, retrying"
+            sleep 2
+          done
+          echo "the exporter never became reachable at $url"
+          exit 1
   restartPolicy: Never
 {{- end }}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -432,6 +432,9 @@ func BuildFQNameAndMultiplier(
 	case strings.HasSuffix(rFieldStr, " [us]"):
 		suffixTransformed = split + "_seconds"
 		multiplier = 0.000001
+	case strings.HasSuffix(rFieldStr, " [ms]"):
+		suffixTransformed = split + "_seconds"
+		multiplier = 0.001
 	}
 
 	suffixTransformed = strings.ReplaceAll(suffixTransformed, ".", "_")

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -107,6 +107,20 @@ func TestBuildFQNameAndMultiplierMicroseconds(t *testing.T) {
 	assert.Equal(t, "prefix_clocks_event_reasons_counters_sw_thermal_slowdown_seconds", fqName)
 }
 
+func TestBuildFQNameAndMultiplierMilliseconds(t *testing.T) {
+	t.Parallel()
+
+	// seen on driver 590.48: power_smoothing.window_multiplier [ms]
+	fqName, multiplier := exporter.BuildFQNameAndMultiplier(
+		"prefix",
+		"power_smoothing.window_multiplier [ms]",
+		slogt.New(t),
+	)
+
+	assertFloat(t, 0.001, multiplier)
+	assert.Equal(t, "prefix_power_smoothing_window_multiplier_seconds", fqName)
+}
+
 func TestBuildFQNameAndMultiplierNoPrefix(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Driver 590.48 introduced `power_smoothing.window_multiplier [ms]`, the first query field with a millisecond unit. The metric name builder did not know the ` [ms]` suffix, so every startup on that driver logged the "returned field contains unexpected characters ... please report it in the project's issue tracker" error and exposed the field as `..._window_multiplier_ms` with an unscaled value.

Millisecond fields now follow the same convention as microsecond ones: `_seconds` suffix, value scaled accordingly (`x0.001`).

Verified against the committed H200 capture (driver 590.48): the startup error is gone. Found during the H200 capture session.