### PR TITLE
feat: add value ranges and a config file to the fake nvidia-smi

### DIFF
--- a/cmd/fake-nvidia-smi/main.go
+++ b/cmd/fake-nvidia-smi/main.go
@@ -1,11 +1,13 @@
 // fake-nvidia-smi replays a GPU capture, so the exporter can run end to end
 // on a machine without a GPU. The corpus from internal/captures is embedded,
 // making the binary self-contained; --capture takes an embedded capture name
-// or a path to a capture file. Repeat --set field=value to replace a field's
-// value in the replayed output, which lets you drive a state a capture does
-// not contain (a GPU in a bad state, an odd reading, a permission error)
-// without hand-editing a capture. Used by the integration tests, and handy for
-// local development:
+// or a path to a capture file. Repeat --set field=value to pin a field to a
+// value, and --set-range field=min:max to serve a fresh random value in that
+// range on each run, so metrics move. --config file.yaml carries the whole
+// setup (capture, state, per-field overrides, failure injection) instead of
+// flags; because the fake is invoked fresh each scrape, editing the file changes
+// the next scrape with no exporter restart. Used by the integration tests, and
+// handy for local development:
 //
 //	go run ./cmd/fake-nvidia-smi --help-query-gpu
 //	nvidia_gpu_exporter \

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/thejerf/slogassert v0.3.4
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -41,5 +42,4 @@ require (
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/captures/README.md
+++ b/internal/captures/README.md
@@ -163,3 +163,20 @@ Beyond that:
   for example `--set gpu_recovery_action=Reset` or `--set temperature.gpu=95`, to
   exercise a bad GPU or an edge reading without editing a capture. Quote a value
   with spaces, and note that a value cannot contain a comma or a line break.
+- Make values move with `--set-range field=min:max` (repeatable), which serves a
+  fresh random value in the range on each run, so timeseries and gauges are not
+  flat. Add `--seed N` for reproducible values.
+- Put the whole setup in a file with `--config file.yaml` instead of flags:
+
+  ```yaml
+  capture: linux-x86_64__nvidia-h200__590.48.01
+  state: load
+  overrides:
+    gpu_recovery_action: Reset            # a fixed value
+    temperature.gpu: {min: 60, max: 85}   # a random range
+  ```
+
+  Each field is either a fixed value (a scalar, or `value: ...`) or a range
+  (`min` and `max`). A flag overrides the config for the same field. Because the
+  fake is invoked fresh each scrape, editing the file changes the next scrape
+  with no exporter restart (in cached mode, the next collection).

--- a/internal/fakesmi/config.go
+++ b/internal/fakesmi/config.go
@@ -1,0 +1,239 @@
+package fakesmi
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// valueGen produces the value served for one field. It is called once per data
+// row, so a range yields an independent draw for every GPU or process row.
+type valueGen func() string
+
+// rangeSpec is an inclusive numeric range a field's value is drawn from.
+type rangeSpec struct {
+	Min float64 `yaml:"min"`
+	Max float64 `yaml:"max"`
+}
+
+// fileConfig is the YAML schema for --config: the same settings the flags carry.
+type fileConfig struct {
+	Capture   string                   `yaml:"capture"`
+	State     string                   `yaml:"state"`
+	Seed      *int64                   `yaml:"seed"`
+	Overrides map[string]overrideEntry `yaml:"overrides"`
+	Exit      *int                     `yaml:"exit"`
+	Delay     string                   `yaml:"delay"`
+	StderrMsg string                   `yaml:"stderr-msg"` //nolint:tagliatelle // matches the --stderr-msg flag
+	FailArg   string                   `yaml:"fail-arg"`   //nolint:tagliatelle // matches the --fail-arg flag
+}
+
+// overrideEntry is one field's override in the config. It is either a fixed
+// value (written as a scalar, or as `value: ...`) or a range (`min` and `max`).
+type overrideEntry struct {
+	fixed *string
+	rng   *rangeSpec
+}
+
+// UnmarshalYAML accepts a scalar (a fixed value) or a mapping with either
+// `value` (fixed) or `min` and `max` (a range), and rejects anything else.
+func (e *overrideEntry) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		e.fixed = &node.Value
+
+		return nil
+	}
+
+	if node.Kind != yaml.MappingNode {
+		return errors.New("override must be a value or a mapping with value or min/max")
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		if key := node.Content[i].Value; key != "value" && key != "min" && key != "max" {
+			return fmt.Errorf("unknown override key %q, want value or min/max", key)
+		}
+	}
+
+	var spec struct {
+		Value *string  `yaml:"value"`
+		Min   *float64 `yaml:"min"`
+		Max   *float64 `yaml:"max"`
+	}
+
+	if err := node.Decode(&spec); err != nil {
+		return fmt.Errorf("failed to decode override: %w", err)
+	}
+
+	return e.assign(spec.Value, spec.Min, spec.Max)
+}
+
+// assign records a decoded override as a fixed value or a range, rejecting a
+// mix of the two or an incomplete range.
+func (e *overrideEntry) assign(value *string, minVal, maxVal *float64) error {
+	switch {
+	case value != nil && (minVal != nil || maxVal != nil):
+		return errors.New("override cannot set both value and min/max")
+	case value != nil:
+		e.fixed = value
+	case minVal != nil && maxVal != nil:
+		e.rng = &rangeSpec{Min: *minVal, Max: *maxVal}
+	default:
+		return errors.New("override needs a value, or both min and max")
+	}
+
+	return nil
+}
+
+// loadFileConfig reads and strictly decodes a config file: an unknown key is an
+// error rather than a silent no-op, so a typo surfaces.
+func loadFileConfig(path string) (*fileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config %q: %w", path, err)
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var cfg fileConfig
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config %q: %w", path, err)
+	}
+
+	return &cfg, nil
+}
+
+// rawOverride is a not-yet-resolved override for one field: either a fixed value
+// or a range. Ranges are resolved into a generator once the seed is known.
+type rawOverride struct {
+	field string
+	fixed *string
+	rng   *rangeSpec
+}
+
+// parseRange parses a "min:max" flag value into a validated range.
+func parseRange(field, raw string) (rangeSpec, error) {
+	minRaw, maxRaw, ok := strings.Cut(raw, ":")
+	if !ok {
+		return rangeSpec{}, fmt.Errorf("invalid --set-range for %q, want min:max", field)
+	}
+
+	minVal, err := strconv.ParseFloat(strings.TrimSpace(minRaw), 64)
+	if err != nil {
+		return rangeSpec{}, fmt.Errorf("invalid --set-range min for %q: %w", field, err)
+	}
+
+	maxVal, err := strconv.ParseFloat(strings.TrimSpace(maxRaw), 64)
+	if err != nil {
+		return rangeSpec{}, fmt.Errorf("invalid --set-range max for %q: %w", field, err)
+	}
+
+	return validateRange(field, rangeSpec{Min: minVal, Max: maxVal})
+}
+
+// validateRange rejects non-finite bounds and min greater than max.
+func validateRange(field string, spec rangeSpec) (rangeSpec, error) {
+	if math.IsNaN(spec.Min) || math.IsInf(spec.Min, 0) || math.IsNaN(spec.Max) || math.IsInf(spec.Max, 0) {
+		return rangeSpec{}, fmt.Errorf("range for %q must have finite bounds", field)
+	}
+
+	if spec.Min > spec.Max {
+		return rangeSpec{}, fmt.Errorf("range for %q has min %v greater than max %v", field, spec.Min, spec.Max)
+	}
+
+	return spec, nil
+}
+
+// validateSetValue rejects a comma or line break, which would corrupt the CSV
+// the exporter splits on commas. It mirrors addOverride's guard.
+func validateSetValue(field, value string) error {
+	if strings.ContainsAny(value, ",\r\n") {
+		return fmt.Errorf("value for %q must not contain a comma or newline", field)
+	}
+
+	return nil
+}
+
+// constGen serves a fixed value on every row.
+func constGen(value string) valueGen {
+	return func() string { return value }
+}
+
+// rangeGen serves a fresh uniform draw from the range on every row. Each field
+// gets its own random source seeded from (seed, field name), so a seed
+// reproduces the values regardless of how many other fields are ranged or in
+// what order they are stored.
+func rangeGen(field string, spec rangeSpec, seed int64) valueGen {
+	//nolint:gosec // not cryptographic: deterministic fake test data
+	src := rand.New(rand.NewSource(fieldSeed(seed, field)))
+	whole := spec.Min == math.Trunc(spec.Min) && spec.Max == math.Trunc(spec.Max)
+
+	return func() string {
+		value := spec.Min + src.Float64()*(spec.Max-spec.Min)
+		if whole {
+			return strconv.FormatInt(int64(math.Round(value)), 10)
+		}
+		// fixed-point ('f' never uses exponent form, which the exporter's number
+		// extractor rejects), full precision so a narrow range is never rounded
+		// outside its bounds
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	}
+}
+
+// fieldSeed derives a per-field random seed, so field order never affects
+// reproducibility and one field's values do not shift when another is ranged.
+func fieldSeed(seed int64, field string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(field))
+
+	//nolint:gosec // deterministic fake seed, the bit pattern is what we want
+	return seed ^ int64(h.Sum64())
+}
+
+// buildOverrides resolves the config base and the flag overlay into the final
+// per-field generator map. Config entries come first, flag overrides last, so a
+// flag wins per field.
+func buildOverrides(fc *fileConfig, flagOps []rawOverride, seed int64) (map[string]valueGen, error) {
+	var ordered []rawOverride
+
+	if fc != nil {
+		for field, entry := range fc.Overrides {
+			if entry.fixed != nil {
+				if err := validateSetValue(field, *entry.fixed); err != nil {
+					return nil, err
+				}
+
+				ordered = append(ordered, rawOverride{field: field, fixed: entry.fixed})
+
+				continue
+			}
+
+			if _, err := validateRange(field, *entry.rng); err != nil {
+				return nil, err
+			}
+
+			ordered = append(ordered, rawOverride{field: field, rng: entry.rng})
+		}
+	}
+
+	ordered = append(ordered, flagOps...)
+
+	out := make(map[string]valueGen, len(ordered))
+	for _, op := range ordered {
+		if op.fixed != nil {
+			out[op.field] = constGen(*op.fixed)
+		} else {
+			out[op.field] = rangeGen(op.field, *op.rng, seed)
+		}
+	}
+
+	return out, nil
+}

--- a/internal/fakesmi/config_test.go
+++ b/internal/fakesmi/config_test.go
@@ -1,0 +1,237 @@
+package fakesmi_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const h200Capture = "linux-x86_64__nvidia-h200__590.48.01"
+
+// dataRows runs a query and returns the data cells of the requested single
+// field, one entry per row (the header is dropped).
+func dataRows(t *testing.T, field string, args ...string) []string {
+	t.Helper()
+
+	full := append(append([]string{}, args...), "--query-gpu="+field, "--format=csv")
+	code, stdout, stderr := runFake(t, full...)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	require.GreaterOrEqual(t, len(lines), 2)
+
+	out := make([]string, 0, len(lines)-1)
+	for _, line := range lines[1:] {
+		out = append(out, strings.TrimSpace(line))
+	}
+
+	return out
+}
+
+func TestSetRangeWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	for _, cell := range dataRows(t, "temperature.gpu",
+		"--capture", h200Capture, "--seed", "3", "--set-range", "temperature.gpu=60:85") {
+		v, err := strconv.ParseFloat(cell, 64)
+		require.NoError(t, err, "cell %q", cell)
+		assert.GreaterOrEqual(t, v, 60.0)
+		assert.LessOrEqual(t, v, 85.0)
+	}
+}
+
+// TestSetRangeSeedReproducible pins that a seed reproduces the values across
+// runs even with several ranged fields (the field order must not matter).
+func TestSetRangeSeedReproducible(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"--capture", h200Capture, "--seed", "99",
+		"--set-range", "temperature.gpu=10:90",
+		"--set-range", "utilization.gpu=0:100",
+		"--set-range", "power.draw=50:400",
+	}
+	// check two of the three ranged fields, so order-independence is exercised
+	for _, field := range []string{"temperature.gpu", "power.draw"} {
+		first := dataRows(t, field, args...)
+		second := dataRows(t, field, args...)
+		assert.Equalf(t, first, second, "same seed must reproduce %s", field)
+	}
+}
+
+// TestSetRangeFormatting proves whole-number bounds yield an integer, fractional
+// bounds yield fixed-point, and a wide range never emits exponent form (which
+// the exporter's number extractor would reject).
+func TestSetRangeFormatting(t *testing.T) {
+	t.Parallel()
+
+	intCell := dataRows(t, "temperature.gpu",
+		"--capture", h200Capture, "--seed", "1", "--set-range", "temperature.gpu=60:85")[0]
+	assert.NotContains(t, intCell, ".")
+
+	floatCell := dataRows(t, "power.draw",
+		"--capture", h200Capture, "--seed", "1", "--set-range", "power.draw=0.5:1.5")[0]
+	assert.Contains(t, floatCell, ".")
+
+	// a fractional wide range exercises the float branch on a large magnitude,
+	// where a lazy formatter would switch to exponent notation
+	wideCell := dataRows(t, "power.draw",
+		"--capture", h200Capture, "--seed", "1", "--set-range", "power.draw=0.5:100000000.5")[0]
+	assert.Contains(t, wideCell, ".")
+	assert.NotContainsf(t, strings.ToLower(wideCell), "e", "must be fixed-point, got %q", wideCell)
+}
+
+// TestSetRangePerRowIndependent proves each data row draws its own value, so a
+// multi-process (or multi-GPU) capture does not move in lockstep.
+func TestSetRangePerRowIndependent(t *testing.T) {
+	t.Parallel()
+
+	code, stdout, stderr := runFake(t, "--capture", "linux-x86_64__nvidia-l40s__595.80",
+		"--state", "load", "--seed", "5", "--set-range", "used_gpu_memory=1:1000000",
+		"--query-compute-apps=pid,used_gpu_memory", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Greater(t, len(lines), 2, "need at least two process rows")
+
+	mem := make(map[string]bool)
+	for _, line := range lines[1:] {
+		mem[strings.Split(line, ", ")[1]] = true
+	}
+
+	assert.Greater(t, len(mem), 1, "rows should draw independent values, got %v", mem)
+}
+
+func TestSetRangeInvalid(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []string{"temperature.gpu=notarange", "temperature.gpu=90:10", "=60:85", "x=a:b"} {
+		code, _, stderr := runFake(t, "--capture", h200Capture, "--set-range", bad, "-L")
+		assert.Equalf(t, 2, code, "--set-range %q should be rejected", bad)
+		assert.NotEmpty(t, stderr)
+	}
+}
+
+// writeConfig writes a temp yaml config and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fake.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	return path
+}
+
+func TestConfigFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, `
+capture: `+h200Capture+`
+state: load
+overrides:
+  gpu_recovery_action: Reset
+  compute_mode: {value: Prohibited}
+  temperature.gpu: {min: 70, max: 71}
+`)
+
+	// a scalar fixed value, an object fixed value, and a range in one section
+	assert.Equal(t, "Reset", dataRows(t, "gpu_recovery_action", "--config", cfg, "--seed", "1")[0])
+	assert.Equal(t, "Prohibited", dataRows(t, "compute_mode", "--config", cfg, "--seed", "1")[0])
+
+	temp := dataRows(t, "temperature.gpu", "--config", cfg, "--seed", "1")[0]
+	v, err := strconv.ParseFloat(temp, 64)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, v, 70.0)
+	assert.LessOrEqual(t, v, 71.0)
+}
+
+// TestConfigFlagPrecedence proves a flag overrides the config for the same field.
+func TestConfigFlagPrecedence(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, "capture: "+h200Capture+"\noverrides:\n  temperature.gpu: {min: 10, max: 20}\n")
+
+	// --set wins over the config's range for temperature.gpu, wherever --config sits
+	cell := dataRows(t, "temperature.gpu", "--set", "temperature.gpu=42", "--config", cfg)[0]
+	assert.Equal(t, "42", cell)
+}
+
+func TestConfigRejectsUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, "captur: x\n") // typo
+	code, _, stderr := runFake(t, "--config", cfg, "--query-gpu=uuid", "--format=csv")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "config")
+}
+
+// TestSetRangeFractionalBounds proves a narrow, sub-unit, or negative
+// fractional range never rounds a value outside its bounds and never emits
+// exponent form.
+func TestSetRangeFractionalBounds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		field    string
+		min, max float64
+	}{
+		{"temperature.gpu=1.234:1.234", 1.234, 1.234},
+		{"temperature.gpu=0.001:0.002", 0.001, 0.002},
+		{"power.draw=-5.5:-5.0", -5.5, -5.0},
+	} {
+		field := strings.SplitN(tc.field, "=", 2)[0]
+		for _, cell := range dataRows(t, field, "--capture", h200Capture, "--seed", "2", "--set-range", tc.field) {
+			assert.NotContainsf(t, strings.ToLower(cell), "e", "no exponent, got %q", cell)
+
+			v, err := strconv.ParseFloat(cell, 64)
+			require.NoError(t, err, cell)
+			assert.GreaterOrEqual(t, v, tc.min)
+			assert.LessOrEqual(t, v, tc.max)
+		}
+	}
+}
+
+// TestConfigSeedReproducible proves a seed in the config reproduces the values.
+func TestConfigSeedReproducible(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, "capture: "+h200Capture+"\nseed: 55\noverrides:\n"+
+		"  temperature.gpu: {min: 0, max: 1000}\n  power.draw: {min: 0, max: 500}\n")
+	first := dataRows(t, "temperature.gpu", "--config", cfg)
+	second := dataRows(t, "temperature.gpu", "--config", cfg)
+	assert.Equal(t, first, second)
+}
+
+// TestConfigRejectsCommaValue proves a config value with a comma is rejected,
+// matching the --set guard.
+func TestConfigRejectsCommaValue(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, "overrides:\n  process_name: {value: \"a,b\"}\n")
+	code, _, stderr := runFake(t, "--capture", h200Capture, "--config", cfg, "--query-gpu=uuid", "--format=csv")
+	assert.Equal(t, 2, code)
+	assert.NotEmpty(t, stderr)
+}
+
+// TestConfigRejectsBadOverride covers the override-entry validation: a fixed
+// value and a range are mutually exclusive, a range needs both bounds, and an
+// unknown key inside an entry is rejected.
+func TestConfigRejectsBadOverride(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		"overrides:\n  power.draw: {value: 100, min: 1, max: 2}\n",
+		"overrides:\n  power.draw: {min: 1}\n",
+		"overrides:\n  power.draw: {mim: 1, max: 2}\n",
+	} {
+		cfg := writeConfig(t, body)
+		code, _, stderr := runFake(t, "--capture", h200Capture, "--config", cfg, "--query-gpu=uuid", "--format=csv")
+		assert.Equalf(t, 2, code, "config %q should be rejected", body)
+		assert.NotEmpty(t, stderr)
+	}
+}

--- a/internal/fakesmi/fakesmi.go
+++ b/internal/fakesmi/fakesmi.go
@@ -7,6 +7,7 @@
 package fakesmi
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -42,9 +43,10 @@ type config struct {
 	exitCode    int
 	exitSet     bool
 	// overrides replaces a query field's value in every data row, keyed by the
-	// field name. It lets a test drive a state a real capture does not contain
-	// (a bad GPU, an edge value, a permission error) without a new capture file.
-	overrides map[string]string
+	// field name, with a generator (a fixed value from --set, or a fresh random
+	// draw from --set-range). It lets a run drive a state a real capture does not
+	// contain, or make values move, without a new capture file.
+	overrides map[string]valueGen
 }
 
 // Run executes the fake: it parses the fake's own leading flags, loads the
@@ -118,84 +120,248 @@ func loadCapture(value string) (*capture.Capture, error) {
 	return parsed, nil
 }
 
-// parseFlags consumes the fake's own flags from the front of args, returning
-// the remaining arguments, which form the nvidia-smi invocation to replay.
-//
-//nolint:cyclop
+// rawFlags holds the leading flags as given, before a --config base is loaded
+// and merged. The *Set bools record which fields a flag set, so a flag wins over
+// the config regardless of where --config sits in the arguments.
+type rawFlags struct {
+	capturePath string
+	captureSet  bool
+	state       string
+	stateSet    bool
+	stderrMsg   string
+	stderrSet   bool
+	failArg     string
+	failSet     bool
+	exitCode    int
+	exitSet     bool
+	delay       time.Duration
+	delaySet    bool
+	configPath  string
+	seed        int64
+	seedSet     bool
+	ops         []rawOverride // --set and --set-range, in argument order
+}
+
+// parseFlags consumes the fake's own flags from the front of args, then resolves
+// them against an optional --config base, returning the remaining arguments,
+// which form the nvidia-smi invocation to replay.
 func parseFlags(args []string) (config, []string, error) {
-	cfg := config{capturePath: captures.Default, state: DefaultState}
+	var raw rawFlags
 
 	for len(args) > 0 {
 		name, value, hasValue := strings.Cut(args[0], "=")
 
 		switch name {
-		case "--capture", "--state", "--stderr-msg", "--fail-arg", "--exit", "--delay", "--set":
+		case "--capture", "--state", "--stderr-msg", "--fail-arg", "--exit", "--delay",
+			"--set", "--set-range", "--config", "--seed":
 		default:
-			return cfg, args, nil
+			return resolve(raw, args)
 		}
 
 		args = args[1:]
 
 		if !hasValue {
 			if len(args) == 0 {
-				return cfg, nil, fmt.Errorf("flag %s needs a value", name)
+				return config{}, nil, fmt.Errorf("flag %s needs a value", name)
 			}
 
 			value, args = args[0], args[1:]
 		}
 
-		var err error
-
-		switch name {
-		case "--capture":
-			cfg.capturePath = value
-		case "--state":
-			cfg.state = value
-		case "--stderr-msg":
-			cfg.stderrMsg = value
-		case "--fail-arg":
-			cfg.failArg = value
-		case "--exit":
-			cfg.exitSet = true
-
-			if cfg.exitCode, err = strconv.Atoi(value); err != nil {
-				return cfg, nil, fmt.Errorf("invalid --exit value %q: %w", value, err)
-			}
-		case "--delay":
-			if cfg.delay, err = time.ParseDuration(value); err != nil {
-				return cfg, nil, fmt.Errorf("invalid --delay value %q: %w", value, err)
-			}
-		case "--set":
-			if err = addOverride(&cfg, value); err != nil {
-				return cfg, nil, err
-			}
+		if err := applyFlag(&raw, name, value); err != nil {
+			return config{}, nil, err
 		}
 	}
 
-	return cfg, nil, nil
+	return resolve(raw, nil)
 }
 
-// addOverride records one --set field=value pair. A comma or newline in the
-// value is rejected because it would corrupt the CSV row the exporter splits on
-// commas; the field name must be non-empty; the value may be empty; and a
-// repeated field takes the last value.
-func addOverride(cfg *config, raw string) error {
-	field, value, ok := strings.Cut(raw, "=")
-	if !ok || field == "" {
-		return fmt.Errorf("invalid --set %q, want field=value", raw)
-	}
+// applyFlag records a single parsed flag into raw.
+//
+//nolint:cyclop
+func applyFlag(raw *rawFlags, name, value string) error {
+	switch name {
+	case "--capture":
+		raw.capturePath, raw.captureSet = value, true
+	case "--state":
+		raw.state, raw.stateSet = value, true
+	case "--stderr-msg":
+		raw.stderrMsg, raw.stderrSet = value, true
+	case "--fail-arg":
+		raw.failArg, raw.failSet = value, true
+	case "--exit":
+		code, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("invalid --exit value %q: %w", value, err)
+		}
 
-	if strings.ContainsAny(value, ",\r\n") {
-		return fmt.Errorf("invalid --set value for %q: must not contain a comma or newline", field)
-	}
+		raw.exitCode, raw.exitSet = code, true
+	case "--delay":
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("invalid --delay value %q: %w", value, err)
+		}
 
-	if cfg.overrides == nil {
-		cfg.overrides = make(map[string]string)
-	}
+		raw.delay, raw.delaySet = d, true
+	case "--config":
+		if value == "" {
+			return errors.New("--config needs a path")
+		}
 
-	cfg.overrides[field] = value
+		raw.configPath = value
+	case "--seed":
+		s, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid --seed value %q: %w", value, err)
+		}
+
+		raw.seed, raw.seedSet = s, true
+	case "--set":
+		op, err := parseSetFlag(value)
+		if err != nil {
+			return err
+		}
+
+		raw.ops = append(raw.ops, op)
+	case "--set-range":
+		op, err := parseSetRangeFlag(value)
+		if err != nil {
+			return err
+		}
+
+		raw.ops = append(raw.ops, op)
+	}
 
 	return nil
+}
+
+// resolve merges the parsed flags with an optional --config base into the final
+// config: the config supplies defaults, and any flag-set value wins per field.
+func resolve(raw rawFlags, rest []string) (config, []string, error) {
+	cfg := config{capturePath: captures.Default, state: DefaultState}
+
+	var fc *fileConfig
+
+	if raw.configPath != "" {
+		loaded, err := loadFileConfig(raw.configPath)
+		if err != nil {
+			return config{}, nil, err
+		}
+
+		fc = loaded
+	}
+
+	mergeBaseSettings(&cfg, raw, fc)
+
+	if err := mergeFailureSettings(&cfg, raw, fc); err != nil {
+		return config{}, nil, err
+	}
+
+	seed := time.Now().UnixNano()
+
+	switch {
+	case raw.seedSet:
+		seed = raw.seed
+	case fc != nil && fc.Seed != nil:
+		seed = *fc.Seed
+	}
+
+	overrides, err := buildOverrides(fc, raw.ops, seed)
+	if err != nil {
+		return config{}, nil, err
+	}
+
+	cfg.overrides = overrides
+
+	return cfg, rest, nil
+}
+
+// mergeBaseSettings applies capture and state, preferring a flag over the
+// config over the default.
+func mergeBaseSettings(cfg *config, raw rawFlags, fc *fileConfig) {
+	switch {
+	case raw.captureSet:
+		cfg.capturePath = raw.capturePath
+	case fc != nil && fc.Capture != "":
+		cfg.capturePath = fc.Capture
+	}
+
+	switch {
+	case raw.stateSet:
+		cfg.state = raw.state
+	case fc != nil && fc.State != "":
+		cfg.state = fc.State
+	}
+}
+
+// mergeFailureSettings applies the failure-injection settings, preferring a flag
+// over the config.
+//
+//nolint:cyclop // a flat flag-over-config merge, one branch per setting
+func mergeFailureSettings(cfg *config, raw rawFlags, fc *fileConfig) error {
+	switch {
+	case raw.stderrSet:
+		cfg.stderrMsg = raw.stderrMsg
+	case fc != nil && fc.StderrMsg != "":
+		cfg.stderrMsg = fc.StderrMsg
+	}
+
+	switch {
+	case raw.failSet:
+		cfg.failArg = raw.failArg
+	case fc != nil && fc.FailArg != "":
+		cfg.failArg = fc.FailArg
+	}
+
+	switch {
+	case raw.exitSet:
+		cfg.exitCode, cfg.exitSet = raw.exitCode, true
+	case fc != nil && fc.Exit != nil:
+		cfg.exitCode, cfg.exitSet = *fc.Exit, true
+	}
+
+	switch {
+	case raw.delaySet:
+		cfg.delay = raw.delay
+	case fc != nil && fc.Delay != "":
+		d, err := time.ParseDuration(fc.Delay)
+		if err != nil {
+			return fmt.Errorf("invalid config delay %q: %w", fc.Delay, err)
+		}
+
+		cfg.delay = d
+	}
+
+	return nil
+}
+
+// parseSetFlag parses one --set field=value into a fixed override.
+func parseSetFlag(raw string) (rawOverride, error) {
+	field, value, ok := strings.Cut(raw, "=")
+	if !ok || field == "" {
+		return rawOverride{}, fmt.Errorf("invalid --set %q, want field=value", raw)
+	}
+
+	if err := validateSetValue(field, value); err != nil {
+		return rawOverride{}, err
+	}
+
+	return rawOverride{field: field, fixed: &value}, nil
+}
+
+// parseSetRangeFlag parses one --set-range field=min:max into a range override.
+func parseSetRangeFlag(raw string) (rawOverride, error) {
+	field, rangeRaw, ok := strings.Cut(raw, "=")
+	if !ok || field == "" {
+		return rawOverride{}, fmt.Errorf("invalid --set-range %q, want field=min:max", raw)
+	}
+
+	spec, err := parseRange(field, rangeRaw)
+	if err != nil {
+		return rawOverride{}, err
+	}
+
+	return rawOverride{field: field, rng: &spec}, nil
 }
 
 // failMatching implements the selective failure injection: when an argument
@@ -229,7 +395,7 @@ func failMatching(cfg config, args []string, stderr io.Writer) bool {
 func answer(
 	capt *capture.Capture,
 	state string,
-	overrides map[string]string,
+	overrides map[string]valueGen,
 	args []string,
 	stdout, stderr io.Writer,
 ) int {

--- a/internal/fakesmi/project.go
+++ b/internal/fakesmi/project.go
@@ -21,7 +21,7 @@ var errEmptySection = errors.New("section body has no header row")
 // columns, in the requested order, for the header and every row. When overrides
 // are given, a data row's cell for a named field is replaced before projection,
 // so tests can drive values a real capture does not contain.
-func project(section *capture.Section, requestRaw string, overrides map[string]string) (string, error) {
+func project(section *capture.Section, requestRaw string, overrides map[string]valueGen) (string, error) {
 	recorded, err := recordedFields(section.Command)
 	if err != nil {
 		return "", err
@@ -65,7 +65,7 @@ func projectRow(
 	recorded []string,
 	columnOf map[string]int,
 	columns []int,
-	overrides map[string]string,
+	overrides map[string]valueGen,
 ) (string, error) {
 	freeTextColumn := -1
 	if column, hasFreeText := columnOf[freeTextField]; hasFreeText && lineNum > 0 {
@@ -92,10 +92,10 @@ func projectRow(
 // applyOverrides replaces the cell of every field named in overrides with the
 // given value, keyed by the recorded field order. Fields not named are left as
 // recorded, and an override for a field absent from this section is ignored.
-func applyOverrides(cells, recorded []string, overrides map[string]string) {
+func applyOverrides(cells, recorded []string, overrides map[string]valueGen) {
 	for column, name := range recorded {
-		if value, ok := overrides[name]; ok {
-			cells[column] = value
+		if gen, ok := overrides[name]; ok {
+			cells[column] = gen()
 		}
 	}
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -332,6 +334,37 @@ func TestValueOverrideQuotedSpaces(t *testing.T) {
 		fakeCommand(defaultCapture(t), "--set", quote("name=Fake RTX 3090")))
 
 	assert.Regexp(t, `nvidia_smi_gpu_info\{[^}]*name="Fake RTX 3090"`, scrape(t, baseURL))
+}
+
+// TestValueRange proves --set-range flows through to a metric within its bounds.
+func TestValueRange(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+
+		fakeCommand(defaultCapture(t), "--seed", "1", "--set-range", "temperature.gpu=90:95"))
+
+	match := regexp.MustCompile(`nvidia_smi_temperature_gpu\{uuid="[^"]+"\} (\d+(?:\.\d+)?)`).
+		FindStringSubmatch(scrape(t, baseURL))
+	require.NotNil(t, match)
+
+	v, err := strconv.ParseFloat(match[1], 64)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, v, 90.0)
+	assert.LessOrEqual(t, v, 95.0)
+}
+
+// TestConfigFile proves a --config yaml drives the capture and a fixed override
+// with no --capture flag, so the whole setup can live in the file.
+func TestConfigFile(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "fake.yaml")
+	body := "capture: " + captures.Default + "\noverrides:\n  temperature.gpu: {value: \"88\"}\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+quote(fakeBin)+" --config "+quote(cfgPath))
+
+	assert.Regexp(t, `nvidia_smi_temperature_gpu\{uuid="[^"]+"\} 88\b`, scrape(t, baseURL))
 }
 
 // TestGPURecoveryActionBadState drives gpu_recovery_action to "Reset" with the


### PR DESCRIPTION
The fake nvidia-smi could pin a field to a value with `--set`. It can now also make values move and read its whole setup from a file, which is what makes iterating on the Grafana dashboard (and demoing) without a GPU comfortable.

## What's new

- `--set-range field=min:max` (repeatable): serves a fresh uniform-random value in the range on each run, so the exporter's timeseries and gauges move instead of sitting flat. `--seed N` makes the values reproducible for tests.
- `--config file.yaml`: carries the whole setup as an alternative to flags. Because the fake is a short-lived process invoked once per scrape, editing the file changes the next scrape with no exporter restart (in cached mode, the next collection).

```yaml
capture: linux-x86_64__nvidia-h200__590.48.01
state: load
overrides:
  gpu_recovery_action: Reset            # a fixed value (a scalar, or value:)
  temperature.gpu: {min: 60, max: 85}   # a random range
  power.draw:      {min: 50, max: 350}
```

Each override is either a fixed value or a range. A flag wins over the config for the same field, and an unknown key is rejected.

## Notes

- Each ranged field draws from its own random source seeded from the field name, so a seed reproduces the values no matter how many fields are ranged, and every GPU or process row draws its own value rather than moving in lockstep.
- Ranged floats are emitted in fixed-point at full precision, so a narrow range is never rounded outside its bounds and a wide one never becomes exponent form (which the exporter's number extractor would reject).
- This supersedes #449 (the auto-realistic-mutation idea): explicit user-controlled ranges give moving values with control, which is simpler and more useful for the dashboard loop.
