### PR TITLE
feat: sign release artifacts (checksums, images, charts)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ defaults:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the GitHub release
+      packages: write # push images to GHCR
+      id-token: write # cosign keyless image signing (OIDC)
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
@@ -38,6 +42,29 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.10.0
+        with:
+          # renovate: depName=sigstore/cosign datasource=github-releases
+          cosign-release: v2.6.1
+      - name: Import the signing key
+        # no xtrace: this step handles the private key
+        shell: bash --noprofile --norc -euo pipefail {0}
+        run: |
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          gpgconf --kill gpg-agent || true
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          fpr="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/{print $10; exit}')"
+          # fail loudly if the secret is not the key the docs and chart advertise
+          expected="$(awk '/signKey:/{f=1} f&&/fingerprint:/{print $2; exit}' charts/nvidia-gpu-exporter/Chart.yaml)"
+          if [ "${fpr}" != "${expected}" ]; then
+            echo "imported key ${fpr} does not match the documented fingerprint ${expected}" >&2
+            exit 1
+          fi
+          echo "GPG_FINGERPRINT=${fpr}" >>"${GITHUB_ENV}"
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v7.2.3
         with:
@@ -47,6 +74,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRIVATE_ACCESS_TOKEN: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Sign the container images
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          for repo in \
+            docker.io/utkuozdemir/nvidia_gpu_exporter \
+            ghcr.io/utkuozdemir/nvidia_gpu_exporter; do
+            # the tag was just pushed; retry the registry read to avoid a race
+            digest=""
+            for _ in 1 2 3 4 5; do
+              if digest="$(docker buildx imagetools inspect "${repo}:${version}" \
+                --format '{{ .Manifest.Digest }}')"; then
+                break
+              fi
+              sleep 5
+            done
+            if [ -z "${digest}" ]; then
+              echo "could not resolve a digest for ${repo}:${version}" >&2
+              exit 1
+            fi
+            cosign sign --yes "${repo}@${digest}"
+          done
 
   helm-chart:
     runs-on: ubuntu-24.04
@@ -54,6 +103,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write # cosign keyless chart signing (OIDC)
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
@@ -64,19 +114,81 @@ jobs:
           chart_version="$((major + 1)).${minor}.${patch}"
           echo "APP_VERSION=${app_version}" >>"${GITHUB_ENV}"
           echo "CHART_VERSION=${chart_version}" >>"${GITHUB_ENV}"
-      - name: Package chart
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.10.0
+        with:
+          # renovate: depName=sigstore/cosign datasource=github-releases
+          cosign-release: v2.6.1
+      - name: Log in to GHCR
+        # before importing the key, so no third-party action runs while the
+        # private key material is present on disk
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Import the signing key
+        # no xtrace: this step handles the private key and passphrase
+        shell: bash --noprofile --norc -euo pipefail {0}
         run: |
+          mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          gpgconf --kill gpg-agent || true
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          fpr="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/{print $10; exit}')"
+          # fail loudly if the secret is not the key the docs and chart advertise
+          expected="$(awk '/signKey:/{f=1} f&&/fingerprint:/{print $2; exit}' charts/nvidia-gpu-exporter/Chart.yaml)"
+          if [ "${fpr}" != "${expected}" ]; then
+            echo "imported key ${fpr} does not match the documented fingerprint ${expected}" >&2
+            exit 1
+          fi
+          # helm reads the pre-2.1 keyring format, so export the key into one
+          umask 077
+          gpg --batch --pinentry-mode loopback \
+            --passphrase "${GPG_PASSPHRASE}" \
+            --export-secret-keys "${fpr}" > /tmp/secring.gpg
+          gpg --armor --export "${fpr}" > /tmp/pubkey.asc
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Package and sign chart
+        # no xtrace: this step handles the passphrase
+        shell: bash --noprofile --norc -euo pipefail {0}
+        run: |
+          umask 077
+          trap 'rm -f /tmp/passphrase.txt' EXIT
+          echo "${GPG_PASSPHRASE}" > /tmp/passphrase.txt
           helm package charts/nvidia-gpu-exporter \
             --version "${CHART_VERSION}" \
             --app-version "${APP_VERSION}" \
-            --destination /tmp/chart-dist
+            --destination /tmp/chart-dist \
+            --sign \
+            --key "nvidia_gpu_exporter release signing" \
+            --keyring /tmp/secring.gpg \
+            --passphrase-file /tmp/passphrase.txt
           cp charts/artifacthub-repo.yml /tmp/chart-dist/
-      - name: Push chart to GHCR
+          cp /tmp/pubkey.asc /tmp/chart-dist/
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Push and sign the chart on GHCR
+        # no xtrace: the registry login reads the token on stdin
+        shell: bash --noprofile --norc -euo pipefail {0}
         run: |
-          helm registry login ghcr.io \
+          printf '%s' "${GH_TOKEN}" | helm registry login ghcr.io \
             --username "${{ github.repository_owner }}" \
-            --password "${{ secrets.GITHUB_TOKEN }}"
-          helm push /tmp/chart-dist/*.tgz "oci://ghcr.io/${{ github.repository_owner }}/charts"
+            --password-stdin
+          push_output="$(helm push /tmp/chart-dist/*.tgz "oci://ghcr.io/${{ github.repository_owner }}/charts" 2>&1)"
+          echo "${push_output}"
+          # sign the immutable digest, not the mutable tag
+          digest="$(echo "${push_output}" | awk '/[Dd]igest:/{print $2; exit}')"
+          if [ -z "${digest}" ]; then
+            echo "could not determine the pushed chart digest" >&2
+            exit 1
+          fi
+          cosign sign --yes \
+            "ghcr.io/${{ github.repository_owner }}/charts/nvidia-gpu-exporter@${digest}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish chart to the Helm repository on gh-pages
         run: |
           git config user.name "github-actions[bot]"
@@ -89,12 +201,14 @@ jobs:
             git rm -rfq .
           fi
           cp /tmp/chart-dist/*.tgz .
+          cp /tmp/chart-dist/*.tgz.prov .
           cp /tmp/chart-dist/artifacthub-repo.yml .
+          cp /tmp/chart-dist/pubkey.asc .
           if [ -f index.yaml ]; then
             helm repo index . --url "https://utkuozdemir.github.io/nvidia_gpu_exporter" --merge index.yaml
           else
             helm repo index . --url "https://utkuozdemir.github.io/nvidia_gpu_exporter"
           fi
-          git add ./*.tgz index.yaml artifacthub-repo.yml
+          git add ./*.tgz ./*.tgz.prov index.yaml artifacthub-repo.yml pubkey.asc
           git commit -m "publish chart ${CHART_VERSION} (app ${APP_VERSION})"
           git push origin gh-pages

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,6 +97,29 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
+# One detached signature over checksums.txt covers every binary, archive and
+# package, since the file lists their sha256 sums. The passphrase comes in on
+# stdin so it never lands on the process command line or in the logs. Skipped
+# in snapshot builds, so no key is needed for PR CI.
+signs:
+  - id: checksums
+    cmd: gpg
+    artifacts: checksum
+    signature: "${artifact}.asc"
+    stdin: "{{ .Env.GPG_PASSPHRASE }}"
+    args:
+      - "--batch"
+      - "--no-tty"
+      - "--pinentry-mode=loopback"
+      - "--passphrase-fd=0"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--armor"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
 git:
   ignore_tags: # skip prereleases when finding the previous tag for the changelog
     - "*-*"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Here's how it looks like:
 
 See [INSTALL.md](docs/INSTALL.md) for details.
 
+## Verifying releases
+
+Release artifacts are signed so you can check they came from this project's
+release pipeline:
+
+- The `checksums.txt` file attached to each release is signed with GPG
+  (`checksums.txt.asc`), which covers every binary, archive and package.
+- The container images and the Helm chart are signed keyless with
+  [cosign](https://github.com/sigstore/cosign), tied to the release workflow's
+  identity.
+
+See [INSTALL.md](docs/INSTALL.md) for the exact verification commands, and the
+[chart README](charts/nvidia-gpu-exporter/README.md) for the chart.
+
 ## Configuration
 
 See [CONFIGURE.md](docs/CONFIGURE.md) for details.

--- a/charts/nvidia-gpu-exporter/Chart.yaml
+++ b/charts/nvidia-gpu-exporter/Chart.yaml
@@ -22,6 +22,9 @@ maintainers:
     url: https://utkuozdemir.org
 annotations:
   artifacthub.io/license: MIT
+  artifacthub.io/signKey: |
+    fingerprint: 93122B2C53431C2F60964EB7EAC49314A32B9205
+    url: https://utkuozdemir.github.io/nvidia_gpu_exporter/pubkey.asc
   artifacthub.io/links: |
     - name: Grafana dashboard
       url: https://grafana.com/grafana/dashboards/14574

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -30,6 +30,30 @@ helm install nvidia-gpu-exporter nvidia-gpu-exporter/nvidia-gpu-exporter \
   --set runtimeClassName=nvidia
 ```
 
+### Verifying the chart signature
+
+Releases from the classic repository are signed with GPG provenance files
+(key fingerprint `93122B2C53431C2F60964EB7EAC49314A32B9205`). To verify,
+fetch the public key once and pass it to helm:
+
+```bash
+curl -fsSL https://utkuozdemir.github.io/nvidia_gpu_exporter/pubkey.asc | gpg --dearmor > nvidia-gpu-exporter.gpg
+helm install nvidia-gpu-exporter nvidia-gpu-exporter/nvidia-gpu-exporter \
+  --verify --keyring nvidia-gpu-exporter.gpg \
+  --set runtimeClassName=nvidia
+```
+
+Helm's provenance check only covers classic-repository installs. The OCI
+artifact on GHCR is signed separately with cosign (keyless), so verify an OCI
+install like this (replace `CHART_VERSION` with the version you are pulling):
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='^https://github\.com/utkuozdemir/nvidia_gpu_exporter/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  ghcr.io/utkuozdemir/charts/nvidia-gpu-exporter:CHART_VERSION
+```
+
 ## Per-process GPU metrics
 
 Enable `computeApps.enabled` to also export per-process GPU metrics

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -30,6 +30,30 @@ helm install nvidia-gpu-exporter nvidia-gpu-exporter/nvidia-gpu-exporter \
   --set runtimeClassName=nvidia
 ```
 
+### Verifying the chart signature
+
+Releases from the classic repository are signed with GPG provenance files
+(key fingerprint `93122B2C53431C2F60964EB7EAC49314A32B9205`). To verify,
+fetch the public key once and pass it to helm:
+
+```bash
+curl -fsSL https://utkuozdemir.github.io/nvidia_gpu_exporter/pubkey.asc | gpg --dearmor > nvidia-gpu-exporter.gpg
+helm install nvidia-gpu-exporter nvidia-gpu-exporter/nvidia-gpu-exporter \
+  --verify --keyring nvidia-gpu-exporter.gpg \
+  --set runtimeClassName=nvidia
+```
+
+Helm's provenance check only covers classic-repository installs. The OCI
+artifact on GHCR is signed separately with cosign (keyless), so verify an OCI
+install like this (replace `CHART_VERSION` with the version you are pulling):
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='^https://github\.com/utkuozdemir/nvidia_gpu_exporter/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  ghcr.io/utkuozdemir/charts/nvidia-gpu-exporter:CHART_VERSION
+```
+
 ## Per-process GPU metrics
 
 Enable `computeApps.enabled` to also export per-process GPU metrics

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -54,6 +54,18 @@ mv nvidia_gpu_exporter /usr/bin
 nvidia_gpu_exporter --help
 ```
 
+### Verifying the download
+
+Each release also ships a `checksums.txt` and a detached GPG signature
+`checksums.txt.asc` that covers it. Import the public key once, then check the
+signature and the checksum of what you downloaded:
+
+```bash
+curl -fsSL https://utkuozdemir.github.io/nvidia_gpu_exporter/pubkey.asc | gpg --import
+gpg --verify checksums.txt.asc checksums.txt
+sha256sum --ignore-missing -c checksums.txt
+```
+
 ## Installing with winget (Windows)
 
 On Windows the exporter is also available through
@@ -260,6 +272,18 @@ environment instead.
 > the container runs on the default runtime and no GPU access is injected. In
 > that case the exporter still comes up, but it serves only its own health
 > metrics with `nvidia_smi_last_collect_success 0`.
+
+### Verifying the image
+
+The images on Docker Hub and GHCR are signed keyless with cosign. Verify one
+(replace `VERSION` with a tag released after signing was introduced) with:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='^https://github\.com/utkuozdemir/nvidia_gpu_exporter/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  utkuozdemir/nvidia_gpu_exporter:VERSION
+```
 
 ### Fallback without the NVIDIA Container Toolkit
 

--- a/hack/generate-signing-key.sh
+++ b/hack/generate-signing-key.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Generates the repo-wide GPG signing key and wires up the public parts.
+#
+# This key signs the released helm chart provenance files and the release
+# checksums. Container images and the OCI chart are signed keyless with cosign
+# and need no key, so this is the only signing key the project has.
+#
+# What it does:
+#   - generates an RSA-4096, sign-only, non-expiring key in a throwaway keyring
+#   - uploads the private key and passphrase as the GPG_PRIVATE_KEY and
+#     GPG_PASSPHRASE repository secrets, and deletes the old CHART_SIGNING_*
+#     secrets if present
+#   - patches the new fingerprint into the chart's signKey annotation
+#   - drops the private key and passphrase into a fresh temporary directory for
+#     you to move into your password manager, then delete
+#
+# The public fingerprint is the only thing that ends up committed. The public
+# key itself is exported and published to the Helm repository by CI at release
+# time, so it does not live in the repository tree.
+#
+# Re-run this script to rotate the key. Old releases stay verifiable against the
+# old key.
+
+set -euo pipefail
+
+repo="utkuozdemir/nvidia_gpu_exporter"
+key_uid="nvidia_gpu_exporter release signing <utkuozdemir@gmail.com>"
+chart_yaml="charts/nvidia-gpu-exporter/Chart.yaml"
+out_dir="$(mktemp -d "${TMPDIR:-/tmp}/nvidia_gpu_exporter-signing.XXXXXX")"
+
+for tool in gpg gh openssl awk; do
+  if ! command -v "$tool" > /dev/null 2>&1; then
+    echo "error: required tool not found: $tool" >&2
+    exit 1
+  fi
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ ! -f "$chart_yaml" ]; then
+  echo "error: $chart_yaml not found; run from the repository" >&2
+  exit 1
+fi
+
+if ! grep -Eq '^[[:space:]]*fingerprint: [0-9A-Fa-f]{40}$' "$chart_yaml"; then
+  echo "error: could not find a fingerprint line to update in $chart_yaml" >&2
+  exit 1
+fi
+
+if ! gh auth status > /dev/null 2>&1; then
+  echo "error: gh is not authenticated; run 'gh auth login' first" >&2
+  exit 1
+fi
+
+# throwaway keyring so nothing touches the real ~/.gnupg
+GNUPGHOME="$(mktemp -d "${TMPDIR:-/tmp}/nvidia_gpu_exporter-gnupg.XXXXXX")"
+export GNUPGHOME
+trap 'rm -rf "$GNUPGHOME"' EXIT
+chmod 700 "$GNUPGHOME"
+
+# let gpg take the passphrase from --passphrase instead of a pinentry prompt
+printf 'allow-loopback-pinentry\n' > "$GNUPGHOME/gpg-agent.conf"
+gpgconf --kill gpg-agent > /dev/null 2>&1 || true
+
+passphrase="$(openssl rand -base64 32)"
+
+echo "Generating an RSA-4096 sign-only key with no expiry ..."
+gpg --batch --pinentry-mode loopback --passphrase "$passphrase" \
+  --quick-generate-key "$key_uid" rsa4096 sign never
+
+fingerprint="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/{print $10; exit}')"
+if [ -z "$fingerprint" ]; then
+  echo "error: failed to read the generated key fingerprint" >&2
+  exit 1
+fi
+
+umask 077
+# --export-secret-keys needs the passphrase to unlock the key; --export does not
+gpg --batch --pinentry-mode loopback --passphrase "$passphrase" \
+  --armor --export-secret-keys "$fingerprint" > "$out_dir/private-key.asc"
+gpg --armor --export "$fingerprint" > "$out_dir/pubkey.asc"
+printf '%s' "$passphrase" > "$out_dir/passphrase.txt"
+printf '%s\n' "$fingerprint" > "$out_dir/fingerprint.txt"
+
+if [ ! -s "$out_dir/private-key.asc" ]; then
+  echo "error: exported private key is empty; aborting before touching secrets" >&2
+  exit 1
+fi
+
+echo "Uploading the GPG_PRIVATE_KEY and GPG_PASSPHRASE secrets ..."
+gh secret set -R "$repo" GPG_PRIVATE_KEY < "$out_dir/private-key.asc"
+printf '%s' "$passphrase" | gh secret set -R "$repo" GPG_PASSPHRASE
+
+echo "Removing the old CHART_SIGNING_* secrets if they exist ..."
+gh secret delete -R "$repo" CHART_SIGNING_KEY > /dev/null 2>&1 || true
+gh secret delete -R "$repo" CHART_SIGNING_PASSPHRASE > /dev/null 2>&1 || true
+
+echo "Writing the fingerprint into $chart_yaml ..."
+tmp_chart="$(mktemp)"
+sed -E "s/^([[:space:]]*fingerprint: )[0-9A-Fa-f]{40}$/\1${fingerprint}/" \
+  "$chart_yaml" > "$tmp_chart"
+mv "$tmp_chart" "$chart_yaml"
+
+cat << EOF
+
+Done. Fingerprint: ${fingerprint}
+
+The fingerprint is already written into $chart_yaml. The public key is
+published to the Helm repository by CI at release time, so it stays out of the
+repository tree.
+
+Temporary key material is in:
+  $out_dir
+
+Handle it now:
+  1. Move these into your password manager:
+       $out_dir/private-key.asc
+       $out_dir/passphrase.txt
+  2. Then delete the whole temporary directory:
+       rm -rf $out_dir
+
+The repository secrets GPG_PRIVATE_KEY and GPG_PASSPHRASE are what CI uses.
+EOF


### PR DESCRIPTION
Signs everything a release produces, so anyone pulling it can confirm it came from this repository's release pipeline.

## What is signed

- Checksums: one GPG signature over `checksums.txt` (published as `checksums.txt.asc`), covering every binary, archive, `.deb` and `.rpm`.
- Helm chart provenance: the same GPG key signs the chart's `.prov` file for the classic Helm repository.
- Container images on Docker Hub and GHCR, and the OCI chart on GHCR: signed keyless with cosign through GitHub's OIDC, so there is no key to manage for those.

One GPG key covers everything PGP can sign. Images use the OCI world's own signing, where GPG does not apply. The key is sign-only with no expiry, and its fingerprint lives in the chart metadata (`93122B2C53431C2F60964EB7EAC49314A32B9205`).

## How to verify

`docs/INSTALL.md` covers checksums for binaries and cosign for images. The chart README covers helm provenance for classic installs and cosign for OCI installs.

## Notes

- Images and the OCI chart are signed by immutable digest, not by tag.
- The release fails if the imported key does not match the fingerprint the chart advertises, so a wrong or stale secret cannot ship an unverifiable release.
- The steps that touch key material run without command tracing and with a restrictive umask, and third-party actions run before the private key is written to disk.
- `hack/generate-signing-key.sh` generates the key, uploads the secrets and records the fingerprint, so rotating it is one command.
- The `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` secrets are already set; the old `CHART_SIGNING_*` secrets were removed.
- deb/rpm embedded package signatures and SLSA build-provenance attestations were left out on purpose: the checksum signature already covers package integrity, and cosign already provides the image attestation.

PR CI needs no key: the goreleaser sign and cosign steps only run on a real tag release.
