### PR TITLE
feat: expose GPU recovery action and fabric state as metrics

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -5,6 +5,38 @@ This is an example output of the returned metrics.
 Note that when `AUTO` query fields mode is used (it is the default),
 the exporter will discover new fields and expose them on a best-effort basis.
 
+## Enum-valued metrics
+
+Many `nvidia-smi` fields report a state rather than a number. The exporter maps
+those to a number so they can be scraped. A field that is unavailable, reading a
+value like `N/A`, `[Not Supported]` or `[Insufficient Permissions]`, is not
+exported. A value that is present but not recognized (an unexpected or brand-new
+state) is also skipped rather than guessed, and is logged so the gap is visible.
+
+Two-state fields become `1`/`0`. This covers every field whose value is
+`Enabled`/`Disabled`, `Yes`/`No`, or `Active`/`Not Active`, for example
+`persistence_mode`, `accounting.mode`, `display_mode`, `display_active`,
+`ecc.mode.current`/`.pending`, `mig.mode.current`/`.pending`,
+`gsp.mode.current`/`.default`, `c2c.mode`, `remapped_rows.failure`/`.pending`,
+and every `clocks_event_reasons.*` throttle flag (`gpu_idle`, `hw_slowdown`,
+`sw_power_cap`, and so on). Which fields appear depends on the GPU and driver,
+because query fields are auto-discovered.
+
+Multi-state fields carry the state as their integer value:
+
+- `nvidia_smi_pstate`: the performance state, `0` (`P0`, maximum performance)
+  through `15` (`P15`, minimum). Lower means busier, so this is not a load gauge.
+- `nvidia_smi_gpu_recovery_action`: `0` None (healthy), `1` GPU Reset,
+  `2` Node Reboot, `3` Drain P2P, `4` Drain and Reset. A value `> 0` means the
+  driver recommends a recovery action, so it is a good "GPU is unhealthy" alert.
+- `nvidia_smi_fabric_state`: `0` Not Supported, `1` Not Started, `2` In Progress,
+  `3` Completed. Only present on GPUs that join an NVLink fabric.
+- `nvidia_smi_compute_mode`: `0` Default, `1` Exclusive Thread, `2` Prohibited,
+  `3` Exclusive Process.
+
+The last three map to their native NVML enum integer; `pstate` is the raw
+performance-state number.
+
 ```text
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -339,10 +340,21 @@ func (e *GPUExporter) renderRow(metricCh chan<- prometheus.Metric, row nvidiasmi
 	for _, currentCell := range row.Cells {
 		metricInfo := e.qFieldToMetricInfoMap[currentCell.QField]
 
-		num, numErr := nvidiasmi.TransformRawValue(currentCell.RawValue, metricInfo.ValueMultiplier)
+		num, numErr := nvidiasmi.TransformFieldValue(
+			currentCell.QField, currentCell.RawValue, metricInfo.ValueMultiplier)
 		if numErr != nil {
-			e.logger.Debug("failed to transform raw value", "err", numErr, "query_field_name",
-				currentCell.QField, "raw_value", currentCell.RawValue)
+			switch {
+			case errors.Is(numErr, nvidiasmi.ErrAbsentValue):
+				// expected unavailable reading (e.g. an unsupported field), skip quietly
+			case nvidiasmi.IsEnumMappedField(currentCell.QField):
+				// an enum field returned a value we do not map: never guess a number,
+				// but surface it so a new/unexpected state is not silently invisible
+				e.logger.Warn("skipping metric: unrecognized enum value", "query_field_name",
+					currentCell.QField, "raw_value", currentCell.RawValue)
+			default:
+				e.logger.Debug("failed to transform raw value", "err", numErr, "query_field_name",
+					currentCell.QField, "raw_value", currentCell.RawValue)
+			}
 
 			continue
 		}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -334,6 +334,19 @@ func TestValueOverrideQuotedSpaces(t *testing.T) {
 	assert.Regexp(t, `nvidia_smi_gpu_info\{[^}]*name="Fake RTX 3090"`, scrape(t, baseURL))
 }
 
+// TestGPURecoveryActionBadState drives gpu_recovery_action to "Reset" with the
+// fake's --set flag, proving a non-zero recovery action flows through the enum
+// transform and out as a metric. No real bad-GPU capture exists, so this is the
+// end-to-end coverage for the unhealthy path the metric exists to catch.
+func TestGPURecoveryActionBadState(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+
+		fakeCommand(defaultCapture(t), "--set", "gpu_recovery_action=Reset"))
+
+	assert.Regexp(t, `nvidia_smi_gpu_recovery_action\{uuid="[^"]+"\} 1\b`, scrape(t, baseURL))
+}
+
 // TestCachedModeMatchesLive proves background collection serves the same
 // deterministic content as the synchronous mode, pinned by the same expected output file.
 func TestCachedModeMatchesLive(t *testing.T) {

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__idle.metrics
@@ -115,6 +115,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7A.40.73"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__load.metrics
@@ -123,6 +123,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7A.40.73"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__idle.metrics
@@ -151,6 +151,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 4080 SUPER",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x51101462",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.03.44.00.B2"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__load.metrics
@@ -155,6 +155,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 4080 SUPER",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x51101462",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.03.44.00.B2"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__idle.metrics
@@ -199,12 +199,18 @@ nvidia_smi_enforced_power_limit_watts{uuid="00000000-0000-0000-0000-000000000000
 # HELP nvidia_smi_fabric_clique_id fabric.cliqueId
 # TYPE nvidia_smi_fabric_clique_id gauge
 nvidia_smi_fabric_clique_id{uuid="00000000-0000-0000-0000-000000000000"} 0
+# HELP nvidia_smi_fabric_state fabric.state
+# TYPE nvidia_smi_fabric_state gauge
+nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__load.metrics
@@ -209,12 +209,18 @@ nvidia_smi_enforced_power_limit_watts{uuid="00000000-0000-0000-0000-000000000000
 # HELP nvidia_smi_fabric_clique_id fabric.cliqueId
 # TYPE nvidia_smi_fabric_clique_id gauge
 nvidia_smi_fabric_clique_id{uuid="00000000-0000-0000-0000-000000000000"} 0
+# HELP nvidia_smi_fabric_state fabric.state
+# TYPE nvidia_smi_fabric_state gauge
+nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__idle.metrics
@@ -199,12 +199,18 @@ nvidia_smi_enforced_power_limit_watts{uuid="00000000-0000-0000-0000-000000000000
 # HELP nvidia_smi_fabric_clique_id fabric.cliqueId
 # TYPE nvidia_smi_fabric_clique_id gauge
 nvidia_smi_fabric_clique_id{uuid="00000000-0000-0000-0000-000000000000"} 0
+# HELP nvidia_smi_fabric_state fabric.state
+# TYPE nvidia_smi_fabric_state gauge
+nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__load.metrics
@@ -209,12 +209,18 @@ nvidia_smi_enforced_power_limit_watts{uuid="00000000-0000-0000-0000-000000000000
 # HELP nvidia_smi_fabric_clique_id fabric.cliqueId
 # TYPE nvidia_smi_fabric_clique_id gauge
 nvidia_smi_fabric_clique_id{uuid="00000000-0000-0000-0000-000000000000"} 0
+# HELP nvidia_smi_fabric_state fabric.state
+# TYPE nvidia_smi_fabric_state gauge
+nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__idle.metrics
@@ -199,6 +199,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.80",index="0",name="NVIDIA L40S",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x185110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.02.66.00.02"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__load.metrics
@@ -207,6 +207,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.80",index="0",name="NVIDIA L40S",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x185110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.02.66.00.02"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_gsp_mode_current gsp.mode.current
 # TYPE nvidia_smi_gsp_mode_current gauge
 nvidia_smi_gsp_mode_current{uuid="00000000-0000-0000-0000-000000000000"} 1

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__idle.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__idle.metrics
@@ -130,6 +130,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.37
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="591.86",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_index index
 # TYPE nvidia_smi_index gauge
 nvidia_smi_index{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__load.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__load.metrics
@@ -132,6 +132,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="591.86",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_index index
 # TYPE nvidia_smi_index gauge
 nvidia_smi_index{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__idle.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__idle.metrics
@@ -139,6 +139,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="610.62",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_index index
 # TYPE nvidia_smi_index gauge
 nvidia_smi_index{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__load.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__load.metrics
@@ -141,6 +141,9 @@ nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
 # TYPE nvidia_smi_gpu_info gauge
 nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="610.62",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0
 # HELP nvidia_smi_index index
 # TYPE nvidia_smi_index gauge
 nvidia_smi_index{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/nvidiasmi/fields.go
+++ b/internal/nvidiasmi/fields.go
@@ -30,8 +30,14 @@ const (
 	computeCapQField         QField = "compute_cap"
 	pciSubDeviceIDQField     QField = "pci.sub_device_id"
 	indexQField              QField = "index"
-	qFieldsAuto                     = "AUTO"
-	DefaultQField                   = qFieldsAuto
+
+	// Enum-valued fields whose string values are mapped to their native NVML
+	// enum integers (see fieldValueMappers in transform.go).
+	gpuRecoveryActionQField QField = "gpu_recovery_action"
+	fabricStateQField       QField = "fabric.state"
+
+	qFieldsAuto   = "AUTO"
+	DefaultQField = qFieldsAuto
 )
 
 var (

--- a/internal/nvidiasmi/transform.go
+++ b/internal/nvidiasmi/transform.go
@@ -1,6 +1,7 @@
 package nvidiasmi
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -12,6 +13,81 @@ import (
 const floatBitSize = 64
 
 var numericRegex = regexp.MustCompile(`[+-]?(\d*[.])?\d+`)
+
+// ErrAbsentValue marks a value that an enum field reports as expectedly
+// unavailable (for example on a GPU that does not support the field). Callers
+// skip these quietly. It is deliberately distinct from an unrecognized value,
+// which is unexpected and should be surfaced rather than dropped silently.
+var ErrAbsentValue = errors.New("value is an expected-absent token")
+
+// enumFieldAbsentTokens are the values that mean "this field exists but is not
+// available here". This is IsKnownAbsentValue minus "[unknown error]": for a
+// health field an unknown error is a retrieval failure worth surfacing, not a
+// clean unsupported state.
+var enumFieldAbsentTokens = map[string]struct{}{
+	"": {}, "n/a": {}, "[n/a]": {}, "[not supported]": {}, "[insufficient permissions]": {},
+}
+
+// fieldValueMappers maps a query field whose value is an NVML enum string to a
+// function turning that string into the field's native NVML enum integer.
+// Fields not listed fall through to the generic TransformRawValue.
+var fieldValueMappers = map[QField]func(string) (float64, error){
+	// nvmlGpuRecoveryAction_t. 0 (None) is healthy; any non-zero value is a
+	// recovery action the driver recommends, so `> 0` means "needs attention".
+	// Both the short and prefixed spellings are accepted because nvidia-smi's
+	// exact wording is not fully pinned down (no bad-GPU capture to verify);
+	// anything unrecognized is reported by the exporter rather than dropped.
+	gpuRecoveryActionQField: enumValueMapper(gpuRecoveryActionQField, map[string]float64{
+		"none": 0, "gpu reset": 1, "reset": 1, "node reboot": 2, "reboot": 2,
+		"drain p2p": 3, "drain and reset": 4,
+	}),
+	// nvmlGpuFabricState_t. Higher is further along registration; 3 (Completed)
+	// is the healthy steady state.
+	fabricStateQField: enumValueMapper(fabricStateQField, map[string]float64{
+		"not supported": 0, "not started": 1, "in progress": 2, "completed": 3,
+	}),
+}
+
+// IsEnumMappedField reports whether the field's value is mapped through an NVML
+// enum table. The exporter uses this to surface an unrecognized value loudly
+// instead of dropping it like an ordinary non-numeric field.
+func IsEnumMappedField(qField QField) bool {
+	_, ok := fieldValueMappers[qField]
+
+	return ok
+}
+
+// enumValueMapper builds a mapper for an NVML enum field: expected-absent tokens
+// resolve to ErrAbsentValue (skipped quietly), recognized strings map to their
+// native integer, and any other value returns a plain error so it is never
+// turned into a bogus number and the exporter can report it.
+func enumValueMapper(field QField, table map[string]float64) func(string) (float64, error) {
+	return func(raw string) (float64, error) {
+		key := strings.ToLower(strings.TrimSpace(raw))
+
+		if _, absent := enumFieldAbsentTokens[key]; absent {
+			return 0, ErrAbsentValue
+		}
+
+		if v, ok := table[key]; ok {
+			return v, nil
+		}
+
+		return 0, fmt.Errorf("field %q value %q is not a recognized enum value", field, raw)
+	}
+}
+
+// TransformFieldValue transforms a raw value into a float64, applying the
+// field's NVML enum mapping when it has one and otherwise falling back to the
+// generic transform. Keeping the field-aware mapping here leaves the exporter's
+// render loop unaware of any per-field value semantics.
+func TransformFieldValue(qField QField, rawValue string, valueMultiplier float64) (float64, error) {
+	if mapper, ok := fieldValueMappers[qField]; ok {
+		return mapper(rawValue)
+	}
+
+	return TransformRawValue(rawValue, valueMultiplier)
+}
 
 // TransformRawValue transforms a raw value into a float64.
 func TransformRawValue(rawValue string, valueMultiplier float64) (float64, error) {

--- a/internal/nvidiasmi/transform_test.go
+++ b/internal/nvidiasmi/transform_test.go
@@ -55,6 +55,69 @@ func TestTransformRawValueInvalidValues(t *testing.T) {
 	}
 }
 
+func TestTransformFieldValueEnumFields(t *testing.T) {
+	t.Parallel()
+
+	cases := map[nvidiasmi.QField]map[string]float64{
+		"gpu_recovery_action": {
+			"None": 0, "none": 0, "  None  ": 0,
+			"GPU Reset": 1, "Reset": 1, "gpu reset": 1,
+			"Node Reboot": 2, "Reboot": 2,
+			"Drain P2P": 3, "Drain and Reset": 4,
+		},
+		"fabric.state": {
+			"Not Supported": 0, "Not Started": 1, "In Progress": 2, "Completed": 3,
+		},
+	}
+
+	for field, conversions := range cases {
+		for raw, expected := range conversions {
+			val, err := nvidiasmi.TransformFieldValue(field, raw, 1)
+			require.NoErrorf(t, err, "field %q value %q", field, raw)
+			assertFloat(t, expected, val)
+		}
+	}
+}
+
+// TestTransformFieldValueEnumDrops proves the enum mappers never emit a bogus
+// number, and distinguish an expected-absent reading (skipped quietly) from an
+// unexpected one (surfaced): "[Not Supported]" is absent, but a retrieval
+// "[Unknown Error]" or an unknown string is not, so the exporter can warn.
+func TestTransformFieldValueEnumDrops(t *testing.T) {
+	t.Parallel()
+
+	absent := []string{"", "N/A", "[N/A]", "[Not Supported]", "[Insufficient Permissions]"}
+	unexpected := []string{"[Unknown Error]", "definitely-not-a-value", "Power Cycle"}
+
+	for _, field := range []nvidiasmi.QField{"gpu_recovery_action", "fabric.state"} {
+		for _, raw := range absent {
+			_, err := nvidiasmi.TransformFieldValue(field, raw, 1)
+			require.ErrorIsf(t, err, nvidiasmi.ErrAbsentValue, "field %q value %q", field, raw)
+		}
+
+		for _, raw := range unexpected {
+			_, err := nvidiasmi.TransformFieldValue(field, raw, 1)
+			require.Errorf(t, err, "field %q value %q must be an error", field, raw)
+			require.NotErrorIsf(t, err, nvidiasmi.ErrAbsentValue,
+				"field %q value %q must not be treated as absent", field, raw)
+		}
+	}
+}
+
+// TestTransformFieldValueFallsThrough proves fields without an enum mapping keep
+// using the generic transform unchanged.
+func TestTransformFieldValueFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	val, err := nvidiasmi.TransformFieldValue("temperature.gpu", "45", 1)
+	require.NoError(t, err)
+	assertFloat(t, 45, val)
+
+	val, err = nvidiasmi.TransformFieldValue("persistence_mode", "Enabled", 1)
+	require.NoError(t, err)
+	assertFloat(t, 1, val)
+}
+
 func TestTransformRawMultiplier(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #393.

The exporter could not signal that a GPU was in a bad state. `nvidia-smi` reports that as the `gpu_recovery_action` field (`None` when healthy, `Reset`/`Reboot`/... when the driver recommends a recovery action), but the value is a string, so the exporter dropped it.

Enum-valued fields are now mapped to their native NVML enum integer, and two are wired up:

- `nvidia_smi_gpu_recovery_action`: 0 None, 1 GPU Reset, 2 Node Reboot, 3 Drain P2P, 4 Drain and Reset. A value `> 0` means the driver recommends intervention, so it makes a clean "this GPU is unhealthy" alert.
- `nvidia_smi_fabric_state`: 0 Not Supported, 1 Not Started, 2 In Progress, 3 Completed. Present only on GPUs that join an NVLink fabric.

The mapping is conservative. A value the field reports as unavailable (`N/A`, `[Not Supported]`, and so on) is not exported. A value that is present but not recognized is dropped rather than guessed, and logged at warn level, so a new or misspelled state surfaces instead of vanishing or turning into a wrong number.

`docs/METRICS.md` gains a section describing the enum-valued metrics, including the ones that already existed (compute mode, and the enabled/disabled and active/not-active fields).

One honest caveat: the exact `nvidia-smi` strings for the non-`None` recovery actions come from NVIDIA's docs, not a real bad GPU (none of the captures show one), so the table covers the documented spellings and anything else is warned rather than mis-mapped. The end-to-end test drives the bad state with the fake nvidia-smi's `--set gpu_recovery_action=Reset`.
