### PR TITLE
feat: let the fake nvidia-smi override field values via --set

### DIFF
--- a/cmd/fake-nvidia-smi/main.go
+++ b/cmd/fake-nvidia-smi/main.go
@@ -1,7 +1,10 @@
 // fake-nvidia-smi replays a GPU capture, so the exporter can run end to end
 // on a machine without a GPU. The corpus from internal/captures is embedded,
 // making the binary self-contained; --capture takes an embedded capture name
-// or a path to a capture file. Used by the integration tests, and handy for
+// or a path to a capture file. Repeat --set field=value to replace a field's
+// value in the replayed output, which lets you drive a state a capture does
+// not contain (a GPU in a bad state, an odd reading, a permission error)
+// without hand-editing a capture. Used by the integration tests, and handy for
 // local development:
 //
 //	go run ./cmd/fake-nvidia-smi --help-query-gpu

--- a/internal/captures/README.md
+++ b/internal/captures/README.md
@@ -159,3 +159,7 @@ Beyond that:
 - Test field auto-detection against the `--help-query-gpu` sections of many
   drivers at once.
 - Diff the same command across two captures to spot field renames or format drift.
+- Drive a value a capture does not contain with `--set field=value` (repeatable),
+  for example `--set gpu_recovery_action=Reset` or `--set temperature.gpu=95`, to
+  exercise a bad GPU or an edge reading without editing a capture. Quote a value
+  with spaces, and note that a value cannot contain a comma or a line break.

--- a/internal/fakesmi/fakesmi.go
+++ b/internal/fakesmi/fakesmi.go
@@ -41,6 +41,10 @@ type config struct {
 	delay       time.Duration
 	exitCode    int
 	exitSet     bool
+	// overrides replaces a query field's value in every data row, keyed by the
+	// field name. It lets a test drive a state a real capture does not contain
+	// (a bad GPU, an edge value, a permission error) without a new capture file.
+	overrides map[string]string
 }
 
 // Run executes the fake: it parses the fake's own leading flags, loads the
@@ -77,7 +81,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return usageExitCode
 	}
 
-	return answer(capt, cfg.state, rest, stdout, stderr)
+	return answer(capt, cfg.state, cfg.overrides, rest, stdout, stderr)
 }
 
 // loadCapture resolves the --capture value: a path (anything with a path
@@ -125,7 +129,7 @@ func parseFlags(args []string) (config, []string, error) {
 		name, value, hasValue := strings.Cut(args[0], "=")
 
 		switch name {
-		case "--capture", "--state", "--stderr-msg", "--fail-arg", "--exit", "--delay":
+		case "--capture", "--state", "--stderr-msg", "--fail-arg", "--exit", "--delay", "--set":
 		default:
 			return cfg, args, nil
 		}
@@ -161,10 +165,37 @@ func parseFlags(args []string) (config, []string, error) {
 			if cfg.delay, err = time.ParseDuration(value); err != nil {
 				return cfg, nil, fmt.Errorf("invalid --delay value %q: %w", value, err)
 			}
+		case "--set":
+			if err = addOverride(&cfg, value); err != nil {
+				return cfg, nil, err
+			}
 		}
 	}
 
 	return cfg, nil, nil
+}
+
+// addOverride records one --set field=value pair. A comma or newline in the
+// value is rejected because it would corrupt the CSV row the exporter splits on
+// commas; the field name must be non-empty; the value may be empty; and a
+// repeated field takes the last value.
+func addOverride(cfg *config, raw string) error {
+	field, value, ok := strings.Cut(raw, "=")
+	if !ok || field == "" {
+		return fmt.Errorf("invalid --set %q, want field=value", raw)
+	}
+
+	if strings.ContainsAny(value, ",\r\n") {
+		return fmt.Errorf("invalid --set value for %q: must not contain a comma or newline", field)
+	}
+
+	if cfg.overrides == nil {
+		cfg.overrides = make(map[string]string)
+	}
+
+	cfg.overrides[field] = value
+
+	return nil
 }
 
 // failMatching implements the selective failure injection: when an argument
@@ -195,7 +226,13 @@ func failMatching(cfg config, args []string, stderr io.Writer) bool {
 // answer serves the nvidia-smi invocation in args from the capture: the two
 // CSV queries by column projection, anything else by verbatim replay of the
 // section recorded for the same command line.
-func answer(capt *capture.Capture, state string, args []string, stdout, stderr io.Writer) int {
+func answer(
+	capt *capture.Capture,
+	state string,
+	overrides map[string]string,
+	args []string,
+	stdout, stderr io.Writer,
+) int {
 	if request, sectionLabel, isQuery := queryRequest(args); isQuery {
 		section := capt.Find(state, sectionLabel)
 		if section == nil {
@@ -205,7 +242,7 @@ func answer(capt *capture.Capture, state string, args []string, stdout, stderr i
 			return usageExitCode
 		}
 
-		output, err := project(section, request)
+		output, err := project(section, request, overrides)
 		if err != nil {
 			// the real nvidia-smi reports a rejected query on stdout
 			fmt.Fprintln(stdout, err)

--- a/internal/fakesmi/fakesmi_test.go
+++ b/internal/fakesmi/fakesmi_test.go
@@ -146,6 +146,109 @@ func TestComputeAppsProjection(t *testing.T) {
 	assert.True(t, strings.HasPrefix(cells[0], "GPU-"), "gpu_uuid cell: %q", cells[0])
 }
 
+// TestValueOverride proves --set replaces a field's value in the data rows
+// while leaving the header and un-overridden fields alone.
+func TestValueOverride(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(capturesDir, "linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05.txt")
+
+	code, stdout, stderr := runFake(t, "--capture", path,
+		"--set", "temperature.gpu=95", "--set", "gpu_recovery_action=Reset",
+		"--query-gpu=name,temperature.gpu,gpu_recovery_action", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 2)
+
+	// the header names the fields, never the overridden values
+	assert.NotContains(t, lines[0], "95")
+	assert.NotContains(t, lines[0], "Reset")
+
+	cells := strings.Split(lines[1], ", ")
+	require.Len(t, cells, 3)
+	assert.Contains(t, cells[0], "RTX 2080 SUPER", "an un-overridden field must keep its value")
+	assert.Equal(t, "95", cells[1])
+	assert.Equal(t, "Reset", cells[2])
+}
+
+// TestValueOverrideLastWins proves a repeated field takes the last value.
+func TestValueOverrideLastWins(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(capturesDir, "linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05.txt")
+
+	code, stdout, stderr := runFake(t, "--capture", path,
+		"--set", "temperature.gpu=10", "--set", "temperature.gpu=20",
+		"--query-gpu=temperature.gpu", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "20", lines[1])
+}
+
+// TestValueOverrideInvalid proves malformed --set values are rejected, in
+// particular a comma or any line break (which would corrupt the CSV).
+func TestValueOverrideInvalid(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(capturesDir, "linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05.txt")
+
+	for _, bad := range []string{"noequalsign", "=emptyfield", "process_name=a,b", "x=a\nb", "x=a\rb"} {
+		code, _, stderr := runFake(t, "--capture", path, "--set", bad, "-L")
+		assert.Equalf(t, 2, code, "--set %q should be rejected", bad)
+		assert.NotEmpty(t, stderr)
+	}
+}
+
+// TestValueOverrideForms proves the --set=field=value form and an empty value
+// are accepted, and that overriding a field not in the query is a no-op.
+func TestValueOverrideForms(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(capturesDir, "linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05.txt")
+
+	// the --set=field=value form, plus an empty value, plus an override for a
+	// field that is not requested (which must not affect the output)
+	code, stdout, stderr := runFake(t, "--capture", path,
+		"--set=temperature.gpu=", "--set", "not_requested_field=zzz",
+		"--query-gpu=name,temperature.gpu", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	// TrimRight only the trailing newline, so the empty last cell's space survives
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	require.Len(t, lines, 2)
+
+	cells := strings.Split(lines[1], ", ")
+	require.Len(t, cells, 2)
+	assert.Contains(t, cells[0], "RTX 2080 SUPER", "the un-overridden name must survive")
+	assert.Empty(t, cells[1], "an empty override value must produce an empty cell")
+}
+
+// TestValueOverrideFreeTextAndRows proves an override replaces the free-text
+// process_name column (which splitRow reconstructs from its own commas first)
+// and applies to every data row, not just the first.
+func TestValueOverrideFreeTextAndRows(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(capturesDir, "linux-x86_64__nvidia-l40s__595.80.txt")
+
+	code, stdout, stderr := runFake(t, "--capture", path, "--state", "load",
+		"--set", "process_name=overridden",
+		"--query-compute-apps=pid,process_name,used_gpu_memory", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Greater(t, len(lines), 1, "the load state should have at least one process")
+
+	for _, line := range lines[1:] {
+		cells := strings.Split(line, ", ")
+		require.Len(t, cells, 3)
+		assert.Equal(t, "overridden", cells[1])
+	}
+}
+
 func TestUnknownFieldRejected(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fakesmi/project.go
+++ b/internal/fakesmi/project.go
@@ -18,8 +18,10 @@ var errEmptySection = errors.New("section body has no header row")
 // project answers a CSV query for the requested comma-separated fields from a
 // recorded section: the field list recorded in the section's own command line
 // maps field names to CSV columns, and the output carries the requested
-// columns, in the requested order, for the header and every row.
-func project(section *capture.Section, requestRaw string) (string, error) {
+// columns, in the requested order, for the header and every row. When overrides
+// are given, a data row's cell for a named field is replaced before projection,
+// so tests can drive values a real capture does not contain.
+func project(section *capture.Section, requestRaw string, overrides map[string]string) (string, error) {
 	recorded, err := recordedFields(section.Command)
 	if err != nil {
 		return "", err
@@ -43,26 +45,59 @@ func project(section *capture.Section, requestRaw string) (string, error) {
 	output := make([]string, 0, len(lines))
 
 	for lineNum, line := range lines {
-		// the header row never contains free-text cells, row lines may
-		freeTextColumn := -1
-		if column, hasFreeText := columnOf[freeTextField]; hasFreeText && lineNum > 0 {
-			freeTextColumn = column
-		}
-
-		cells, err := splitRow(line, len(recorded), freeTextColumn)
+		row, err := projectRow(line, lineNum, recorded, columnOf, columns, overrides)
 		if err != nil {
 			return "", fmt.Errorf("row %d: %w", lineNum+1, err)
 		}
 
-		projected := make([]string, 0, len(columns))
-		for _, column := range columns {
-			projected = append(projected, cells[column])
-		}
-
-		output = append(output, strings.Join(projected, ", "))
+		output = append(output, row)
 	}
 
 	return strings.Join(output, "\n"), nil
+}
+
+// projectRow splits one CSV line, applies data-row overrides, and returns the
+// requested columns joined back together. The header (lineNum 0) is never
+// overridden and has no free-text cells.
+func projectRow(
+	line string,
+	lineNum int,
+	recorded []string,
+	columnOf map[string]int,
+	columns []int,
+	overrides map[string]string,
+) (string, error) {
+	freeTextColumn := -1
+	if column, hasFreeText := columnOf[freeTextField]; hasFreeText && lineNum > 0 {
+		freeTextColumn = column
+	}
+
+	cells, err := splitRow(line, len(recorded), freeTextColumn)
+	if err != nil {
+		return "", err
+	}
+
+	if lineNum > 0 {
+		applyOverrides(cells, recorded, overrides)
+	}
+
+	projected := make([]string, 0, len(columns))
+	for _, column := range columns {
+		projected = append(projected, cells[column])
+	}
+
+	return strings.Join(projected, ", "), nil
+}
+
+// applyOverrides replaces the cell of every field named in overrides with the
+// given value, keyed by the recorded field order. Fields not named are left as
+// recorded, and an override for a field absent from this section is ignored.
+func applyOverrides(cells, recorded []string, overrides map[string]string) {
+	for column, name := range recorded {
+		if value, ok := overrides[name]; ok {
+			cells[column] = value
+		}
+	}
 }
 
 // requestedColumns resolves a requested comma-separated field list to column

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -311,6 +311,29 @@ func TestComputeAppsDisabled(t *testing.T) {
 	assert.NotContains(t, scrape(t, baseURL), "nvidia_smi_compute_app")
 }
 
+// TestValueOverride proves the fake's --set flag reaches a metric through the
+// exporter's command splitting and collection pipeline, so a test can drive a
+// field's value without a bespoke capture file.
+func TestValueOverride(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+
+		fakeCommand(defaultCapture(t), "--set", "temperature.gpu=95"))
+
+	assert.Regexp(t, `nvidia_smi_temperature_gpu\{uuid="[^"]+"\} 95\b`, scrape(t, baseURL))
+}
+
+// TestValueOverrideQuotedSpaces proves an override value with spaces survives
+// the exporter's command splitting when quoted, checked on the gpu_info label.
+func TestValueOverrideQuotedSpaces(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+
+		fakeCommand(defaultCapture(t), "--set", quote("name=Fake RTX 3090")))
+
+	assert.Regexp(t, `nvidia_smi_gpu_info\{[^}]*name="Fake RTX 3090"`, scrape(t, baseURL))
+}
+
 // TestCachedModeMatchesLive proves background collection serves the same
 // deterministic content as the synchronous mode, pinned by the same expected output file.
 func TestCachedModeMatchesLive(t *testing.T) {


### PR DESCRIPTION
The fake nvidia-smi replayed a capture exactly as recorded. Testing a state no real capture contains, like a GPU in a bad state, an odd reading, or a permission error, meant hand-crafting a whole synthetic capture just to change one cell.

A repeatable `--set field=value` flag now replaces that field's value in the data rows of the replayed CSV output, so a test or a local run can drive any value from a real capture:

```bash
go run ./cmd/nvidia_gpu_exporter --nvidia-smi-command \
  "fake-nvidia-smi --capture linux-x86_64__nvidia-h200__590.48.01 --set temperature.gpu=95 --set fan.speed=80"
```

## Behavior

- The header row is never touched, since it carries the field names the exporter turns into metric names. Only data-row values change.
- The value is an arbitrary string, so error tokens like `[Insufficient Permissions]` and unit-bearing values like `512 MiB` work. A comma or a line break is rejected, because the exporter splits the CSV on commas and either would shift the columns. Quote a value with spaces in the single command string.
- A repeated field takes the last value. An override for a field not in the query is ignored.

## Notes

- This retires the need for synthetic capture files that differ from a real one by a single cell. A later cleanup can replace such a fixture with a `--set` call.
- A separate, larger idea, an opt-in "realistic mutation" mode for a fluctuating no-GPU metrics stream, is intentionally left out and tracked separately.
