### PR TITLE
feat: add a multi-GPU overview dashboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,10 @@ jobs:
           fetch-depth: 0
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.8.0
-      - name: Check that the chart dashboard matches docs/grafana/dashboard.json
-        run: cmp docs/grafana/dashboard.json charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-metrics.json
+      - name: Check that the chart dashboards match docs/grafana/
+        run: |
+          cmp docs/grafana/dashboard.json charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-metrics.json
+          cmp docs/grafana/dashboard-overview.json charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-overview.json
       - name: Lint chart
         run: ct lint --config .ct.yaml --all
       - name: Check that the chart README is current

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ to see your GPU metrics in a nicely visualized way.
 Here's how it looks like:
 ![Grafana dashboard](https://raw.githubusercontent.com/utkuozdemir/nvidia_gpu_exporter/main/docs/grafana/dashboard.png)
 
+For machines with more than one GPU there is a companion
+[overview dashboard](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
+that compares all GPUs of a node side by side and drills down into the
+single-GPU dashboard above. Import it from the JSON file, or enable
+`grafanaDashboard` in the Helm chart to get both dashboards provisioned.
+
 ## Installation
 
 See [INSTALL.md](docs/INSTALL.md) for details.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,9 +38,10 @@ tasks:
   # releases page ("go install" does not work on it, the module carries
   # replace directives). Rule exclusions live in docs/grafana/.lint.
   lint:dashboard:
-    desc: lint the Grafana dashboard against grafana.com best practices
+    desc: lint the Grafana dashboards against grafana.com best practices
     cmds:
       - dashboard-linter lint --strict docs/grafana/dashboard.json
+      - dashboard-linter lint --strict docs/grafana/dashboard-overview.json
 
   release:
     desc: release

--- a/charts/nvidia-gpu-exporter/Chart.yaml
+++ b/charts/nvidia-gpu-exporter/Chart.yaml
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/links: |
     - name: Grafana dashboard
       url: https://grafana.com/grafana/dashboards/14574
+    - name: Grafana dashboard (multi-GPU overview)
+      url: https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -104,6 +104,7 @@ the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU
 nodes via `nodeSelector` or `affinity` before enabling it, otherwise the
 alerts fire for nodes that cannot collect GPU metrics by design.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
+and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
 as a ConfigMap labeled for the Grafana sidecar.
 
 ## Values
@@ -116,7 +117,7 @@ as a ConfigMap labeled for the Grafana sidecar.
 | extraEnv | list | `[]` | Extra environment variables for the exporter container |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | grafanaDashboard.annotations | object | `{}` | Annotations for the dashboard ConfigMap, e.g. the folder annotation of the sidecar |
-| grafanaDashboard.enabled | bool | `false` | Create a ConfigMap with the Grafana dashboard, labeled for the Grafana sidecar to pick up |
+| grafanaDashboard.enabled | bool | `false` | Create a ConfigMap with the Grafana dashboards (single-GPU detail and multi-GPU overview), labeled for the Grafana sidecar to pick up |
 | grafanaDashboard.label | string | `"grafana_dashboard"` | Label that the Grafana sidecar watches for |
 | grafanaDashboard.labelValue | string | `"1"` | Value of the sidecar label |
 | hostNetwork | bool | `false` | Use the host network for the pods |

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -104,6 +104,7 @@ the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU
 nodes via `nodeSelector` or `affinity` before enabling it, otherwise the
 alerts fire for nodes that cannot collect GPU metrics by design.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
+and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
 as a ConfigMap labeled for the Grafana sidecar.
 
 {{ template "chart.valuesSection" . }}

--- a/charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-metrics.json
+++ b/charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-metrics.json
@@ -66,7 +66,22 @@
   "gnetId": 14574,
   "graphTooltip": 0,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "nvidia_gpu_exporter"
+      ],
+      "targetBlank": false,
+      "title": "Related dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "panels": [
     {
       "datasource": {

--- a/charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-overview.json
+++ b/charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-overview.json
@@ -1,0 +1,2431 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.2.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Compare all GPUs of one node side by side: current state, utilization, thermals, throttling and health per GPU. Companion to the Nvidia GPU Metrics dashboard (single-GPU detail, click a GPU in the table to drill down). Shows physical GPUs as reported by nvidia-smi, MIG instances are not broken out: rows are the parent GPUs, whose utilization is not reported in MIG mode and shows n/a. Based on the prometheus metrics from github.com/utkuozdemir/nvidia_gpu_exporter",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "nvidia_gpu_exporter"
+      ],
+      "targetBlank": false,
+      "title": "Related dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Every selected GPU on this node with its current state. Click a GPU name to open it in the single-GPU detail dashboard. Health columns show n/a when the driver does not report the metric.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "#"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open in GPU detail",
+                    "url": "/d/vlvPlrgnk/nvidia-gpu-metrics?${datasource:queryparam}&${job:queryparam}&${node:queryparam}&var-gpu=${__data.fields.uuid}&${__url_time_range}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "uuid"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Utilization"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VRAM Allocated"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "purple",
+                      "value": null
+                    },
+                    {
+                      "color": "#F2CC0C",
+                      "value": 0.85
+                    },
+                    {
+                      "color": "#E02F44",
+                      "value": 0.95
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Temperature"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "celsius"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#56A64B",
+                      "value": null
+                    },
+                    {
+                      "color": "#F2CC0C",
+                      "value": 70
+                    },
+                    {
+                      "color": "#E02F44",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P-State"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "P0 \u00b7 Max perf",
+                        "color": "#2B62D9",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "P1",
+                        "color": "#2B62D9",
+                        "index": 1
+                      },
+                      "2": {
+                        "text": "P2",
+                        "color": "#4880E0",
+                        "index": 2
+                      },
+                      "3": {
+                        "text": "P3",
+                        "color": "#4880E0",
+                        "index": 3
+                      },
+                      "4": {
+                        "text": "P4",
+                        "color": "#6E9BE8",
+                        "index": 4
+                      },
+                      "5": {
+                        "text": "P5",
+                        "color": "#6E9BE8",
+                        "index": 5
+                      },
+                      "6": {
+                        "text": "P6",
+                        "color": "#6E9BE8",
+                        "index": 6
+                      },
+                      "7": {
+                        "text": "P7",
+                        "color": "#6E9BE8",
+                        "index": 7
+                      },
+                      "8": {
+                        "text": "P8 \u00b7 Idle",
+                        "color": "#93B5EE",
+                        "index": 8
+                      },
+                      "9": {
+                        "text": "P9",
+                        "color": "#93B5EE",
+                        "index": 9
+                      },
+                      "10": {
+                        "text": "P10",
+                        "color": "#93B5EE",
+                        "index": 10
+                      },
+                      "11": {
+                        "text": "P11",
+                        "color": "#93B5EE",
+                        "index": 11
+                      },
+                      "12": {
+                        "text": "P12 \u00b7 Deep idle",
+                        "color": "#B6CDF4",
+                        "index": 12
+                      },
+                      "13": {
+                        "text": "P13",
+                        "color": "#B6CDF4",
+                        "index": 13
+                      },
+                      "14": {
+                        "text": "P14",
+                        "color": "#B6CDF4",
+                        "index": 14
+                      },
+                      "15": {
+                        "text": "P15 \u00b7 Min",
+                        "color": "#B6CDF4",
+                        "index": 15
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Throttling"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "None",
+                        "color": "#56A64B",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "1 reason active",
+                        "color": "#FF9830",
+                        "index": 1
+                      },
+                      "2": {
+                        "text": "2 reasons active",
+                        "color": "#FF9830",
+                        "index": 2
+                      },
+                      "3": {
+                        "text": "3 reasons active",
+                        "color": "#E02F44",
+                        "index": 3
+                      },
+                      "4": {
+                        "text": "4 reasons active",
+                        "color": "#E02F44",
+                        "index": 4
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ECC Errors"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "None",
+                        "color": "#56A64B",
+                        "index": 0
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "No ECC",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "No ECC",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#6E7B8B",
+                      "value": null
+                    },
+                    {
+                      "color": "#E02F44",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recovery Action"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "Healthy",
+                        "color": "#56A64B",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "GPU Reset",
+                        "color": "#FF9830",
+                        "index": 1
+                      },
+                      "2": {
+                        "text": "Node Reboot",
+                        "color": "#E02F44",
+                        "index": 2
+                      },
+                      "3": {
+                        "text": "Drain P2P",
+                        "color": "#F2CC0C",
+                        "index": 3
+                      },
+                      "4": {
+                        "text": "Drain & Reset",
+                        "color": "#E02F44",
+                        "index": 4
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "Not reported",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "Not reported",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "md",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "#"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "label_join(label_replace(label_join(nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}, \"ni\", \" #\", \"name\", \"index\"), \"us\", \"($1)\", \"uuid\", \"^(........).*\"), \"gpu_label\", \" \", \"ni\", \"us\")",
+          "instant": true,
+          "range": false,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_utilization_gpu_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_memory_used_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} / nvidia_smi_memory_total_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "C",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_temperature_gpu{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "D",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_power_draw_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} / ((nvidia_smi_enforced_power_limit_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_power_limit_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_power_default_limit_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) > 0)) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "E",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_pstate{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "F",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0))",
+          "instant": true,
+          "range": false,
+          "refId": "G",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by(uuid, instance, job) (nvidia_smi_ecc_errors_uncorrected_aggregate_total{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or sum by(uuid, instance, job) ({__name__=~\"nvidia_smi_ecc_errors_uncorrected_aggregate_.+\", uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"})) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "H",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_gpu_recovery_action{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "I",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "uuid",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(uuid|index|gpu_label|Value #.+)$"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "index"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Value #A": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "index": 0,
+              "gpu_label": 1,
+              "uuid": 2,
+              "Value #B": 3,
+              "Value #C": 4,
+              "Value #D": 5,
+              "Value #E": 6,
+              "Value #F": 7,
+              "Value #G": 8,
+              "Value #H": 9,
+              "Value #I": 10
+            },
+            "renameByName": {
+              "index": "#",
+              "gpu_label": "GPU",
+              "Value #B": "Utilization",
+              "Value #C": "VRAM Allocated",
+              "Value #D": "Temperature",
+              "Value #E": "Power",
+              "Value #F": "P-State",
+              "Value #G": "Throttling",
+              "Value #H": "ECC Errors",
+              "Value #I": "Recovery Action"
+            }
+          }
+        }
+      ],
+      "title": "GPUs",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Utilization & Memory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "GPU utilization over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_utilization_gpu_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "GPU Utilization %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "How busy the memory controller is. Allocation is the VRAM Allocated panel.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_utilization_memory_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Memory Activity %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Share of VRAM allocated over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_memory_used_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} / nvidia_smi_memory_total_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "VRAM Allocated %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Absolute VRAM allocated over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_memory_used_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "VRAM Allocated",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Power & Thermals",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Core temperature over time, one series per selected GPU. The red line marks 80 \u00b0C.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "#E02F44",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_temperature_gpu{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Temperature",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Power draw over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_power_draw_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Power Draw",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Passively cooled cards report no fan speed and are absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_fan_speed_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Fan Speed %",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Throttling & P-State",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "How many performance-limiting throttle reasons are active per GPU (SW power cap, SW thermal, HW thermal, HW power brake). The per-reason breakdown lives in the GPU detail dashboard.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "None",
+                  "color": "transparent",
+                  "index": 0
+                },
+                "1": {
+                  "text": "1 reason",
+                  "color": "#FF9830",
+                  "index": 1
+                },
+                "2": {
+                  "text": "2 reasons",
+                  "color": "#FF9830",
+                  "index": 2
+                },
+                "3": {
+                  "text": "3 reasons",
+                  "color": "#E02F44",
+                  "index": 3
+                },
+                "4": {
+                  "text": "4 reasons",
+                  "color": "#E02F44",
+                  "index": 4
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 16,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.85,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "((sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0))) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Throttling (history)",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Performance state per GPU. Lower P means busier, deep blue = max performance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "P0 \u00b7 Max perf",
+                  "color": "#2B62D9",
+                  "index": 0
+                },
+                "1": {
+                  "text": "P1",
+                  "color": "#2B62D9",
+                  "index": 1
+                },
+                "2": {
+                  "text": "P2",
+                  "color": "#4880E0",
+                  "index": 2
+                },
+                "3": {
+                  "text": "P3",
+                  "color": "#4880E0",
+                  "index": 3
+                },
+                "4": {
+                  "text": "P4",
+                  "color": "#6E9BE8",
+                  "index": 4
+                },
+                "5": {
+                  "text": "P5",
+                  "color": "#6E9BE8",
+                  "index": 5
+                },
+                "6": {
+                  "text": "P6",
+                  "color": "#6E9BE8",
+                  "index": 6
+                },
+                "7": {
+                  "text": "P7",
+                  "color": "#6E9BE8",
+                  "index": 7
+                },
+                "8": {
+                  "text": "P8 \u00b7 Idle",
+                  "color": "#93B5EE",
+                  "index": 8
+                },
+                "9": {
+                  "text": "P9",
+                  "color": "#93B5EE",
+                  "index": 9
+                },
+                "10": {
+                  "text": "P10",
+                  "color": "#93B5EE",
+                  "index": 10
+                },
+                "11": {
+                  "text": "P11",
+                  "color": "#93B5EE",
+                  "index": 11
+                },
+                "12": {
+                  "text": "P12 \u00b7 Deep idle",
+                  "color": "#B6CDF4",
+                  "index": 12
+                },
+                "13": {
+                  "text": "P13",
+                  "color": "#B6CDF4",
+                  "index": 13
+                },
+                "14": {
+                  "text": "P14",
+                  "color": "#B6CDF4",
+                  "index": 14
+                },
+                "15": {
+                  "text": "P15 \u00b7 Min",
+                  "color": "#B6CDF4",
+                  "index": 15
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 17,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.85,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_pstate{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "P-State (history)",
+      "type": "state-timeline"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 4,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Current graphics clock over time, one series per selected GPU.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "hertz",
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(nvidia_smi_clocks_current_graphics_clock_hz{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "Graphics Clock",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Current memory clock over time, one series per selected GPU.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "hertz",
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(nvidia_smi_clocks_current_memory_clock_hz{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "Memory Clock",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Clocks",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 18,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Uncorrected ECC errors per GPU (aggregate). Cards without ECC report nothing.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "min": 0,
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(sum by(uuid, instance, job) (nvidia_smi_ecc_errors_uncorrected_aggregate_total{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or sum by(uuid, instance, job) ({__name__=~\"nvidia_smi_ecc_errors_uncorrected_aggregate_.+\", uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"})) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "ECC Errors (uncorrected)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Recommended recovery action per GPU. Only recent datacenter drivers report this.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "text"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "Healthy",
+                      "color": "#56A64B",
+                      "index": 0
+                    },
+                    "1": {
+                      "text": "GPU Reset",
+                      "color": "#FF9830",
+                      "index": 1
+                    },
+                    "2": {
+                      "text": "Node Reboot",
+                      "color": "#E02F44",
+                      "index": 2
+                    },
+                    "3": {
+                      "text": "Drain P2P",
+                      "color": "#F2CC0C",
+                      "index": 3
+                    },
+                    "4": {
+                      "text": "Drain & Reset",
+                      "color": "#E02F44",
+                      "index": 4
+                    }
+                  }
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 20,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.85,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(nvidia_smi_gpu_recovery_action{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "Recovery Action (history)",
+          "type": "state-timeline"
+        }
+      ],
+      "title": "Datacenter Health",
+      "type": "row"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "nvidia",
+    "nvidia-smi",
+    "nvidia_gpu_exporter",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(nvidia_smi_index, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(nvidia_smi_index,job)",
+          "refId": "Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(nvidia_smi_index{job=\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(nvidia_smi_index{job=\"$job\"},instance)",
+          "refId": "Prometheus-node-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(label_join(label_replace(label_join(nvidia_smi_gpu_info{instance=\"$node\", job=\"$job\"}, \"ni\", \" #\", \"name\", \"index\"), \"us\", \"($1)\", \"uuid\", \"^(........).*\"), \"gpu_label\", \" \", \"ni\", \"us\"))",
+        "hide": 0,
+        "includeAll": true,
+        "label": "GPU",
+        "multi": true,
+        "name": "gpu",
+        "options": [],
+        "query": {
+          "query": "query_result(label_join(label_replace(label_join(nvidia_smi_gpu_info{instance=\"$node\", job=\"$job\"}, \"ni\", \" #\", \"name\", \"index\"), \"us\", \"($1)\", \"uuid\", \"^(........).*\"), \"gpu_label\", \" \", \"ni\", \"us\"))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/gpu_label=\"(?<text>[^\"]+)|uuid=\"(?<value>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Nvidia GPU Overview",
+  "uid": "nvidia-gpu-overview",
+  "weekStart": ""
+}

--- a/charts/nvidia-gpu-exporter/templates/dashboard-configmap.yaml
+++ b/charts/nvidia-gpu-exporter/templates/dashboard-configmap.yaml
@@ -13,4 +13,6 @@ metadata:
 data:
   nvidia-gpu-metrics.json: |-
     {{- .Files.Get "dashboards/nvidia-gpu-metrics.json" | nindent 4 }}
+  nvidia-gpu-overview.json: |-
+    {{- .Files.Get "dashboards/nvidia-gpu-overview.json" | nindent 4 }}
 {{- end }}

--- a/charts/nvidia-gpu-exporter/values.yaml
+++ b/charts/nvidia-gpu-exporter/values.yaml
@@ -150,8 +150,8 @@ prometheusRule:
     severity: warning
 
 grafanaDashboard:
-  # -- Create a ConfigMap with the Grafana dashboard, labeled for the Grafana
-  # sidecar to pick up
+  # -- Create a ConfigMap with the Grafana dashboards (single-GPU detail and
+  # multi-GPU overview), labeled for the Grafana sidecar to pick up
   enabled: false
   # -- Label that the Grafana sidecar watches for
   label: grafana_dashboard

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,7 +21,10 @@ Follow the steps below:
 9. Hit "Import". The dashboard picks your Prometheus data source automatically.
    If you have more than one, use the "Data source" dropdown at the top of the
    dashboard.
-10. Enjoy the dashboard!
+10. Enjoy the dashboard! If the machine has more than one GPU, also import
+    [the overview dashboard](https://raw.githubusercontent.com/utkuozdemir/nvidia_gpu_exporter/main/docs/grafana/dashboard-overview.json)
+    (copy the JSON into the "Import via dashboard JSON model" field) to
+    compare all GPUs side by side.
 
 ## Using .deb or .rpm packages
 

--- a/docs/grafana/dashboard-overview.json
+++ b/docs/grafana/dashboard-overview.json
@@ -1,0 +1,2431 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.2.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Compare all GPUs of one node side by side: current state, utilization, thermals, throttling and health per GPU. Companion to the Nvidia GPU Metrics dashboard (single-GPU detail, click a GPU in the table to drill down). Shows physical GPUs as reported by nvidia-smi, MIG instances are not broken out: rows are the parent GPUs, whose utilization is not reported in MIG mode and shows n/a. Based on the prometheus metrics from github.com/utkuozdemir/nvidia_gpu_exporter",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "nvidia_gpu_exporter"
+      ],
+      "targetBlank": false,
+      "title": "Related dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Every selected GPU on this node with its current state. Click a GPU name to open it in the single-GPU detail dashboard. Health columns show n/a when the driver does not report the metric.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "#"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open in GPU detail",
+                    "url": "/d/vlvPlrgnk/nvidia-gpu-metrics?${datasource:queryparam}&${job:queryparam}&${node:queryparam}&var-gpu=${__data.fields.uuid}&${__url_time_range}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 320
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "uuid"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Utilization"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VRAM Allocated"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "purple",
+                      "value": null
+                    },
+                    {
+                      "color": "#F2CC0C",
+                      "value": 0.85
+                    },
+                    {
+                      "color": "#E02F44",
+                      "value": 0.95
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Temperature"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "celsius"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#56A64B",
+                      "value": null
+                    },
+                    {
+                      "color": "#F2CC0C",
+                      "value": 70
+                    },
+                    {
+                      "color": "#E02F44",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P-State"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "P0 \u00b7 Max perf",
+                        "color": "#2B62D9",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "P1",
+                        "color": "#2B62D9",
+                        "index": 1
+                      },
+                      "2": {
+                        "text": "P2",
+                        "color": "#4880E0",
+                        "index": 2
+                      },
+                      "3": {
+                        "text": "P3",
+                        "color": "#4880E0",
+                        "index": 3
+                      },
+                      "4": {
+                        "text": "P4",
+                        "color": "#6E9BE8",
+                        "index": 4
+                      },
+                      "5": {
+                        "text": "P5",
+                        "color": "#6E9BE8",
+                        "index": 5
+                      },
+                      "6": {
+                        "text": "P6",
+                        "color": "#6E9BE8",
+                        "index": 6
+                      },
+                      "7": {
+                        "text": "P7",
+                        "color": "#6E9BE8",
+                        "index": 7
+                      },
+                      "8": {
+                        "text": "P8 \u00b7 Idle",
+                        "color": "#93B5EE",
+                        "index": 8
+                      },
+                      "9": {
+                        "text": "P9",
+                        "color": "#93B5EE",
+                        "index": 9
+                      },
+                      "10": {
+                        "text": "P10",
+                        "color": "#93B5EE",
+                        "index": 10
+                      },
+                      "11": {
+                        "text": "P11",
+                        "color": "#93B5EE",
+                        "index": 11
+                      },
+                      "12": {
+                        "text": "P12 \u00b7 Deep idle",
+                        "color": "#B6CDF4",
+                        "index": 12
+                      },
+                      "13": {
+                        "text": "P13",
+                        "color": "#B6CDF4",
+                        "index": 13
+                      },
+                      "14": {
+                        "text": "P14",
+                        "color": "#B6CDF4",
+                        "index": 14
+                      },
+                      "15": {
+                        "text": "P15 \u00b7 Min",
+                        "color": "#B6CDF4",
+                        "index": 15
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Throttling"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "None",
+                        "color": "#56A64B",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "1 reason active",
+                        "color": "#FF9830",
+                        "index": 1
+                      },
+                      "2": {
+                        "text": "2 reasons active",
+                        "color": "#FF9830",
+                        "index": 2
+                      },
+                      "3": {
+                        "text": "3 reasons active",
+                        "color": "#E02F44",
+                        "index": 3
+                      },
+                      "4": {
+                        "text": "4 reasons active",
+                        "color": "#E02F44",
+                        "index": 4
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "n/a",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ECC Errors"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "None",
+                        "color": "#56A64B",
+                        "index": 0
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "No ECC",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "No ECC",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "#6E7B8B",
+                      "value": null
+                    },
+                    {
+                      "color": "#E02F44",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Recovery Action"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "Healthy",
+                        "color": "#56A64B",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "GPU Reset",
+                        "color": "#FF9830",
+                        "index": 1
+                      },
+                      "2": {
+                        "text": "Node Reboot",
+                        "color": "#E02F44",
+                        "index": 2
+                      },
+                      "3": {
+                        "text": "Drain P2P",
+                        "color": "#F2CC0C",
+                        "index": 3
+                      },
+                      "4": {
+                        "text": "Drain & Reset",
+                        "color": "#E02F44",
+                        "index": 4
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "-1": {
+                        "text": "Not reported",
+                        "color": "#6E7B8B",
+                        "index": 99
+                      }
+                    }
+                  },
+                  {
+                    "type": "special",
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "Not reported",
+                        "color": "#6E7B8B",
+                        "index": 100
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "md",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "#"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "label_join(label_replace(label_join(nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}, \"ni\", \" #\", \"name\", \"index\"), \"us\", \"($1)\", \"uuid\", \"^(........).*\"), \"gpu_label\", \" \", \"ni\", \"us\")",
+          "instant": true,
+          "range": false,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_utilization_gpu_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_memory_used_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} / nvidia_smi_memory_total_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "C",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_temperature_gpu{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "D",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_power_draw_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} / ((nvidia_smi_enforced_power_limit_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_power_limit_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_power_default_limit_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) > 0)) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "E",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_pstate{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "F",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0))",
+          "instant": true,
+          "range": false,
+          "refId": "G",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by(uuid, instance, job) (nvidia_smi_ecc_errors_uncorrected_aggregate_total{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or sum by(uuid, instance, job) ({__name__=~\"nvidia_smi_ecc_errors_uncorrected_aggregate_.+\", uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"})) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "H",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_gpu_recovery_action{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0 - 1)",
+          "instant": true,
+          "range": false,
+          "refId": "I",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "uuid",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^(uuid|index|gpu_label|Value #.+)$"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "index"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Value #A": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "index": 0,
+              "gpu_label": 1,
+              "uuid": 2,
+              "Value #B": 3,
+              "Value #C": 4,
+              "Value #D": 5,
+              "Value #E": 6,
+              "Value #F": 7,
+              "Value #G": 8,
+              "Value #H": 9,
+              "Value #I": 10
+            },
+            "renameByName": {
+              "index": "#",
+              "gpu_label": "GPU",
+              "Value #B": "Utilization",
+              "Value #C": "VRAM Allocated",
+              "Value #D": "Temperature",
+              "Value #E": "Power",
+              "Value #F": "P-State",
+              "Value #G": "Throttling",
+              "Value #H": "ECC Errors",
+              "Value #I": "Recovery Action"
+            }
+          }
+        }
+      ],
+      "title": "GPUs",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Utilization & Memory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "GPU utilization over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_utilization_gpu_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "GPU Utilization %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "How busy the memory controller is. Allocation is the VRAM Allocated panel.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_utilization_memory_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Memory Activity %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Share of VRAM allocated over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_memory_used_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} / nvidia_smi_memory_total_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "VRAM Allocated %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Absolute VRAM allocated over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_memory_used_bytes{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "VRAM Allocated",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Power & Thermals",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Core temperature over time, one series per selected GPU. The red line marks 80 \u00b0C.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "#E02F44",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_temperature_gpu{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Temperature",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Power draw over time, one series per selected GPU.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_power_draw_watts{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Power Draw",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Passively cooled cards report no fan speed and are absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_fan_speed_ratio{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Fan Speed %",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Throttling & P-State",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "How many performance-limiting throttle reasons are active per GPU (SW power cap, SW thermal, HW thermal, HW power brake). The per-reason breakdown lives in the GPU detail dashboard.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "None",
+                  "color": "transparent",
+                  "index": 0
+                },
+                "1": {
+                  "text": "1 reason",
+                  "color": "#FF9830",
+                  "index": 1
+                },
+                "2": {
+                  "text": "2 reasons",
+                  "color": "#FF9830",
+                  "index": 2
+                },
+                "3": {
+                  "text": "3 reasons",
+                  "color": "#E02F44",
+                  "index": 3
+                },
+                "4": {
+                  "text": "4 reasons",
+                  "color": "#E02F44",
+                  "index": 4
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 16,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.85,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "((sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_power_cap{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0)) + (sum by(uuid, instance, job) (nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"} or nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or (sum by(uuid, instance, job) (nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * 0))) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "Throttling (history)",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Performance state per GPU. Lower P means busier, deep blue = max performance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "P0 \u00b7 Max perf",
+                  "color": "#2B62D9",
+                  "index": 0
+                },
+                "1": {
+                  "text": "P1",
+                  "color": "#2B62D9",
+                  "index": 1
+                },
+                "2": {
+                  "text": "P2",
+                  "color": "#4880E0",
+                  "index": 2
+                },
+                "3": {
+                  "text": "P3",
+                  "color": "#4880E0",
+                  "index": 3
+                },
+                "4": {
+                  "text": "P4",
+                  "color": "#6E9BE8",
+                  "index": 4
+                },
+                "5": {
+                  "text": "P5",
+                  "color": "#6E9BE8",
+                  "index": 5
+                },
+                "6": {
+                  "text": "P6",
+                  "color": "#6E9BE8",
+                  "index": 6
+                },
+                "7": {
+                  "text": "P7",
+                  "color": "#6E9BE8",
+                  "index": 7
+                },
+                "8": {
+                  "text": "P8 \u00b7 Idle",
+                  "color": "#93B5EE",
+                  "index": 8
+                },
+                "9": {
+                  "text": "P9",
+                  "color": "#93B5EE",
+                  "index": 9
+                },
+                "10": {
+                  "text": "P10",
+                  "color": "#93B5EE",
+                  "index": 10
+                },
+                "11": {
+                  "text": "P11",
+                  "color": "#93B5EE",
+                  "index": 11
+                },
+                "12": {
+                  "text": "P12 \u00b7 Deep idle",
+                  "color": "#B6CDF4",
+                  "index": 12
+                },
+                "13": {
+                  "text": "P13",
+                  "color": "#B6CDF4",
+                  "index": 13
+                },
+                "14": {
+                  "text": "P14",
+                  "color": "#B6CDF4",
+                  "index": 14
+                },
+                "15": {
+                  "text": "P15 \u00b7 Min",
+                  "color": "#B6CDF4",
+                  "index": 15
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 17,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.85,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(nvidia_smi_pstate{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A",
+          "legendFormat": "#{{index}} {{name}}"
+        }
+      ],
+      "title": "P-State (history)",
+      "type": "state-timeline"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 4,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Current graphics clock over time, one series per selected GPU.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "hertz",
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(nvidia_smi_clocks_current_graphics_clock_hz{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "Graphics Clock",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Current memory clock over time, one series per selected GPU.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "hertz",
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(nvidia_smi_clocks_current_memory_clock_hz{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "Memory Clock",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Clocks",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 18,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Uncorrected ECC errors per GPU (aggregate). Cards without ECC report nothing.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "min": 0,
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(sum by(uuid, instance, job) (nvidia_smi_ecc_errors_uncorrected_aggregate_total{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) or sum by(uuid, instance, job) ({__name__=~\"nvidia_smi_ecc_errors_uncorrected_aggregate_.+\", uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"})) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "ECC Errors (uncorrected)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Recommended recovery action per GPU. Only recent datacenter drivers report this.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "text"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "Healthy",
+                      "color": "#56A64B",
+                      "index": 0
+                    },
+                    "1": {
+                      "text": "GPU Reset",
+                      "color": "#FF9830",
+                      "index": 1
+                    },
+                    "2": {
+                      "text": "Node Reboot",
+                      "color": "#E02F44",
+                      "index": 2
+                    },
+                    "3": {
+                      "text": "Drain P2P",
+                      "color": "#F2CC0C",
+                      "index": 3
+                    },
+                    "4": {
+                      "text": "Drain & Reset",
+                      "color": "#E02F44",
+                      "index": 4
+                    }
+                  }
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 20,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.85,
+            "showValue": "auto",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(nvidia_smi_gpu_recovery_action{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{uuid=~\"$gpu\", instance=\"$node\", job=\"$job\"}",
+              "instant": false,
+              "range": true,
+              "refId": "A",
+              "legendFormat": "#{{index}} {{name}}"
+            }
+          ],
+          "title": "Recovery Action (history)",
+          "type": "state-timeline"
+        }
+      ],
+      "title": "Datacenter Health",
+      "type": "row"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "nvidia",
+    "nvidia-smi",
+    "nvidia_gpu_exporter",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(nvidia_smi_index, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(nvidia_smi_index,job)",
+          "refId": "Prometheus-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(nvidia_smi_index{job=\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(nvidia_smi_index{job=\"$job\"},instance)",
+          "refId": "Prometheus-node-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(label_join(label_replace(label_join(nvidia_smi_gpu_info{instance=\"$node\", job=\"$job\"}, \"ni\", \" #\", \"name\", \"index\"), \"us\", \"($1)\", \"uuid\", \"^(........).*\"), \"gpu_label\", \" \", \"ni\", \"us\"))",
+        "hide": 0,
+        "includeAll": true,
+        "label": "GPU",
+        "multi": true,
+        "name": "gpu",
+        "options": [],
+        "query": {
+          "query": "query_result(label_join(label_replace(label_join(nvidia_smi_gpu_info{instance=\"$node\", job=\"$job\"}, \"ni\", \" #\", \"name\", \"index\"), \"us\", \"($1)\", \"uuid\", \"^(........).*\"), \"gpu_label\", \" \", \"ni\", \"us\"))",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/gpu_label=\"(?<text>[^\"]+)|uuid=\"(?<value>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Nvidia GPU Overview",
+  "uid": "nvidia-gpu-overview",
+  "weekStart": ""
+}

--- a/docs/grafana/dashboard.json
+++ b/docs/grafana/dashboard.json
@@ -66,7 +66,22 @@
   "gnetId": 14574,
   "graphTooltip": 0,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "nvidia_gpu_exporter"
+      ],
+      "targetBlank": false,
+      "title": "Related dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "panels": [
     {
       "datasource": {

--- a/hack/compose/README.md
+++ b/hack/compose/README.md
@@ -1,9 +1,11 @@
 # Local dev stack
 
-A one-command stack for developing the exporter and its Grafana dashboard on a
+A one-command stack for developing the exporter and its Grafana dashboards on a
 machine with **no GPU**. It runs the real exporter against the fake nvidia-smi
-(`cmd/fake-nvidia-smi`), scrapes it with Prometheus, and serves the dashboard in
-Grafana with live, moving values.
+(`cmd/fake-nvidia-smi`), scrapes it with Prometheus, and serves the dashboards
+in Grafana with live, moving values. Two exporter instances play two "nodes"
+(an eight-GPU consumer box on `fake.yaml`, a two-GPU passive L40S box on
+`fake2.yaml`), so per-node filtering and multi-GPU comparison are exercisable.
 
 ## Run
 
@@ -15,9 +17,11 @@ Grafana with live, moving values.
 Then open:
 
 - Grafana: <http://localhost:3000> (anonymous admin, no login) — the **Nvidia GPU
-  Metrics** dashboard is provisioned and already pointed at Prometheus.
+  Metrics** and **Nvidia GPU Overview** dashboards are provisioned and already
+  pointed at Prometheus.
 - Prometheus: <http://localhost:9090>
-- Exporter metrics: <http://localhost:9835/metrics>
+- Exporter metrics: <http://localhost:9835/metrics> (node one),
+  <http://localhost:9836/metrics> (node two)
 
 Stop and wipe the throwaway state (Prometheus/Grafana volumes):
 
@@ -32,7 +36,7 @@ running containers and their data volumes are disposable.
 
 `fake/fake.yaml` drives the fake. `fluctuate: true` jitters everything that
 naturally moves (utilization, temperature, power, clocks, fan, memory) around
-the captured values, `gpus:` simulates four cards from the single-GPU capture
+the captured values, `gpus:` simulates eight cards from the single-GPU capture
 (the last one deliberately sick, to preview the health states in the GPU
 dropdown), and `overrides:` drive the states the jitter does not cover, like
 the throttle flags. The fake is invoked fresh on every scrape, so **editing
@@ -47,16 +51,20 @@ overrides:
 
 Field names are nvidia-smi query fields; see `internal/captures/README.md`. To
 drive a different card, change `capture:` to any embedded capture name.
+`fake2.yaml` drives the second exporter the same way; its passive L40S cards
+report no fan speed, which exercises the "metric absent" paths on the
+dashboards.
 
-## Iterate on the dashboard
+## Iterate on the dashboards
 
-The dashboard is authored in the Grafana UI and exported to
-`docs/grafana/dashboard.json` (the published artifact, grafana.com 14574). That
-file selects its data source through a template variable, which resolves to
+The dashboards are authored in the Grafana UI and exported to
+`docs/grafana/dashboard.json` (single-GPU detail, grafana.com 14574) and
+`docs/grafana/dashboard-overview.json` (multi-GPU comparison). Those files
+select their data source through a template variable, which resolves to
 this stack's sole Prometheus on its own, so `render-dashboard.sh` simply
-copies it into the provisioning directory.
+copies them into the provisioning directory.
 
-Loop: edit `docs/grafana/dashboard.json` (or edit in the UI and export it there),
-run `./hack/compose/render-dashboard.sh`, and Grafana reloads within a few
-seconds. Keep `docs/grafana/dashboard.json` and
-`charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-metrics.json` byte-identical.
+Loop: edit the JSON under `docs/grafana/` (or edit in the UI and export it
+there), run `./hack/compose/render-dashboard.sh`, and Grafana reloads within a
+few seconds. Keep each `docs/grafana/*.json` and its copy under
+`charts/nvidia-gpu-exporter/dashboards/` byte-identical.

--- a/hack/compose/docker-compose.yaml
+++ b/hack/compose/docker-compose.yaml
@@ -5,7 +5,8 @@ name: nvidia-gpu-exporter-dev
 # and pointed at Prometheus. See README.md.
 
 services:
-  exporter:
+  # first "node": eight consumer cards incl. one deliberately sick, fake.yaml
+  node1:
     build:
       context: ../..
       dockerfile: hack/compose/Dockerfile
@@ -21,6 +22,21 @@ services:
     ports:
       - "9835:9835"
 
+  # second "node": same exporter image, different fake (passive L40S cards,
+  # fake2.yaml), so the dashboards can prove per-node filtering, joins and
+  # links do not bleed across instances. See fake/fake2.yaml.
+  node2:
+    build:
+      context: ../..
+      dockerfile: hack/compose/Dockerfile
+    command:
+      - "--nvidia-smi-command=/usr/local/bin/fake-nvidia-smi --config /etc/fake/fake2.yaml"
+      - "--collect.compute-apps"
+    volumes:
+      - ./fake:/etc/fake:ro
+    ports:
+      - "9836:9835"
+
   prometheus:
     image: prom/prometheus:v3.13.0
     ports:
@@ -29,7 +45,8 @@ services:
       - ./prometheus/config:/etc/prometheus
       - prometheus-data:/prometheus
     depends_on:
-      - exporter
+      - node1
+      - node2
 
   grafana:
     image: grafana/grafana:13.1.0

--- a/hack/compose/fake/fake.yaml
+++ b/hack/compose/fake/fake.yaml
@@ -9,7 +9,7 @@ state: load
 # memory (including per-process). An explicit override below beats the jitter.
 fluctuate: true
 
-# Four cards from the single-GPU capture, each with a stable generated uuid,
+# Eight cards from the single-GPU capture, each with a stable generated uuid,
 # so the GPU selector, per-GPU filtering and per-process rows can be exercised
 # without hardware. The last card is deliberately sick to preview the health
 # banner, the throttle timeline and the temperature alert colors: select it in
@@ -18,10 +18,23 @@ gpus:
   - {}
   - {}
   - {}
+  - {}
+  - {}
+  - {}
+  - {}
   - overrides:
       gpu_recovery_action: "Node Reboot"
       temperature.gpu: 93
       clocks_event_reasons.hw_thermal_slowdown: 1
+      # ECC preview on the sick card only: the 2080 capture reports no ECC,
+      # these force the banner tile red + populate the datacenter ECC detail
+      # panel. Healthy cards keep "No ECC" so the overview dashboard can show
+      # the sick/healthy contrast. Delete to restore "No ECC" everywhere
+      # (series go stale on the next scrape).
+      ecc.errors.uncorrected.aggregate.total:   5
+      ecc.errors.uncorrected.aggregate.dram:    3
+      ecc.errors.uncorrected.aggregate.sram:    2
+      ecc.errors.uncorrected.volatile.total:    1
 
 overrides:
   # screenshot mode: a busy inference box. These beat the capture-anchored
@@ -54,11 +67,5 @@ overrides:
   pstate:                                           {min: 0, max: 5}  # busy states, coherent with the load
   # recovery action / fabric state are enum-string fields: ranges cannot
   # drive them (bare integers are rejected), only fixed strings like the
-  # per-GPU gpu_recovery_action above.
-  # ECC preview: the 2080 capture reports no ECC, these force the banner tile
-  # red + populate the datacenter ECC detail panel. Delete to restore "No ECC"
-  # (series go stale on the next scrape).
-  ecc.errors.uncorrected.aggregate.total:   5
-  ecc.errors.uncorrected.aggregate.dram:    3
-  ecc.errors.uncorrected.aggregate.sram:    2
-  ecc.errors.uncorrected.volatile.total:    1
+  # per-GPU gpu_recovery_action above. ECC errors are also per-GPU overrides
+  # on the sick card, so healthy cards keep reporting "No ECC".

--- a/hack/compose/fake/fake2.yaml
+++ b/hack/compose/fake/fake2.yaml
@@ -1,0 +1,24 @@
+# Drives the fake nvidia-smi behind the second exporter instance, so the
+# stack exposes two nodes and the dashboards can prove that per-node
+# filtering, joins and drill-down links do not bleed across instances.
+# A passive datacenter card: fan.speed reports [N/A], which exercises the
+# "metric absent, show N/A, not zero" paths in the overview dashboard.
+capture: linux-x86_64__nvidia-l40s__595.80
+state: load
+fluctuate: true
+
+# Two cards, both healthy: the sick-GPU preview lives on the first node
+# (fake.yaml). Explicit uuids, because the generated ones would repeat the
+# first node's (same base + index on both exporters) and real uuids are
+# globally unique. The capture's NVENC load sits near idle, so lift
+# utilization and power into ranges that look like an inference box next to
+# node one.
+gpus:
+  - uuid: GPU-7b1e4c8a-2f60-49d3-9e5b-a86cf03d217e
+  - uuid: GPU-c94d02f7-6a3b-4e18-b2d0-5f77e94a6c31
+
+overrides:
+  utilization.gpu:    {min: 55, max: 96}
+  utilization.memory: {min: 30, max: 70}
+  power.draw:         {min: 190, max: 330}
+  temperature.gpu:    {min: 55, max: 74}

--- a/hack/compose/prometheus/config/prometheus.yml
+++ b/hack/compose/prometheus/config/prometheus.yml
@@ -6,4 +6,4 @@ global:
 scrape_configs:
   - job_name: "nvidia_gpu_exporter"
     static_configs:
-      - targets: ["exporter:9835"]
+      - targets: ["node1:9835", "node2:9835"]

--- a/hack/compose/render-dashboard.sh
+++ b/hack/compose/render-dashboard.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
-# Copy the published dashboard into a provisioning copy for the dev stack.
+# Copy the published dashboards into provisioning copies for the dev stack.
 #
-# docs/grafana/dashboard.json is the published artifact (grafana.com 14574).
-# It selects its data source through a template variable, which resolves to
+# docs/grafana/dashboard.json (grafana.com 14574) and
+# docs/grafana/dashboard-overview.json are the published artifacts. They
+# select their data source through a template variable, which resolves to
 # this stack's sole Prometheus on its own, so no substitution is needed. The
-# published artifact ships non-editable, so the dev copy flips that one flag
+# published artifacts ship non-editable, so the dev copies flip that one flag
 # back, otherwise the author-in-the-UI loop below would be blocked
 # (allowUiUpdates in the provider does not override the dashboard model).
-# Grafana's provider polls the output, so re-run this after editing the
+# Grafana's provider polls the output, so re-run this after editing a
 # dashboard to see the change live.
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
-src="$here/../../docs/grafana/dashboard.json"
-dst="$here/grafana/dashboards/nvidia-gpu-metrics.json"
 
-mkdir -p "$(dirname "$dst")"
-sed 's/"editable": false/"editable": true/' "$src" > "$dst"
-echo "rendered $dst"
+render() {
+  local src="$here/../../docs/grafana/$1"
+  local dst="$here/grafana/dashboards/$2"
+
+  mkdir -p "$(dirname "$dst")"
+  sed 's/"editable": false/"editable": true/' "$src" > "$dst"
+  echo "rendered $dst"
+}
+
+render dashboard.json nvidia-gpu-metrics.json
+render dashboard-overview.json nvidia-gpu-overview.json


### PR DESCRIPTION
Adds a second Grafana dashboard, **Nvidia GPU Overview**, that compares all GPUs of one node side by side, and keeps the existing dashboard as the single-GPU detail view. Closes #226.

## What's in it

- **GPU selector is multi-select with All** — compare two cards or watch the whole node.
- **GPUs table** as the "right now" surface: one row per GPU (identified like the GPU dropdown: name, index, uuid prefix), gauge cells for utilization / VRAM / temperature / power, and named states for P-State, throttling, ECC and recovery action. Clicking a GPU drills into the detail dashboard with data source, job, node, GPU and time range preselected.
- **History sections**: per-GPU utilization, memory activity/allocation, temperature, power and fan timeseries; a per-GPU throttling-count timeline and the P-State timeline; clocks and datacenter health in collapsed rows; shared crosshair.
- **Honest absence semantics**: a GPU that does not report a metric shows a slate "n/a" / "No ECC" / "Not reported" cell — never a healthy zero, and never a silently vanished column, even when the metric is absent for every selected GPU (each query is anchored on the GPU inventory with a sentinel for missing values).
- **Same design language** as the recent dashboard overhaul: hue = metric family, status palette reserved for real problems, state names always in text, the throttle field-rename fallback everywhere, every query filtered by job and node. Identity across GPUs uses the standard categorical palette with per-GPU legends.
- Scope: physical GPUs as reported by nvidia-smi; MIG instances are not broken out (parent rows show utilization as n/a). `job`/`node` stay single-select; all aggregations keep `(uuid, instance, job)` so a future fleet-level dashboard can reuse the same identity contract.

## Plumbing

- Helm chart ships both dashboards in one ConfigMap; CI compares both published JSONs with their chart copies; `task lint:dashboard` lints both (strict passes).
- The compose dev stack now simulates two nodes (an 8-GPU consumer box with one deliberately sick card, and a 2-GPU passive L40S box with no fan readings) so multi-GPU comparison, per-node filtering and the absence paths are all exercisable without hardware.
- Docs: README, INSTALL, chart README and Artifact Hub metadata link the overview (repo JSON until it gets a grafana.com ID).

## Verification

Developed and verified against the live compose stack (fake nvidia-smi): all queries checked against Prometheus on both simulated nodes (joins, throttle counts, ECC only on the sick card, absence sentinels, no cross-instance bleed), and both dashboards provision cleanly on Grafana 13.1 and on 11.2, the declared minimum.

## Follow-ups after merge (maintainer)

- Publish the overview on grafana.com and swap the repo-JSON links for the new ID.
- Republish 14574: the detail dashboard gained a "Related dashboards" link block.
- Screenshot for the README/grafana.com listing.
