### PR TITLE
feat: fluctuate values and simulate multiple GPUs in the fake nvidia-smi

### DIFF
--- a/cmd/fake-nvidia-smi/main.go
+++ b/cmd/fake-nvidia-smi/main.go
@@ -3,15 +3,23 @@
 // making the binary self-contained; --capture takes an embedded capture name
 // or a path to a capture file. Repeat --set field=value to pin a field to a
 // value, and --set-range field=min:max to serve a fresh random value in that
-// range on each run, so metrics move. --config file.yaml carries the whole
-// setup (capture, state, per-field overrides, failure injection) instead of
-// flags; because the fake is invoked fresh each scrape, editing the file changes
-// the next scrape with no exporter restart. Used by the integration tests, and
-// handy for local development:
+// range on each run, so metrics move. --fluctuate jitters the naturally
+// varying fields (utilization, temperature, power draw, current clocks, fan
+// speed, used memory) around their captured values instead, with no per-field
+// setup. --gpus N replicates the captured GPU into N simulated cards with
+// distinct, stable identities (the generated uuids never change across runs,
+// so Prometheus series survive); the CSV queries report all N, while the
+// other nvidia-smi invocations keep replaying the single-GPU recording
+// verbatim. --config file.yaml carries the whole setup (capture, state,
+// per-field overrides, per-GPU identities and overrides, failure injection)
+// instead of flags; because the fake is invoked fresh each scrape, editing
+// the file changes the next scrape with no exporter restart. Used by the
+// integration tests, and handy for local development:
 //
 //	go run ./cmd/fake-nvidia-smi --help-query-gpu
 //	nvidia_gpu_exporter \
 //	  --nvidia-smi-command "fake-nvidia-smi --capture linux-x86_64__nvidia-h200__590.48.01 --state load"
+//	nvidia_gpu_exporter --nvidia-smi-command "fake-nvidia-smi --gpus 4 --fluctuate"
 package main
 
 import (

--- a/internal/fakesmi/config.go
+++ b/internal/fakesmi/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"math"
 	"math/rand"
 	"os"
@@ -30,6 +31,8 @@ type fileConfig struct {
 	State     string                   `yaml:"state"`
 	Seed      *int64                   `yaml:"seed"`
 	Overrides map[string]overrideEntry `yaml:"overrides"`
+	GPUs      *gpusFileConfig          `yaml:"gpus"`
+	Fluctuate bool                     `yaml:"fluctuate"`
 	Exit      *int                     `yaml:"exit"`
 	Delay     string                   `yaml:"delay"`
 	StderrMsg string                   `yaml:"stderr-msg"` //nolint:tagliatelle // matches the --stderr-msg flag
@@ -198,41 +201,100 @@ func fieldSeed(seed int64, field string) int64 {
 	return seed ^ int64(h.Sum64())
 }
 
-// buildOverrides resolves the config base and the flag overlay into the final
-// per-field generator map. Config entries come first, flag overrides last, so a
-// flag wins per field.
-func buildOverrides(fc *fileConfig, flagOps []rawOverride, seed int64) (map[string]valueGen, error) {
-	var ordered []rawOverride
+// opsFromEntries validates and converts config override entries into ordered
+// rawOverrides. Iteration order is irrelevant to reproducibility, because
+// every ranged generator is seeded per field.
+func opsFromEntries(entries map[string]overrideEntry) ([]rawOverride, error) {
+	ops := make([]rawOverride, 0, len(entries))
 
-	if fc != nil {
-		for field, entry := range fc.Overrides {
-			if entry.fixed != nil {
-				if err := validateSetValue(field, *entry.fixed); err != nil {
-					return nil, err
-				}
-
-				ordered = append(ordered, rawOverride{field: field, fixed: entry.fixed})
-
-				continue
-			}
-
-			if _, err := validateRange(field, *entry.rng); err != nil {
+	for field, entry := range entries {
+		if entry.fixed != nil {
+			if err := validateSetValue(field, *entry.fixed); err != nil {
 				return nil, err
 			}
 
-			ordered = append(ordered, rawOverride{field: field, rng: entry.rng})
+			ops = append(ops, rawOverride{field: field, fixed: entry.fixed})
+
+			continue
 		}
+
+		if _, err := validateRange(field, *entry.rng); err != nil {
+			return nil, err
+		}
+
+		ops = append(ops, rawOverride{field: field, rng: entry.rng})
 	}
 
-	ordered = append(ordered, flagOps...)
+	return ops, nil
+}
 
-	out := make(map[string]valueGen, len(ordered))
-	for _, op := range ordered {
+// genMap turns rawOverrides into per-field generators. seedScope prefixes the
+// per-field seed derivation, so a per-GPU entry gets draws independent from a
+// top-level entry on the same field.
+func genMap(ops []rawOverride, seed int64, seedScope string) map[string]valueGen {
+	out := make(map[string]valueGen, len(ops))
+
+	for _, op := range ops {
 		if op.fixed != nil {
 			out[op.field] = constGen(*op.fixed)
 		} else {
-			out[op.field] = rangeGen(op.field, *op.rng, seed)
+			out[op.field] = rangeGen(seedScope+op.field, *op.rng, seed)
 		}
+	}
+
+	return out
+}
+
+// buildOverrides resolves the override layers into one generator map per
+// simulated GPU (a single map when gpus is off). Per field, a flag beats a
+// per-GPU config entry, which beats a top-level config entry. Top-level and
+// flag generators are shared across the GPU maps, so their per-row draws keep
+// every row independent exactly as in the single-GPU case.
+func buildOverrides(
+	fc *fileConfig,
+	flagOps []rawOverride,
+	gpuEntries []gpuFileEntry,
+	gpuCount int,
+	seed int64,
+) ([]map[string]valueGen, error) {
+	var topOps []rawOverride
+
+	if fc != nil {
+		ops, err := opsFromEntries(fc.Overrides)
+		if err != nil {
+			return nil, err
+		}
+
+		topOps = ops
+	}
+
+	if gpuCount == 0 {
+		return []map[string]valueGen{genMap(append(topOps, flagOps...), seed, "")}, nil
+	}
+
+	if err := rejectIdentityOverrides(append(topOps, flagOps...), gpuEntries); err != nil {
+		return nil, err
+	}
+
+	base := genMap(topOps, seed, "")
+	flags := genMap(flagOps, seed, "")
+
+	out := make([]map[string]valueGen, gpuCount)
+
+	for gpu := range out {
+		merged := maps.Clone(base)
+
+		if gpu < len(gpuEntries) {
+			ops, err := opsFromEntries(gpuEntries[gpu].overrides)
+			if err != nil {
+				return nil, err
+			}
+
+			maps.Copy(merged, genMap(ops, seed, fmt.Sprintf("gpu%d:", gpu)))
+		}
+
+		maps.Copy(merged, flags)
+		out[gpu] = merged
 	}
 
 	return out, nil

--- a/internal/fakesmi/fakesmi.go
+++ b/internal/fakesmi/fakesmi.go
@@ -42,11 +42,18 @@ type config struct {
 	delay       time.Duration
 	exitCode    int
 	exitSet     bool
-	// overrides replaces a query field's value in every data row, keyed by the
+	// overrides replaces a query field's value in the data rows, keyed by the
 	// field name, with a generator (a fixed value from --set, or a fresh random
 	// draw from --set-range). It lets a run drive a state a real capture does not
-	// contain, or make values move, without a new capture file.
-	overrides map[string]valueGen
+	// contain, or make values move, without a new capture file. One map per
+	// simulated GPU, indexed by the GPU; a single map when gpus is off.
+	overrides []map[string]valueGen
+	// gpus holds the simulated GPUs' identities the captured GPU row is
+	// replicated into; nil replays the capture's rows untouched.
+	gpus []gpuIdentity
+	// fluct jitters naturally-varying fields around their captured values;
+	// nil when --fluctuate is off.
+	fluct *fluctuator
 }
 
 // Run executes the fake: it parses the fake's own leading flags, loads the
@@ -83,7 +90,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return usageExitCode
 	}
 
-	return answer(capt, cfg.state, cfg.overrides, rest, stdout, stderr)
+	return answer(capt, &cfg, rest, stdout, stderr)
 }
 
 // loadCapture resolves the --capture value: a path (anything with a path
@@ -124,22 +131,26 @@ func loadCapture(value string) (*capture.Capture, error) {
 // and merged. The *Set bools record which fields a flag set, so a flag wins over
 // the config regardless of where --config sits in the arguments.
 type rawFlags struct {
-	capturePath string
-	captureSet  bool
-	state       string
-	stateSet    bool
-	stderrMsg   string
-	stderrSet   bool
-	failArg     string
-	failSet     bool
-	exitCode    int
-	exitSet     bool
-	delay       time.Duration
-	delaySet    bool
-	configPath  string
-	seed        int64
-	seedSet     bool
-	ops         []rawOverride // --set and --set-range, in argument order
+	capturePath  string
+	captureSet   bool
+	state        string
+	stateSet     bool
+	stderrMsg    string
+	stderrSet    bool
+	failArg      string
+	failSet      bool
+	exitCode     int
+	exitSet      bool
+	delay        time.Duration
+	delaySet     bool
+	configPath   string
+	seed         int64
+	seedSet      bool
+	gpus         int
+	gpusSet      bool
+	fluctuate    bool
+	fluctuateSet bool
+	ops          []rawOverride // --set and --set-range, in argument order
 }
 
 // parseFlags consumes the fake's own flags from the front of args, then resolves
@@ -151,9 +162,20 @@ func parseFlags(args []string) (config, []string, error) {
 	for len(args) > 0 {
 		name, value, hasValue := strings.Cut(args[0], "=")
 
+		if name == "--fluctuate" {
+			rest, err := applyFluctuateFlag(&raw, value, hasValue, args[1:])
+			if err != nil {
+				return config{}, nil, err
+			}
+
+			args = rest
+
+			continue
+		}
+
 		switch name {
 		case "--capture", "--state", "--stderr-msg", "--fail-arg", "--exit", "--delay",
-			"--set", "--set-range", "--config", "--seed":
+			"--set", "--set-range", "--config", "--seed", "--gpus":
 		default:
 			return resolve(raw, args)
 		}
@@ -189,33 +211,12 @@ func applyFlag(raw *rawFlags, name, value string) error {
 		raw.stderrMsg, raw.stderrSet = value, true
 	case "--fail-arg":
 		raw.failArg, raw.failSet = value, true
-	case "--exit":
-		code, err := strconv.Atoi(value)
-		if err != nil {
-			return fmt.Errorf("invalid --exit value %q: %w", value, err)
-		}
-
-		raw.exitCode, raw.exitSet = code, true
-	case "--delay":
-		d, err := time.ParseDuration(value)
-		if err != nil {
-			return fmt.Errorf("invalid --delay value %q: %w", value, err)
-		}
-
-		raw.delay, raw.delaySet = d, true
 	case "--config":
 		if value == "" {
 			return errors.New("--config needs a path")
 		}
 
 		raw.configPath = value
-	case "--seed":
-		s, err := strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid --seed value %q: %w", value, err)
-		}
-
-		raw.seed, raw.seedSet = s, true
 	case "--set":
 		op, err := parseSetFlag(value)
 		if err != nil {
@@ -230,9 +231,79 @@ func applyFlag(raw *rawFlags, name, value string) error {
 		}
 
 		raw.ops = append(raw.ops, op)
+	default:
+		return applyNumericFlag(raw, name, value)
 	}
 
 	return nil
+}
+
+// applyNumericFlag records the flags carrying a parsed number.
+func applyNumericFlag(raw *rawFlags, name, value string) error {
+	switch name {
+	case "--exit":
+		code, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("invalid --exit value %q: %w", value, err)
+		}
+
+		raw.exitCode, raw.exitSet = code, true
+	case "--delay":
+		duration, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("invalid --delay value %q: %w", value, err)
+		}
+
+		raw.delay, raw.delaySet = duration, true
+	case "--seed":
+		seed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid --seed value %q: %w", value, err)
+		}
+
+		raw.seed, raw.seedSet = seed, true
+	case "--gpus":
+		count, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("invalid --gpus value %q: %w", value, err)
+		}
+
+		if err := validateGPUCount(count); err != nil {
+			return err
+		}
+
+		raw.gpus, raw.gpusSet = count, true
+	}
+
+	return nil
+}
+
+// applyFluctuateFlag parses the one boolean flag. The generic parser always
+// consumes a following value, which here would swallow the first nvidia-smi
+// argument, so a bare --fluctuate means true, and a following bare true/false
+// (any strconv.ParseBool spelling) is consumed only when it is one.
+func applyFluctuateFlag(raw *rawFlags, value string, hasValue bool, rest []string) ([]string, error) {
+	if !hasValue && len(rest) > 0 {
+		if _, err := strconv.ParseBool(rest[0]); err == nil {
+			value, hasValue = rest[0], true
+			rest = rest[1:]
+		}
+	}
+
+	enabled := true
+
+	if hasValue {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --fluctuate value %q: %w", value, err)
+		}
+
+		enabled = parsed
+	}
+
+	raw.fluctuate, raw.fluctuateSet = enabled, true
+
+	return rest, nil
 }
 
 // resolve merges the parsed flags with an optional --config base into the final
@@ -257,6 +328,17 @@ func resolve(raw rawFlags, rest []string) (config, []string, error) {
 		return config{}, nil, err
 	}
 
+	if err := mergeValueSettings(&cfg, raw, fc); err != nil {
+		return config{}, nil, err
+	}
+
+	return cfg, rest, nil
+}
+
+// mergeValueSettings resolves everything that shapes the served values: the
+// seed, the simulated GPUs, the override generators and the fluctuation.
+// Flags win over the config per setting, as everywhere else.
+func mergeValueSettings(cfg *config, raw rawFlags, fc *fileConfig) error {
 	seed := time.Now().UnixNano()
 
 	switch {
@@ -266,14 +348,29 @@ func resolve(raw rawFlags, rest []string) (config, []string, error) {
 		seed = *fc.Seed
 	}
 
-	overrides, err := buildOverrides(fc, raw.ops, seed)
+	gpus, gpuEntries, err := resolveGPUs(raw, fc)
 	if err != nil {
-		return config{}, nil, err
+		return err
 	}
 
+	overrides, err := buildOverrides(fc, raw.ops, gpuEntries, len(gpus), seed)
+	if err != nil {
+		return err
+	}
+
+	cfg.gpus = gpus
 	cfg.overrides = overrides
 
-	return cfg, rest, nil
+	fluctuate := raw.fluctuate
+	if !raw.fluctuateSet {
+		fluctuate = fc != nil && fc.Fluctuate
+	}
+
+	if fluctuate {
+		cfg.fluct = newFluctuator(seed)
+	}
+
+	return nil
 }
 
 // mergeBaseSettings applies capture and state, preferring a flag over the
@@ -392,45 +489,74 @@ func failMatching(cfg config, args []string, stderr io.Writer) bool {
 // answer serves the nvidia-smi invocation in args from the capture: the two
 // CSV queries by column projection, anything else by verbatim replay of the
 // section recorded for the same command line.
-func answer(
-	capt *capture.Capture,
-	state string,
-	overrides map[string]valueGen,
-	args []string,
-	stdout, stderr io.Writer,
-) int {
+func answer(capt *capture.Capture, cfg *config, args []string, stdout, stderr io.Writer) int {
 	if request, sectionLabel, isQuery := queryRequest(args); isQuery {
-		section := capt.Find(state, sectionLabel)
-		if section == nil {
-			fmt.Fprintf(stderr, "fake-nvidia-smi: capture has no %q section for state %q\n",
-				sectionLabel, state)
-
-			return usageExitCode
-		}
-
-		output, err := project(section, request, overrides)
-		if err != nil {
-			// the real nvidia-smi reports a rejected query on stdout
-			fmt.Fprintln(stdout, err)
-
-			return errorExitCode
-		}
-
-		fmt.Fprintln(stdout, output)
-
-		return 0
+		return answerQuery(capt, cfg, request, sectionLabel, stdout, stderr)
 	}
 
-	if section := findVerbatim(capt, state, args); section != nil {
+	if section := findVerbatim(capt, cfg.state, args); section != nil {
 		fmt.Fprintln(stdout, section.Body)
 
 		return 0
 	}
 
 	fmt.Fprintf(stderr, "fake-nvidia-smi: capture has no section recorded for %q in state %q\n",
-		strings.Join(args, " "), state)
+		strings.Join(args, " "), cfg.state)
 
 	return usageExitCode
+}
+
+// answerQuery serves one of the two CSV queries by projecting the recorded
+// section through the transform pipeline.
+func answerQuery(capt *capture.Capture, cfg *config, request, sectionLabel string, stdout, stderr io.Writer) int {
+	if len(cfg.gpus) > 0 {
+		if err := validateReplicableCapture(capt, cfg.state); err != nil {
+			fmt.Fprintf(stderr, "fake-nvidia-smi: %v\n", err)
+
+			return usageExitCode
+		}
+	}
+
+	section := capt.Find(cfg.state, sectionLabel)
+	if section == nil {
+		fmt.Fprintf(stderr, "fake-nvidia-smi: capture has no %q section for state %q\n",
+			sectionLabel, cfg.state)
+
+		return usageExitCode
+	}
+
+	output, err := project(section, request, cfg)
+	if err != nil {
+		// the real nvidia-smi reports a rejected query on stdout
+		fmt.Fprintln(stdout, err)
+
+		return errorExitCode
+	}
+
+	fmt.Fprintln(stdout, output)
+
+	return 0
+}
+
+// validateReplicableCapture ensures the selected state's query-gpu recording
+// has exactly one data row: gpus replicates that row per simulated GPU, and a
+// capture that already records several GPUs has no defined replication
+// semantics. The check also guards a compute-apps query, whose rows join the
+// GPUs by identity.
+func validateReplicableCapture(capt *capture.Capture, state string) error {
+	section := capt.Find(state, "query-gpu (csv")
+	if section == nil {
+		return fmt.Errorf("gpus needs a query-gpu section for state %q to replicate", state)
+	}
+
+	// the parsed body is trimmed of surrounding blank lines, so its newline
+	// count is exactly the number of data rows after the header
+	if rows := strings.Count(section.Body, "\n"); rows != 1 {
+		return fmt.Errorf("gpus needs a single-GPU capture, but the query-gpu section for state %q has %d data rows",
+			state, rows)
+	}
+
+	return nil
 }
 
 // queryRequest recognizes the two CSV query invocations. It returns the

--- a/internal/fakesmi/fluctuate.go
+++ b/internal/fakesmi/fluctuate.go
@@ -1,0 +1,211 @@
+package fakesmi
+
+import (
+	"math"
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// fluctuateRelativeSpread is the jitter half-width as a fraction of the
+// captured value, and fluctuateMinSpread its absolute floor so a captured
+// zero still moves a little.
+const (
+	fluctuateRelativeSpread = 0.10
+	fluctuateMinSpread      = 1.0
+)
+
+// fluctuateFields is the whitelist of query fields that naturally move on a
+// live GPU: utilization, temperature, power draw, current clocks, fan speed
+// and used memory. Everything else — identity, capacities, limits, modes,
+// enum states, counters — stays as recorded.
+var fluctuateFields = map[string]struct{}{
+	"utilization.gpu": {}, "utilization.memory": {}, "utilization.encoder": {},
+	"utilization.decoder": {}, "utilization.jpeg": {}, "utilization.ofa": {},
+	"temperature.gpu": {}, "temperature.memory": {},
+	"fan.speed":  {},
+	"power.draw": {}, "power.draw.average": {}, "power.draw.instant": {},
+	"module.power.draw.average": {}, "module.power.draw.instant": {},
+	"clocks.current.graphics": {}, "clocks.current.sm": {},
+	"clocks.current.memory": {}, "clocks.current.video": {},
+	"memory.used": {}, "used_gpu_memory": {},
+}
+
+// fluctuator jitters whitelisted cells around their captured values. It is
+// deliberately not a valueGen: a generator cannot see the captured baseline,
+// which is the whole premise here. Each field draws from its own source
+// seeded from (seed, field), so field order never affects reproducibility,
+// and sequential draws per row keep replicated GPU rows independent.
+type fluctuator struct {
+	seed    int64
+	sources map[string]*rand.Rand
+}
+
+func newFluctuator(seed int64) *fluctuator {
+	return &fluctuator{seed: seed, sources: map[string]*rand.Rand{}}
+}
+
+func (f *fluctuator) source(field string) *rand.Rand {
+	src, ok := f.sources[field]
+	if !ok {
+		//nolint:gosec // not cryptographic: deterministic fake test data
+		src = rand.New(rand.NewSource(fieldSeed(f.seed, "fluctuate:"+field)))
+		f.sources[field] = src
+	}
+
+	return src
+}
+
+// apply jitters the whitelisted cells of one data row. A field with an
+// explicit override belongs to the override and is skipped, and a cell that
+// does not carry a plain number (e.g. "[N/A]", "[Not Supported]") is never
+// touched, so an unsupported field never gains a value.
+func (f *fluctuator) apply(cells, recorded []string, columnOf map[string]int, overridden map[string]valueGen) {
+	for column, field := range recorded {
+		if _, moves := fluctuateFields[field]; !moves {
+			continue
+		}
+
+		if _, isOverridden := overridden[field]; isOverridden {
+			continue
+		}
+
+		cell, ok := parseNumericCell(cells[column])
+		if !ok {
+			continue
+		}
+
+		cells[column] = cell.format(f.jitter(field, cell))
+	}
+
+	f.reconcileMemory(cells, columnOf, overridden)
+}
+
+// jitter draws a fresh value around the captured one, clamped to stay
+// plausible: never negative, and never above 100 for a percentage.
+func (f *fluctuator) jitter(field string, cell numericCell) float64 {
+	spread := math.Max(fluctuateRelativeSpread*math.Abs(cell.value), fluctuateMinSpread)
+
+	value := cell.value + (2*f.source(field).Float64()-1)*spread
+	value = math.Max(value, 0)
+
+	if cell.isPercent() {
+		value = math.Min(value, 100)
+	}
+
+	return value
+}
+
+// reconcileMemory keeps the memory columns physically consistent after
+// jittering: used is capped to what the card can actually allocate (total
+// minus reserved), and free is recomputed from the jittered used, so
+// used/free/total never contradict each other. An explicitly overridden used
+// or free is the user's business and is left alone, and a row without the
+// involved columns (a compute-apps row, a minimal capture) is untouched.
+func (f *fluctuator) reconcileMemory(cells []string, columnOf map[string]int, overridden map[string]valueGen) {
+	if _, isOverridden := overridden["memory.used"]; isOverridden {
+		return
+	}
+
+	used, usedColumn, usedOK := numericCellAt(cells, columnOf, "memory.used")
+	total, _, totalOK := numericCellAt(cells, columnOf, "memory.total")
+
+	if !usedOK || !totalOK {
+		return
+	}
+
+	reserved := 0.0
+	if cell, _, reservedOK := numericCellAt(cells, columnOf, "memory.reserved"); reservedOK {
+		reserved = cell.value
+	}
+
+	capacity := math.Max(total.value-reserved, 0)
+
+	usedValue := math.Min(used.value, capacity)
+	if usedValue != used.value {
+		cells[usedColumn] = used.format(usedValue)
+	}
+
+	if _, freeOverridden := overridden["memory.free"]; freeOverridden {
+		return
+	}
+
+	free, freeColumn, freeOK := numericCellAt(cells, columnOf, "memory.free")
+	if !freeOK {
+		return
+	}
+
+	cells[freeColumn] = free.format(math.Max(capacity-usedValue, 0))
+}
+
+// numericCellAt parses the named field's cell when the section records the
+// field and the cell carries a plain number.
+func numericCellAt(cells []string, columnOf map[string]int, field string) (numericCell, int, bool) {
+	column, has := columnOf[field]
+	if !has {
+		return numericCell{}, 0, false
+	}
+
+	cell, ok := parseNumericCell(cells[column])
+
+	return cell, column, ok
+}
+
+// numericCell is a parsed CSV cell of the shape "<number>[ <unit>]", e.g.
+// "38 %", "39.32 W", "214 MiB" or a bare "40".
+type numericCell struct {
+	value    float64
+	decimals int
+	// suffix keeps everything after the number verbatim, leading space
+	// included; empty for a bare number.
+	suffix string
+}
+
+// numericPrefix matches the plain decimal number a cell may start with. It is
+// deliberately narrower than strconv.ParseFloat: no exponent form, no
+// hex, no inf/nan, mirroring what the exporter's own number extractor
+// tolerates.
+var numericPrefix = regexp.MustCompile(`^[+-]?\d+(\.\d+)?`)
+
+// parseNumericCell parses a cell into its longest numeric prefix and unit
+// tail ("38 %", "39.32W", a bare "40"). Anything else — "[N/A]", "N/A",
+// "[Not Supported]", an empty cell — does not parse and is left alone by the
+// caller. A tail containing digits is also refused: it means the cell is not
+// the "<number><unit>" shape (an exponent form the exporter rejects, a
+// timestamp, a second number), and rewriting it could turn a cell the
+// exporter drops into one it accepts.
+func parseNumericCell(cell string) (numericCell, bool) {
+	token := numericPrefix.FindString(cell)
+	if token == "" {
+		return numericCell{}, false
+	}
+
+	suffix := cell[len(token):]
+	if strings.ContainsAny(suffix, "0123456789") {
+		return numericCell{}, false
+	}
+
+	value, err := strconv.ParseFloat(token, 64)
+	if err != nil {
+		return numericCell{}, false
+	}
+
+	decimals := 0
+	if _, fraction, hasFraction := strings.Cut(token, "."); hasFraction {
+		decimals = len(fraction)
+	}
+
+	return numericCell{value: value, decimals: decimals, suffix: suffix}, true
+}
+
+// format renders a new value in the captured cell's shape: same decimal
+// places, same unit tail. Fixed-point only, which the exporter's number
+// extractor requires.
+func (c numericCell) format(value float64) string {
+	return strconv.FormatFloat(value, 'f', c.decimals, 64) + c.suffix
+}
+
+func (c numericCell) isPercent() bool {
+	return strings.TrimSpace(c.suffix) == "%"
+}

--- a/internal/fakesmi/fluctuate_test.go
+++ b/internal/fakesmi/fluctuate_test.go
@@ -1,0 +1,285 @@
+package fakesmi_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rtx2080Capture = "linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05"
+
+// numericPart splits a cell like "39.32 W" into its number and unit suffix.
+func numericPart(t *testing.T, cell string) (float64, string) {
+	t.Helper()
+
+	token, suffix, _ := strings.Cut(cell, " ")
+
+	v, err := strconv.ParseFloat(token, 64)
+	require.NoError(t, err, "cell %q", cell)
+
+	return v, suffix
+}
+
+// TestFluctuateMovesAndReproduces proves a whitelisted field moves between
+// runs with different seeds and reproduces with the same seed.
+func TestFluctuateMovesAndReproduces(t *testing.T) {
+	t.Parallel()
+
+	one := dataRows(t, "temperature.gpu", "--capture", rtx2080Capture, "--fluctuate", "--seed", "1")
+	two := dataRows(t, "temperature.gpu", "--capture", rtx2080Capture, "--fluctuate", "--seed", "2")
+	oneAgain := dataRows(t, "temperature.gpu", "--capture", rtx2080Capture, "--fluctuate", "--seed", "1")
+
+	assert.Equal(t, one, oneAgain, "same seed must reproduce")
+	assert.NotEqual(t, one, two, "different seeds must differ")
+}
+
+// TestFluctuateBoundsAndShape proves jittered values stay within the ±10%
+// (min ±1) band around the captured value, keep the unit suffix, and keep the
+// captured decimal shape.
+func TestFluctuateBoundsAndShape(t *testing.T) {
+	t.Parallel()
+
+	// captured: power.draw "39.32 W", temperature.gpu "40", fan.speed "38 %"
+	for seed := range 20 {
+		args := []string{"--capture", rtx2080Capture, "--fluctuate", "--seed", strconv.Itoa(seed)}
+
+		power, unit := numericPart(t, dataRows(t, "power.draw", args...)[0])
+		assert.Equal(t, "W", unit)
+		assert.InDelta(t, 39.32, power, 3.932+0.001)
+		assert.GreaterOrEqual(t, power, 0.0)
+
+		temp, _ := numericPart(t, dataRows(t, "temperature.gpu", args...)[0])
+		assert.InDelta(t, 40, temp, 4.0+0.5) // integer shape rounds the ±4 band
+
+		fan, unit := numericPart(t, dataRows(t, "fan.speed", args...)[0])
+		assert.Equal(t, "%", unit)
+		assert.InDelta(t, 38, fan, 3.8+0.5)
+	}
+}
+
+// TestFluctuatePercentClamp uses the L40S idle capture, which genuinely
+// records 100% GPU utilization, to prove a percentage never exceeds 100.
+func TestFluctuatePercentClamp(t *testing.T) {
+	t.Parallel()
+
+	for seed := range 30 {
+		cell := dataRows(t, "utilization.gpu",
+			"--capture", "linux-x86_64__nvidia-l40s__595.80", "--fluctuate", "--seed", strconv.Itoa(seed))[0]
+		v, unit := numericPart(t, cell)
+		assert.Equal(t, "%", unit)
+		assert.LessOrEqual(t, v, 100.0, "cell %q", cell)
+		assert.GreaterOrEqual(t, v, 90.0-0.5, "cell %q", cell)
+	}
+}
+
+// TestFluctuateLeavesUnavailableAndFixedFields proves an unavailable cell
+// never gains a number (H200-MIG reports fan speed and utilization as [N/A])
+// and a non-whitelisted field stays byte-identical.
+func TestFluctuateLeavesUnavailableAndFixedFields(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"--capture", "linux-x86_64__nvidia-h200-mig__590.48.01", "--fluctuate", "--seed", "7"}
+
+	assert.Equal(t, "[N/A]", dataRows(t, "fan.speed", args...)[0])
+	assert.Equal(t, "[N/A]", dataRows(t, "utilization.gpu", args...)[0])
+
+	// capacities, enum states and identity never move
+	assert.Equal(t, "143771 MiB", dataRows(t, "memory.total", args...)[0])
+	assert.Equal(t, "Enabled", dataRows(t, "mig.mode.current", args...)[0])
+	assert.Equal(t, "GPU-00000000-0000-0000-0000-000000000000", dataRows(t, "uuid", args...)[0])
+}
+
+// TestFluctuateOverridePrecedence proves an explicit override beats the
+// fluctuation for its field while others keep moving.
+func TestFluctuateOverridePrecedence(t *testing.T) {
+	t.Parallel()
+
+	rows := dataRows(t, "temperature.gpu",
+		"--capture", rtx2080Capture, "--fluctuate", "--set", "temperature.gpu=42", "--seed", "3")
+	assert.Equal(t, "42", rows[0])
+}
+
+// TestFluctuateMemoryConsistency proves the memory columns stay consistent
+// after jittering: used never exceeds total minus reserved, and free is
+// recomputed so the four values add up.
+func TestFluctuateMemoryConsistency(t *testing.T) {
+	t.Parallel()
+
+	for seed := range 20 {
+		code, stdout, stderr := runFake(t, "--capture", h200Capture, "--state", "load",
+			"--fluctuate", "--seed", strconv.Itoa(seed),
+			"--query-gpu=memory.total,memory.reserved,memory.used,memory.free", "--format=csv")
+		require.Equal(t, 0, code, "stderr: %s", stderr)
+
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		require.Len(t, lines, 2)
+
+		cells := strings.Split(lines[1], ", ")
+		require.Len(t, cells, 4)
+
+		total, _ := numericPart(t, cells[0])
+		reserved, _ := numericPart(t, cells[1])
+		used, _ := numericPart(t, cells[2])
+		free, _ := numericPart(t, cells[3])
+
+		assert.LessOrEqual(t, used, total-reserved, "row %q", lines[1])
+		assert.InDelta(t, total-reserved, used+free, 0.001, "row %q", lines[1])
+	}
+}
+
+// TestFluctuateFlagForms covers the boolean flag's spellings: bare form,
+// =BOOL form, separated BOOL form, and the flag switching off a config's
+// fluctuate.
+func TestFluctuateFlagForms(t *testing.T) {
+	t.Parallel()
+
+	baseline := dataRows(t, "temperature.gpu", "--capture", rtx2080Capture)
+
+	// bare form followed directly by the query: must not swallow it
+	moved := dataRows(t, "temperature.gpu", "--capture", rtx2080Capture, "--fluctuate", "--seed", "12")
+	require.Len(t, moved, 1)
+
+	// separated bool value
+	separated := dataRows(t, "temperature.gpu", "--capture", rtx2080Capture, "--fluctuate", "false")
+	assert.Equal(t, baseline, separated)
+
+	// =BOOL form disabling a config's fluctuate: output matches plain replay
+	cfg := writeConfig(t, "capture: "+rtx2080Capture+"\nfluctuate: true\n")
+	disabled := dataRows(t, "temperature.gpu", "--config", cfg, "--fluctuate=false")
+	assert.Equal(t, baseline, disabled)
+
+	// the config alone enables it: power draw carries two decimals, so the
+	// jittered value differs from the captured one
+	assert.NotEqual(t, dataRows(t, "power.draw", "--capture", rtx2080Capture),
+		dataRows(t, "power.draw", "--config", cfg, "--seed", "8"))
+
+	// a non-bool value is rejected
+	code, _, stderr := runFake(t, "--capture", rtx2080Capture, "--fluctuate=nope", "-L")
+	assert.Equal(t, 2, code)
+	assert.NotEmpty(t, stderr)
+}
+
+// TestFluctuateMemoryOverridePrecedence proves the memory reconciliation
+// never runs over an explicitly overridden memory cell, and that it computes
+// against an overridden total.
+func TestFluctuateMemoryOverridePrecedence(t *testing.T) {
+	t.Parallel()
+
+	memoryQuery := func(sets ...string) []string {
+		t.Helper()
+
+		args := make([]string, 0, 7+2*len(sets))
+		args = append(args, "--capture", rtx2080Capture, "--fluctuate", "--seed", "6")
+
+		for _, set := range sets {
+			args = append(args, "--set", set)
+		}
+
+		code, stdout, stderr := runFake(t,
+			append(args, "--query-gpu=memory.total,memory.reserved,memory.used,memory.free", "--format=csv")...)
+		require.Equal(t, 0, code, "stderr: %s", stderr)
+
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		require.Len(t, lines, 2)
+
+		return strings.Split(lines[1], ", ")
+	}
+
+	// an overridden used is served verbatim and free stays as captured,
+	// instead of being recomputed against the override
+	cells := memoryQuery("memory.used=999999")
+	assert.Equal(t, "999999", cells[2])
+	assert.Equal(t, "7571 MiB", cells[3])
+
+	// an overridden free is served verbatim while used still jitters
+	cells = memoryQuery("memory.free=1234")
+	assert.NotEqual(t, "214 MiB", cells[2])
+	assert.Equal(t, "1234", cells[3])
+
+	// an overridden total feeds the recomputation of free
+	cells = memoryQuery("memory.total=100000")
+	used, _ := numericPart(t, cells[2])
+	free, _ := numericPart(t, cells[3])
+	assert.InDelta(t, 100000-408, used+free, 0.001)
+}
+
+// TestFluctuateCellGrammar proves a cell fluctuates when its number is a
+// plain decimal prefix — a unit glued on with no space included, as the
+// exporter itself tolerates — while an exponent-form cell, which the
+// exporter rejects, is never rewritten into something it would accept.
+func TestFluctuateCellGrammar(t *testing.T) {
+	t.Parallel()
+
+	fence := strings.Repeat("#", 80)
+	capture := fence + `
+# idle :: query-gpu (csv, what the exporter parses)
+# $ nvidia-smi --query-gpu=uuid,temperature.gpu,power.draw,fan.speed --format=csv
+` + fence + `
+uuid, temperature.gpu, power.draw, fan.speed
+GPU-1, 40%, 39.32W, 1e3 %
+`
+
+	path := filepath.Join(t.TempDir(), "glued-units.txt")
+	require.NoError(t, os.WriteFile(path, []byte(capture), 0o600))
+
+	code, stdout, stderr := runFake(t, "--capture", path, "--fluctuate", "--seed", "3",
+		"--query-gpu=temperature.gpu,power.draw,fan.speed", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 2)
+
+	cells := strings.Split(lines[1], ", ")
+	require.Len(t, cells, 3)
+
+	temperature, ok := strings.CutSuffix(cells[0], "%")
+	assert.True(t, ok, "glued unit must be preserved verbatim, got %q", cells[0])
+
+	v, err := strconv.ParseFloat(temperature, 64)
+	require.NoError(t, err, "cell %q", cells[0])
+	assert.InDelta(t, 40, v, 4.5)
+	assert.NotEqual(t, "40%", cells[0], "a glued-unit cell must still fluctuate")
+
+	power, ok := strings.CutSuffix(cells[1], "W")
+	assert.True(t, ok, "glued unit must be preserved verbatim, got %q", cells[1])
+
+	_, err = strconv.ParseFloat(power, 64)
+	require.NoError(t, err, "cell %q", cells[1])
+	assert.NotEqual(t, "39.32W", cells[1])
+
+	assert.Equal(t, "1e3 %", cells[2],
+		"an exponent cell the exporter rejects must never become a value it accepts")
+}
+
+// TestFluctuateComputeApps proves per-process used memory moves while pids
+// and names stay fixed.
+func TestFluctuateComputeApps(t *testing.T) {
+	t.Parallel()
+
+	query := []string{"--query-compute-apps=pid,process_name,used_gpu_memory", "--format=csv"}
+	base := []string{"--capture", "linux-x86_64__nvidia-l40s__595.80", "--state", "load"}
+
+	code, plain, stderr := runFake(t, append(base, query...)...)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	code, moved, stderr := runFake(t, append(append(base, "--fluctuate", "--seed", "4"), query...)...)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	plainLines := strings.Split(strings.TrimSpace(plain), "\n")
+	movedLines := strings.Split(strings.TrimSpace(moved), "\n")
+	require.Len(t, movedLines, len(plainLines))
+	require.Greater(t, len(plainLines), 1)
+
+	for i := 1; i < len(plainLines); i++ {
+		plainCells := strings.Split(plainLines[i], ", ")
+		movedCells := strings.Split(movedLines[i], ", ")
+		assert.Equal(t, plainCells[0], movedCells[0], "pid must not move")
+		assert.Equal(t, plainCells[1], movedCells[1], "process name must not move")
+		assert.NotEqual(t, plainCells[2], movedCells[2], "used memory should move")
+	}
+}

--- a/internal/fakesmi/gpus.go
+++ b/internal/fakesmi/gpus.go
@@ -1,0 +1,267 @@
+package fakesmi
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+// maxGPUs bounds the simulated GPU count: the identities derive a PCI bus id
+// per GPU, and the bus byte has 255 usable values.
+const maxGPUs = 255
+
+// reservedIdentityFields are the query fields that carry a GPU's identity.
+// While gpus is active they come exclusively from the gpus entries (or the
+// generator): a shared override would stamp the same uuid on every simulated
+// GPU, and the exporter, which labels all per-GPU metrics by uuid alone,
+// would then emit duplicate label sets and fail the whole scrape.
+var reservedIdentityFields = map[string]struct{}{
+	"uuid": {}, "serial": {}, "index": {}, "count": {},
+	"pci.bus_id": {}, "pci.bus": {},
+	"gpu_uuid": {}, "gpu_serial": {}, "gpu_bus_id": {},
+}
+
+// gpuIdentity is one simulated GPU's resolved identity. An empty serial keeps
+// the captured cell.
+type gpuIdentity struct {
+	uuid   string
+	serial string
+}
+
+// gpusFileConfig is the yaml form of the gpus setting: either a scalar count
+// (identical cards with generated identities, same as --gpus) or a sequence
+// of per-GPU entries.
+type gpusFileConfig struct {
+	count   int
+	entries []gpuFileEntry
+}
+
+// gpuFileEntry is one per-GPU config entry: an optional explicit identity and
+// optional overrides that layer on top of the top-level ones for this GPU
+// only.
+type gpuFileEntry struct {
+	uuid      string
+	serial    string
+	overrides map[string]overrideEntry
+}
+
+// UnmarshalYAML accepts a scalar count or a sequence of per-GPU entries, and
+// rejects anything else.
+func (g *gpusFileConfig) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		count, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return fmt.Errorf("gpus must be a count or a list of GPU entries, got %q", node.Value)
+		}
+
+		g.count = count
+
+		return validateGPUCount(count)
+	}
+
+	if node.Kind != yaml.SequenceNode {
+		return errors.New("gpus must be a count or a list of GPU entries")
+	}
+
+	for _, item := range node.Content {
+		entry, err := decodeGPUEntry(item)
+		if err != nil {
+			return err
+		}
+
+		g.entries = append(g.entries, entry)
+	}
+
+	return validateGPUCount(len(g.entries))
+}
+
+// decodeGPUEntry strictly decodes one per-GPU entry: an unknown key is an
+// error, matching the top-level config's KnownFields behavior.
+func decodeGPUEntry(node *yaml.Node) (gpuFileEntry, error) {
+	if node.Kind != yaml.MappingNode {
+		return gpuFileEntry{}, errors.New("gpus entry must be a mapping with uuid, serial or overrides")
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		if key := node.Content[i].Value; key != "uuid" && key != "serial" && key != "overrides" {
+			return gpuFileEntry{}, fmt.Errorf("unknown gpus entry key %q, want uuid, serial or overrides", key)
+		}
+	}
+
+	var spec struct {
+		UUID      string                   `yaml:"uuid"`
+		Serial    string                   `yaml:"serial"`
+		Overrides map[string]overrideEntry `yaml:"overrides"`
+	}
+
+	if err := node.Decode(&spec); err != nil {
+		return gpuFileEntry{}, fmt.Errorf("failed to decode gpus entry: %w", err)
+	}
+
+	return gpuFileEntry{uuid: spec.UUID, serial: spec.Serial, overrides: spec.Overrides}, nil
+}
+
+// validateGPUCount rejects a count the bus-id scheme cannot represent.
+func validateGPUCount(count int) error {
+	if count < 1 || count > maxGPUs {
+		return fmt.Errorf("gpu count must be between 1 and %d, got %d", maxGPUs, count)
+	}
+
+	return nil
+}
+
+// resolveGPUs merges the --gpus flag with the config's gpus setting into the
+// final identity list. The flag wins entirely: its generated identities
+// replace any per-GPU config entries, including their overrides. A nil result
+// means multi-GPU is off. The returned entries carry the per-GPU overrides
+// for buildOverrides.
+func resolveGPUs(raw rawFlags, fc *fileConfig) ([]gpuIdentity, []gpuFileEntry, error) {
+	var (
+		entries []gpuFileEntry
+		count   int
+	)
+
+	switch {
+	case raw.gpusSet:
+		count = raw.gpus
+	case fc != nil && fc.GPUs != nil:
+		count, entries = fc.GPUs.count, fc.GPUs.entries
+		if count == 0 {
+			count = len(entries)
+		}
+	default:
+		return nil, nil, nil
+	}
+
+	identities, err := buildIdentities(count, entries)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return identities, entries, nil
+}
+
+// buildIdentities resolves each GPU's identity: an explicit uuid/serial from
+// its entry when given, a generated stable uuid otherwise. Explicit uuids
+// must stay distinct after the exporter's own normalization, or all series
+// would collapse into one.
+func buildIdentities(count int, entries []gpuFileEntry) ([]gpuIdentity, error) {
+	identities := make([]gpuIdentity, count)
+	seen := make(map[string]int, count)
+
+	for index := range identities {
+		id := gpuIdentity{uuid: generatedUUID(index)}
+
+		if index < len(entries) {
+			if entries[index].uuid != "" {
+				id.uuid = entries[index].uuid
+			}
+
+			id.serial = entries[index].serial
+		}
+
+		if err := validateSetValue("uuid", id.uuid); err != nil {
+			return nil, err
+		}
+
+		if err := validateSetValue("serial", id.serial); err != nil {
+			return nil, err
+		}
+
+		normalized := nvidiasmi.NormalizeUUID(id.uuid)
+		if previous, duplicate := seen[normalized]; duplicate {
+			return nil, fmt.Errorf("gpus %d and %d share uuid %q", previous, index, id.uuid)
+		}
+
+		seen[normalized] = index
+		identities[index] = id
+	}
+
+	return identities, nil
+}
+
+// generatedUUID derives GPU i's stable uuid from a fixed namespace plus the
+// index — never from the run seed. Metric values are intentionally
+// non-reproducible across runs, but the identity must be reproducible, or
+// Prometheus would see a brand new series on every scrape. The RFC 4122
+// version/variant bits keep the shape valid for tooling that checks it.
+func generatedUUID(index int) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "nvidia_gpu_exporter/fake-nvidia-smi/gpu/%d", index))
+	sum[6] = sum[6]&0x0f | 0x40
+	sum[8] = sum[8]&0x3f | 0x80
+
+	return fmt.Sprintf("GPU-%x-%x-%x-%x-%x", sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16])
+}
+
+// rewriteIdentity stamps GPU index's identity onto one data row. Only the
+// columns the capture actually records are touched, so a minimal hand-written
+// capture keeps working; both the query-gpu field names and the compute-apps
+// gpu_* spellings are covered, and a section only carries one of the two
+// sets.
+func rewriteIdentity(cells []string, columnOf map[string]int, id gpuIdentity, index, total int) {
+	set := func(field, value string) {
+		if column, ok := columnOf[field]; ok {
+			cells[column] = value
+		}
+	}
+
+	set("uuid", id.uuid)
+	set("gpu_uuid", id.uuid)
+
+	if id.serial != "" {
+		set("serial", id.serial)
+		set("gpu_serial", id.serial)
+	}
+
+	set("index", strconv.Itoa(index))
+	set("count", strconv.Itoa(total))
+	set("pci.bus", fmt.Sprintf("0x%02X", index+1))
+
+	for _, field := range []string{"pci.bus_id", "gpu_bus_id"} {
+		if column, ok := columnOf[field]; ok {
+			cells[column] = rewriteBusID(cells[column], index+1)
+		}
+	}
+}
+
+// rewriteBusID replaces the bus byte of a captured PCI bus id (e.g.
+// "00000000:0C:00.0"), keeping the captured domain, device and function so
+// the id stays in the card's recorded shape; an unrecognized shape is
+// replaced with a canonical id wholesale. Uppercase hex matches the corpus.
+func rewriteBusID(captured string, bus int) string {
+	parts := strings.Split(captured, ":")
+	if len(parts) != 3 {
+		return fmt.Sprintf("00000000:%02X:00.0", bus)
+	}
+
+	parts[1] = fmt.Sprintf("%02X", bus)
+
+	return strings.Join(parts, ":")
+}
+
+// rejectIdentityOverrides refuses any override that targets an identity field
+// while gpus is active, from any layer (flags, top-level config, per-GPU
+// entries). Without gpus, identity fields stay overridable as before.
+func rejectIdentityOverrides(ops []rawOverride, entries []gpuFileEntry) error {
+	for _, op := range ops {
+		if _, reserved := reservedIdentityFields[op.field]; reserved {
+			return fmt.Errorf("field %q is a per-GPU identity and cannot be overridden while gpus is active", op.field)
+		}
+	}
+
+	for _, entry := range entries {
+		for field := range entry.overrides {
+			if _, reserved := reservedIdentityFields[field]; reserved {
+				return fmt.Errorf("field %q is a per-GPU identity and cannot be overridden while gpus is active", field)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/fakesmi/gpus_test.go
+++ b/internal/fakesmi/gpus_test.go
@@ -1,0 +1,356 @@
+package fakesmi_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// queryRows runs a query-gpu invocation and returns the data rows split into
+// cells.
+func queryRows(t *testing.T, fields string, args ...string) [][]string {
+	t.Helper()
+
+	full := append(append([]string{}, args...), "--query-gpu="+fields, "--format=csv")
+	code, stdout, stderr := runFake(t, full...)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Greater(t, len(lines), 1)
+
+	rows := make([][]string, 0, len(lines)-1)
+	for _, line := range lines[1:] {
+		rows = append(rows, strings.Split(line, ", "))
+	}
+
+	return rows
+}
+
+// TestGPUsReplication proves --gpus N replicates the captured GPU row with
+// distinct, stable identities: uuid, index, count, and PCI addressing.
+func TestGPUsReplication(t *testing.T) {
+	t.Parallel()
+
+	rows := queryRows(t, "uuid,index,count,pci.bus_id,pci.bus,name",
+		"--capture", rtx2080Capture, "--gpus", "3")
+	require.Len(t, rows, 3)
+
+	uuids := map[string]bool{}
+
+	for index, row := range rows {
+		assert.True(t, strings.HasPrefix(row[0], "GPU-"), "uuid %q", row[0])
+		assert.NotEqual(t, "GPU-00000000-0000-0000-0000-000000000000", row[0], "masked uuid must be replaced")
+		uuids[row[0]] = true
+
+		assert.Equal(t, strconv.Itoa(index), row[1], "index")
+		assert.Equal(t, "3", row[2], "count")
+		assert.Equal(t, "00000000:0"+strconv.Itoa(index+1)+":00.0", row[3], "pci.bus_id")
+		assert.Equal(t, "0x0"+strconv.Itoa(index+1), row[4], "pci.bus")
+		assert.Contains(t, row[5], "RTX 2080 SUPER", "name must replicate as captured")
+	}
+
+	assert.Len(t, uuids, 3, "uuids must be distinct")
+
+	// identities must be stable across runs (and independent of the seed)
+	again := queryRows(t, "uuid,index,count,pci.bus_id,pci.bus,name",
+		"--capture", rtx2080Capture, "--gpus", "3", "--seed", "77")
+	assert.Equal(t, rows, again)
+}
+
+// TestGPUsGeneratedUUIDsGolden pins the generated uuids to their exact
+// values. They are an external contract: users' Prometheus series are keyed
+// by them, so an accidental change to the derivation namespace would churn
+// every series on an upgrade. A failure here means the derivation changed —
+// that is a breaking change, not a test to update casually.
+func TestGPUsGeneratedUUIDsGolden(t *testing.T) {
+	t.Parallel()
+
+	rows := queryRows(t, "uuid", "--capture", rtx2080Capture, "--gpus", "2")
+	require.Len(t, rows, 2)
+
+	assert.Equal(t, "GPU-1c67088e-9ecb-4564-bb97-6151ecc2ef64", rows[0][0])
+	assert.Equal(t, "GPU-ef427e4f-1970-42f2-ab0c-ecf0e56a33b9", rows[1][0])
+
+	// RFC 4122 shape: version nibble 4, variant bits 10
+	for _, row := range rows {
+		parts := strings.Split(strings.TrimPrefix(row[0], "GPU-"), "-")
+		require.Len(t, parts, 5)
+		assert.Equal(t, byte('4'), parts[2][0], "version nibble in %q", row[0])
+		assert.Contains(t, "89ab", string(parts[3][0]), "variant nibble in %q", row[0])
+	}
+}
+
+// TestGPUsBusIDHex proves the bus byte renders as uppercase two-digit hex
+// once the count passes 9.
+func TestGPUsBusIDHex(t *testing.T) {
+	t.Parallel()
+
+	rows := queryRows(t, "pci.bus_id,pci.bus", "--capture", rtx2080Capture, "--gpus", "10")
+	require.Len(t, rows, 10)
+	assert.Equal(t, "00000000:0A:00.0", rows[9][0])
+	assert.Equal(t, "0x0A", rows[9][1])
+}
+
+// TestGPUsComputeApps proves the per-process rows are replicated once per
+// GPU with the owning GPU's identity stamped on.
+func TestGPUsComputeApps(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"--capture", "linux-x86_64__nvidia-l40s__595.80", "--state", "load", "--gpus", "2"}
+
+	gpuRows := queryRows(t, "uuid", args...)
+	require.Len(t, gpuRows, 2)
+
+	code, plain, stderr := runFake(t, "--capture", "linux-x86_64__nvidia-l40s__595.80", "--state", "load",
+		"--query-compute-apps=gpu_uuid,gpu_bus_id,pid,process_name", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	processes := len(strings.Split(strings.TrimSpace(plain), "\n")) - 1
+	require.Positive(t, processes)
+
+	code, stdout, stderr := runFake(t,
+		append(args, "--query-compute-apps=gpu_uuid,gpu_bus_id,pid,process_name", "--format=csv")...)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 1+2*processes, "each process must appear once per GPU")
+
+	for i, line := range lines[1:] {
+		cells := strings.Split(line, ", ")
+		gpu := i / processes
+		assert.Equal(t, gpuRows[gpu][0], cells[0], "gpu_uuid must match the owning GPU")
+		assert.Equal(t, "00000000:0"+strconv.Itoa(gpu+1)+":00.0", cells[1], "gpu_bus_id")
+	}
+}
+
+// TestGPUsComputeAppsSerial proves an explicit per-GPU serial reaches the
+// compute-apps rows too.
+func TestGPUsComputeAppsSerial(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, `
+capture: linux-x86_64__nvidia-l40s__595.80
+state: load
+gpus:
+  - serial: "1111"
+  - serial: "2222"
+`)
+
+	code, stdout, stderr := runFake(t, "--config", cfg,
+		"--query-compute-apps=gpu_serial,pid", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Greater(t, len(lines), 2)
+
+	processes := (len(lines) - 1) / 2
+	for i, line := range lines[1:] {
+		want := "1111"
+		if i/processes == 1 {
+			want = "2222"
+		}
+
+		assert.Equal(t, want, strings.Split(line, ", ")[0], "row %q", line)
+	}
+}
+
+// TestGPUsHeaderOnlyComputeApps proves a capture state with no processes
+// stays header-only under --gpus.
+func TestGPUsHeaderOnlyComputeApps(t *testing.T) {
+	t.Parallel()
+
+	code, stdout, stderr := runFake(t, "--capture", rtx2080Capture, "--gpus", "4",
+		"--query-compute-apps=gpu_uuid,pid,process_name,used_gpu_memory", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	assert.Len(t, strings.Split(strings.TrimSpace(stdout), "\n"), 1)
+}
+
+// TestGPUsConfigEntries proves per-GPU config entries: explicit identity
+// lands verbatim, per-GPU overrides hit only their GPU, top-level overrides
+// hit every GPU, and an omitted uuid falls back to the generated one.
+func TestGPUsConfigEntries(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, `
+capture: `+rtx2080Capture+`
+overrides:
+  compute_mode: Prohibited
+gpus:
+  - uuid: GPU-1937b558-347d-0f30-105b-893b98985668
+    serial: "1320621059033"
+    overrides:
+      temperature.gpu: {min: 55, max: 80}
+  - {}
+`)
+
+	rows := queryRows(t, "uuid,serial,temperature.gpu,compute_mode", "--config", cfg, "--seed", "9")
+	require.Len(t, rows, 2)
+
+	assert.Equal(t, "GPU-1937b558-347d-0f30-105b-893b98985668", rows[0][0])
+	assert.Equal(t, "1320621059033", rows[0][1])
+
+	hot, err := strconv.ParseFloat(rows[0][2], 64)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, hot, 55.0)
+	assert.LessOrEqual(t, hot, 80.0)
+
+	// the second GPU: generated uuid, captured serial, captured temperature
+	assert.True(t, strings.HasPrefix(rows[1][0], "GPU-"))
+	assert.NotEqual(t, rows[0][0], rows[1][0])
+	assert.Equal(t, "[N/A]", rows[1][1], "omitted serial keeps the captured cell")
+	assert.Equal(t, "40", rows[1][2], "no per-GPU override, no fluctuate: captured value")
+
+	// the top-level override applies to both
+	assert.Equal(t, "Prohibited", rows[0][3])
+	assert.Equal(t, "Prohibited", rows[1][3])
+}
+
+// TestGPUsCountShorthand proves config `gpus: N` equals --gpus N, and the
+// flag wins over the config's entries.
+func TestGPUsCountShorthand(t *testing.T) {
+	t.Parallel()
+
+	scalar := writeConfig(t, "capture: "+rtx2080Capture+"\ngpus: 2\n")
+	viaConfig := queryRows(t, "uuid,index,count", "--config", scalar)
+
+	viaFlag := queryRows(t, "uuid,index,count", "--capture", rtx2080Capture, "--gpus", "2")
+	assert.Equal(t, viaFlag, viaConfig)
+
+	// the flag replaces the config's entries wholesale, explicit uuid included
+	entries := writeConfig(t, "capture: "+rtx2080Capture+
+		"\ngpus:\n  - uuid: GPU-1937b558-347d-0f30-105b-893b98985668\n")
+	overridden := queryRows(t, "uuid", "--gpus", "1", "--config", entries)
+	require.Len(t, overridden, 1)
+	assert.NotEqual(t, "GPU-1937b558-347d-0f30-105b-893b98985668", overridden[0][0])
+}
+
+// TestGPUsIdentityOverridesRejected proves overrides on identity fields are
+// rejected while gpus is active (they would collapse the series), from every
+// layer, while staying allowed without gpus.
+func TestGPUsIdentityOverridesRejected(t *testing.T) {
+	t.Parallel()
+
+	// flag override
+	code, _, stderr := runFake(t, "--capture", rtx2080Capture, "--gpus", "2",
+		"--set", "uuid=GPU-x", "--query-gpu=uuid", "--format=csv")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "identity")
+
+	// top-level config override
+	top := writeConfig(t, "capture: "+rtx2080Capture+"\ngpus: 2\noverrides:\n  pci.bus_id: mybus\n")
+	code, _, stderr = runFake(t, "--config", top, "--query-gpu=uuid", "--format=csv")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "identity")
+
+	// per-GPU override
+	per := writeConfig(t, "capture: "+rtx2080Capture+"\ngpus:\n  - overrides:\n      index: {value: 5}\n")
+	code, _, stderr = runFake(t, "--config", per, "--query-gpu=uuid", "--format=csv")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "identity")
+
+	// without gpus, identity fields stay overridable
+	assert.Equal(t, "GPU-x", dataRows(t, "uuid", "--capture", rtx2080Capture, "--set", "uuid=GPU-x")[0])
+}
+
+// TestGPUsValidation covers count bounds, duplicate uuids, and malformed
+// entries.
+func TestGPUsValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, args := range [][]string{
+		{"--gpus", "0"},
+		{"--gpus", "-1"},
+		{"--gpus", "256"},
+		{"--gpus", "nope"},
+	} {
+		code, _, stderr := runFake(t, append(append([]string{"--capture", rtx2080Capture}, args...),
+			"--query-gpu=uuid", "--format=csv")...)
+		assert.Equalf(t, 2, code, "args %v should be rejected", args)
+		assert.NotEmpty(t, stderr)
+	}
+
+	for _, body := range []string{
+		"gpus: 0\n",
+		"gpus: 256\n",
+		"gpus: nope\n",
+		"gpus: {uuid: x}\n",
+		"gpus:\n  - uid: typo\n",
+		// same uuid modulo case and prefix: duplicates after normalization
+		"gpus:\n  - uuid: GPU-1937b558-347d-0f30-105b-893b98985668\n" +
+			"  - uuid: 1937B558-347d-0f30-105b-893b98985668\n",
+	} {
+		cfg := writeConfig(t, "capture: "+rtx2080Capture+"\n"+body)
+		code, _, stderr := runFake(t, "--config", cfg, "--query-gpu=uuid", "--format=csv")
+		assert.Equalf(t, 2, code, "config %q should be rejected", body)
+		assert.NotEmpty(t, stderr)
+	}
+}
+
+// TestGPUsMultiRowCaptureRejected proves gpus refuses a capture whose
+// query-gpu section already records several GPUs, for the compute-apps query
+// too.
+func TestGPUsMultiRowCaptureRejected(t *testing.T) {
+	t.Parallel()
+
+	fence := strings.Repeat("#", 80)
+	capture := fence + `
+# idle :: query-gpu (csv, what the exporter parses)
+# $ nvidia-smi --query-gpu=uuid,name --format=csv
+` + fence + `
+uuid, name
+GPU-1, a
+GPU-2, b
+
+` + fence + `
+# idle :: query-compute-apps (per-process)
+# $ nvidia-smi --query-compute-apps=gpu_uuid,pid --format=csv
+` + fence + `
+gpu_uuid, pid
+`
+
+	path := filepath.Join(t.TempDir(), "two-gpus.txt")
+	require.NoError(t, os.WriteFile(path, []byte(capture), 0o600))
+
+	// without gpus the two recorded rows replay fine
+	code, stdout, stderr := runFake(t, "--capture", path, "--query-gpu=uuid", "--format=csv")
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	assert.Len(t, strings.Split(strings.TrimSpace(stdout), "\n"), 3)
+
+	for _, query := range []string{"--query-gpu=uuid", "--query-compute-apps=gpu_uuid,pid"} {
+		code, _, stderr := runFake(t, "--capture", path, "--gpus", "2", query, "--format=csv")
+		assert.Equal(t, 2, code)
+		assert.Contains(t, stderr, "single-GPU")
+	}
+}
+
+// TestGPUsFluctuateCombined proves the two features compose: distinct GPUs
+// move independently and reproducibly, and a per-GPU fixed override pins one
+// GPU while the other keeps fluctuating.
+func TestGPUsFluctuateCombined(t *testing.T) {
+	t.Parallel()
+
+	cfg := writeConfig(t, `
+capture: `+rtx2080Capture+`
+fluctuate: true
+gpus:
+  - {}
+  - overrides:
+      temperature.gpu: "55"
+`)
+
+	rows := queryRows(t, "uuid,temperature.gpu", "--config", cfg, "--seed", "42")
+	require.Len(t, rows, 2)
+
+	moving, err := strconv.ParseFloat(rows[0][1], 64)
+	require.NoError(t, err)
+	assert.InDelta(t, 40, moving, 4.5, "GPU 0 fluctuates around the captured 40")
+	assert.Equal(t, "55", rows[1][1], "GPU 1 is pinned by its override")
+
+	again := queryRows(t, "uuid,temperature.gpu", "--config", cfg, "--seed", "42")
+	assert.Equal(t, rows, again, "a seed reproduces the combination")
+}

--- a/internal/fakesmi/project.go
+++ b/internal/fakesmi/project.go
@@ -3,6 +3,7 @@ package fakesmi
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/capture"
@@ -18,10 +19,11 @@ var errEmptySection = errors.New("section body has no header row")
 // project answers a CSV query for the requested comma-separated fields from a
 // recorded section: the field list recorded in the section's own command line
 // maps field names to CSV columns, and the output carries the requested
-// columns, in the requested order, for the header and every row. When overrides
-// are given, a data row's cell for a named field is replaced before projection,
-// so tests can drive values a real capture does not contain.
-func project(section *capture.Section, requestRaw string, overrides map[string]valueGen) (string, error) {
+// columns, in the requested order, for the header and every row. Data rows
+// pass through the transform pipeline first: replication into the simulated
+// GPUs (with per-GPU identity), then overrides, then fluctuation. The header
+// row is never transformed.
+func project(section *capture.Section, requestRaw string, cfg *config) (string, error) {
 	recorded, err := recordedFields(section.Command)
 	if err != nil {
 		return "", err
@@ -42,51 +44,93 @@ func project(section *capture.Section, requestRaw string, overrides map[string]v
 		return "", errEmptySection
 	}
 
-	output := make([]string, 0, len(lines))
+	header, err := splitRow(lines[0], len(recorded), -1)
+	if err != nil {
+		return "", fmt.Errorf("row 1: %w", err)
+	}
 
-	for lineNum, line := range lines {
-		row, err := projectRow(line, lineNum, recorded, columnOf, columns, overrides)
-		if err != nil {
-			return "", fmt.Errorf("row %d: %w", lineNum+1, err)
-		}
+	rows, err := splitDataRows(lines[1:], recorded, columnOf)
+	if err != nil {
+		return "", err
+	}
 
-		output = append(output, row)
+	replicas := max(len(cfg.gpus), 1)
+	output := make([]string, 0, 1+replicas*len(rows))
+	output = append(output, joinColumns(header, columns))
+
+	// one block of rows per simulated GPU, so a data row's GPU is its block
+	for gpu := range replicas {
+		output = transformRows(output, rows, gpu, recorded, columnOf, columns, cfg)
 	}
 
 	return strings.Join(output, "\n"), nil
 }
 
-// projectRow splits one CSV line, applies data-row overrides, and returns the
-// requested columns joined back together. The header (lineNum 0) is never
-// overridden and has no free-text cells.
-func projectRow(
-	line string,
-	lineNum int,
+// transformRows runs one simulated GPU's data rows through the pipeline —
+// identity, overrides, fluctuation — and appends their projections to output.
+func transformRows(
+	output []string,
+	rows [][]string,
+	gpu int,
 	recorded []string,
 	columnOf map[string]int,
 	columns []int,
-	overrides map[string]valueGen,
-) (string, error) {
+	cfg *config,
+) []string {
+	// buildOverrides returns exactly one map per replica, so a desync would
+	// fail here loudly rather than silently sharing another GPU's generators
+	overrides := cfg.overrides[gpu]
+
+	for _, row := range rows {
+		cells := row
+
+		if len(cfg.gpus) > 0 {
+			cells = slices.Clone(row)
+			rewriteIdentity(cells, columnOf, cfg.gpus[gpu], gpu, len(cfg.gpus))
+		}
+
+		applyOverrides(cells, recorded, overrides)
+
+		if cfg.fluct != nil {
+			cfg.fluct.apply(cells, recorded, columnOf, overrides)
+		}
+
+		output = append(output, joinColumns(cells, columns))
+	}
+
+	return output
+}
+
+// splitDataRows splits the data lines into cells, reconstructing the one
+// free-text column's own commas when the section has it.
+func splitDataRows(lines, recorded []string, columnOf map[string]int) ([][]string, error) {
 	freeTextColumn := -1
-	if column, hasFreeText := columnOf[freeTextField]; hasFreeText && lineNum > 0 {
+	if column, hasFreeText := columnOf[freeTextField]; hasFreeText {
 		freeTextColumn = column
 	}
 
-	cells, err := splitRow(line, len(recorded), freeTextColumn)
-	if err != nil {
-		return "", err
+	rows := make([][]string, 0, len(lines))
+
+	for lineNum, line := range lines {
+		cells, err := splitRow(line, len(recorded), freeTextColumn)
+		if err != nil {
+			return nil, fmt.Errorf("row %d: %w", lineNum+2, err)
+		}
+
+		rows = append(rows, cells)
 	}
 
-	if lineNum > 0 {
-		applyOverrides(cells, recorded, overrides)
-	}
+	return rows, nil
+}
 
+// joinColumns renders the requested columns of one row.
+func joinColumns(cells []string, columns []int) string {
 	projected := make([]string, 0, len(columns))
 	for _, column := range columns {
 		projected = append(projected, cells[column])
 	}
 
-	return strings.Join(projected, ", "), nil
+	return strings.Join(projected, ", ")
 }
 
 // applyOverrides replaces the cell of every field named in overrides with the

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -367,6 +367,67 @@ func TestConfigFile(t *testing.T) {
 	assert.Regexp(t, `nvidia_smi_temperature_gpu\{uuid="[^"]+"\} 88\b`, scrape(t, baseURL))
 }
 
+// TestMultiGPU proves the fake's --gpus replication comes out of the exporter
+// as distinct per-GPU series: the uuid is the exporter's identity label, so
+// two simulated GPUs must yield two temperature series with different uuids,
+// stable across scrapes.
+func TestMultiGPU(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+fakeCommand(defaultCapture(t), "--gpus", "2"))
+
+	series := regexp.MustCompile(`nvidia_smi_temperature_gpu\{uuid="([^"]+)"\}`)
+
+	first := series.FindAllStringSubmatch(scrape(t, baseURL), -1)
+	require.Len(t, first, 2)
+	assert.NotEqual(t, first[0][1], first[1][1], "the two GPUs must have distinct uuids")
+
+	second := series.FindAllStringSubmatch(scrape(t, baseURL), -1)
+	assert.Equal(t, first, second, "identities must be stable across scrapes")
+}
+
+// TestFluctuate proves the fake's --fluctuate mode moves metrics between
+// scrapes while the identity stays put. The fake seeds from the wall clock on
+// every invocation, so two scrapes draw independent jitter. A single metric
+// could land on the same value twice (power draw has only ~800 formatted
+// outcomes in its band), so the whole set of naturally-varying metrics is
+// compared: all of them repeating at once is practically impossible.
+func TestFluctuate(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+fakeCommand(defaultCapture(t), "--fluctuate"))
+
+	moving := regexp.MustCompile(`^nvidia_smi_(power_draw(_instant)?_watts|temperature_gpu|fan_speed_ratio|` +
+		`clocks_current_\w+|memory_used_bytes)\{`)
+	uuid := regexp.MustCompile(`nvidia_smi_power_draw_watts\{uuid="([^"]+)"\}`)
+
+	movingLines := func(metrics string) []string {
+		var lines []string
+
+		for line := range strings.Lines(metrics) {
+			if moving.MatchString(line) {
+				lines = append(lines, strings.TrimSpace(line))
+			}
+		}
+
+		return lines
+	}
+
+	first := scrape(t, baseURL)
+	second := scrape(t, baseURL)
+
+	firstUUID := uuid.FindStringSubmatch(first)
+	secondUUID := uuid.FindStringSubmatch(second)
+
+	require.NotNil(t, firstUUID)
+	require.NotNil(t, secondUUID)
+	assert.Equal(t, firstUUID[1], secondUUID[1], "the uuid must not move")
+
+	firstMoving := movingLines(first)
+	require.NotEmpty(t, firstMoving)
+	assert.NotEqual(t, firstMoving, movingLines(second), "the varying metrics should move between scrapes")
+}
+
 // TestGPURecoveryActionBadState drives gpu_recovery_action to "Reset" with the
 // fake's --set flag, proving a non-zero recovery action flows through the enum
 // transform and out as a metric. No real bad-GPU capture exists, so this is the


### PR DESCRIPTION
## What

Two opt-in modes for the fake nvidia-smi, aimed at dashboard development and demos on machines without a GPU:

**`--fluctuate`** (or `fluctuate: true` in the config) jitters the naturally varying fields — utilization, temperature, power draw, current clocks, fan speed, used memory — around their captured values, with no per-field setup:

- Each cell keeps its unit suffix and decimal shape (`39.32 W` stays a two-decimal watt value).
- Unavailable values (`[N/A]`, `[Not Supported]`) never gain a number.
- Percentages clamp to 0–100; the memory columns are reconciled so used + free never contradicts total − reserved.
- An explicit `--set`/`--set-range`/config override always beats the jitter.
- The fake runs fresh on each scrape, so the default time-based seed makes every scrape move; `--seed` reproduces values for tests.

**`--gpus N`** (or a `gpus:` count/list in the config) presents several GPUs from a single-GPU capture, replicating the GPU row and the per-process rows once per simulated card:

- Each card gets its own `index`, `count`, PCI address and uuid; compute-apps rows carry the owning card's identity so the exporter's joins stay intact.
- Identity is deliberately decoupled from value randomness: generated uuids derive from a fixed namespace plus the GPU index, so they never change across runs and Prometheus keeps its series.
- Explicit `uuid`/`serial` and per-GPU `overrides` can be set per card in the config (e.g. one hotter card); per-GPU overrides layer over the top-level ones, flags win over both.
- Overriding an identity field while `gpus` is active is rejected: a shared uuid would collapse every card into one series and fail the whole scrape with duplicate label sets.

```yaml
capture: linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05
fluctuate: true
gpus:
  - uuid: GPU-1937b558-347d-0f30-105b-893b98985668
    serial: "1320621059033"
    overrides:
      temperature.gpu: {min: 55, max: 80}
  - {}
```

## Not changed

Both features are opt-in and the default replay stays byte-identical, so the golden replay suite and the existing integration expectations are untouched. Verbatim sections (`-q`, `-L`, dmon/pmon) keep replaying the single-GPU recording; the exporter only parses the two CSV queries.

## Testing

- 21 new unit tests covering jitter bounds/shape, N/A preservation, override precedence (including the memory reconciliation edge cases), identity stability, per-GPU overrides, config/flag merge, and all rejection paths.
- 2 new integration tests scrape the real exporter: `--gpus 2` yields two distinct uuid series stable across scrapes, and `--fluctuate` moves a metric between scrapes while the identity stays put.
- Verified end to end: exporter against `fake-nvidia-smi --gpus 4 --fluctuate`, two scrapes — 4 stable uuids, per-card values moving independently, capacities static, used+free+reserved = total exactly.

Closes #449. Closes #451.