### PR TITLE
feat: harden the HTTP serving and scrape handling

### DIFF
--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -132,6 +132,7 @@ as a ConfigMap labeled for the Grafana sidecar.
 | image.repository | string | `"docker.io/utkuozdemir/nvidia_gpu_exporter"` | Image repository |
 | image.tag | string | `""` | Image tag (if not specified, defaults to the chart's appVersion) |
 | imagePullSecrets | list | `[]` | Image pull secrets |
+| livenessProbe | object | `{"httpGet":{"path":"/-/healthy","port":"http"}}` | Liveness probe for the exporter container. The default checks that the process serves HTTP at all; it deliberately does not depend on collection success, so a failing nvidia-smi keeps the pod scrapeable and the failure visible in the metrics. Set to `null` to disable the probe. |
 | log.format | string | `"logfmt"` | Log format: logfmt, json |
 | log.level | string | `"info"` | Log level: debug, info, warn, error |
 | nameOverride | string | `""` | Override the chart name |
@@ -159,6 +160,7 @@ as a ConfigMap labeled for the Grafana sidecar.
 | prometheusRule.enabled | bool | `false` | Create a Prometheus Operator PrometheusRule with default alerts (requires the Prometheus Operator CRDs). In clusters where the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU nodes via nodeSelector or affinity before enabling this, otherwise the alerts fire for nodes that cannot collect GPU metrics by design. |
 | queryFieldNames | list | `["AUTO"]` | `nvidia-smi` fields to be queried by the exporter. `AUTO` auto-detects them. |
 | queryFieldNamesExclude | list | `[]` | `nvidia-smi` fields to exclude from being queried. Names match literally, with `*` as a wildcard for any sequence of characters. |
+| readinessProbe | object | `{"httpGet":{"path":"/-/ready","port":"http"}}` | Readiness probe for the exporter container, process-level like the liveness probe. Set to `null` to disable the probe. |
 | resources | object | `{}` | Resources for the exporter container |
 | runtimeClassName | string | `""` | Name of the RuntimeClass to run the pods with. GPU access is injected by the NVIDIA container runtime, so the pods must run with it: either set this to the name of your NVIDIA RuntimeClass (usually `nvidia`), or leave it empty if the NVIDIA runtime is the default runtime of your nodes. If neither is the case, the exporter will come up but serve no GPU metrics, reporting `nvidia_smi_last_collect_success 0`. |
 | securityContext | object | `{}` | Security context for the exporter container. The default is unprivileged: GPU access comes from the NVIDIA runtime, which requires no privileges. |

--- a/charts/nvidia-gpu-exporter/templates/daemonset.yaml
+++ b/charts/nvidia-gpu-exporter/templates/daemonset.yaml
@@ -78,14 +78,14 @@ spec:
               {{- if .Values.hostPort.enabled }}
               hostPort: {{ .Values.hostPort.port }}
               {{- end }}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/nvidia-gpu-exporter/values.schema.json
+++ b/charts/nvidia-gpu-exporter/values.schema.json
@@ -44,7 +44,7 @@
     },
     "telemetryPath": {
       "type": "string",
-      "pattern": "^/"
+      "pattern": "^/.*[^/]$"
     },
     "nvidiaSmiCommand": {
       "type": "string",
@@ -93,6 +93,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "livenessProbe": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "readinessProbe": {
+      "type": [
+        "object",
+        "null"
+      ]
     },
     "extraArgs": {
       "type": "array",

--- a/charts/nvidia-gpu-exporter/values.yaml
+++ b/charts/nvidia-gpu-exporter/values.yaml
@@ -54,6 +54,22 @@ log:
   # -- Log format: logfmt, json
   format: logfmt
 
+# -- Liveness probe for the exporter container. The default checks that the
+# process serves HTTP at all; it deliberately does not depend on collection
+# success, so a failing nvidia-smi keeps the pod scrapeable and the failure
+# visible in the metrics. Set to `null` to disable the probe.
+livenessProbe:
+  httpGet:
+    path: /-/healthy
+    port: http
+
+# -- Readiness probe for the exporter container, process-level like the
+# liveness probe. Set to `null` to disable the probe.
+readinessProbe:
+  httpGet:
+    path: /-/ready
+    port: http
+
 # -- Extra command line arguments for the exporter, e.g. `--collect.interval=30s`
 extraArgs: []
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -33,6 +33,19 @@ Flags:
                                 request when keep-alive is enabled.
       --web.telemetry-path="/metrics"
                                 Path under which to expose metrics.
+      --web.max-requests=40     Maximum number of concurrent scrapes of the
+                                metrics endpoint. Requests beyond the limit
+                                are answered with a 503 immediately instead of
+                                queueing up behind a slow collection. 0 disables
+                                the limit.
+      --web.timeout-offset=500ms
+                                Offset subtracted from the scrape
+                                timeout Prometheus advertises in the
+                                X-Prometheus-Scrape-Timeout-Seconds header,
+                                leaving time for the response to reach
+                                Prometheus. The advertised timeout minus this
+                                offset bounds each scrape's collection, on top
+                                of --collect.timeout.
       --nvidia-smi-command="nvidia-smi"
                                 Path or command to be used for the nvidia-smi
                                 executable. Multiple words run the first as the
@@ -147,31 +160,43 @@ cannot be excluded, since the rest of the metrics are labeled by GPU UUID.
 
 ## Background collection
 
-By default the exporter runs `nvidia-smi` once per scrape. If the exporter is
-scraped frequently or by several Prometheus servers at once, that means a lot
-of short-lived `nvidia-smi` processes.
+By default the exporter runs `nvidia-smi` once per scrape. Scrapes that
+arrive while a run is already in progress share that run and serve its
+result, so several Prometheus servers scraping the same exporter at once (a
+common HA setup) do not multiply the `nvidia-smi` runs. Frequent scraping
+still means frequent short-lived `nvidia-smi` processes, though.
 
-Setting `--collect.interval` decouples the two: `nvidia-smi` runs in the
-background at the given interval, and scrapes serve the most recent result.
-The number of `nvidia-smi` runs then depends only on the interval, no matter
-how often the exporter is scraped.
+Setting `--collect.interval` decouples the two completely: `nvidia-smi` runs
+in the background at the given interval, and scrapes serve the most recent
+result. The number of `nvidia-smi` runs then depends only on the interval, no
+matter how often the exporter is scraped.
 
 ```bash
 # Run nvidia-smi every 15 seconds regardless of scrape traffic
 nvidia_gpu_exporter --collect.interval 15s
 ```
 
-Two things to keep in mind in this mode:
+Things to keep in mind in this mode:
 
-- A served reading can be up to one interval old. Prometheus timestamps
-  samples at scrape time, so use `nvidia_smi_last_collect_success_timestamp_seconds`
-  to see how fresh the data actually is. A staleness alert should also cover
-  the case where no collection has succeeded yet, for example:
+- A served reading can be roughly one interval plus the duration of the
+  in-flight collection old, since a new snapshot is only published once its
+  collection completes. Prometheus timestamps samples at scrape time, so use
+  `nvidia_smi_last_collect_success_timestamp_seconds` to see how fresh the
+  data actually is. A staleness alert should budget a few intervals plus
+  `--collect.timeout`, so a single failed cycle does not fire it, and also
+  cover the case where no collection has succeeded yet. For example three
+  intervals plus the timeout, with a 15s interval and the default 10s
+  timeout:
 
   ```text
-  time() - nvidia_smi_last_collect_success_timestamp_seconds > 45
+  time() - nvidia_smi_last_collect_success_timestamp_seconds > 55
     or nvidia_smi_last_collect_success == 0
   ```
+
+- Scrapes never wait for a collection. A scrape arriving before the very
+  first collection completes is answered immediately with
+  `nvidia_smi_last_collect_success 0` and no GPU series; the GPU data appears
+  once the first successful collection completes.
 
 - When a background run fails, the GPU metrics disappear from the output until
   the next successful run instead of going stale silently.
@@ -193,12 +218,36 @@ best-effort: it reliably kills a normal `nvidia-smi`, but it cannot interrupt
 a process stuck in an uninterruptible kernel wait, and with a wrapper command
 (such as the SSH setup above) it only signals the wrapper itself.
 
-If you raise `--collect.timeout` in synchronous mode, keep it below
-`--web.write-timeout` and below the Prometheus `scrape_timeout`, otherwise
-a slow run fails at the HTTP or Prometheus layer first. Background mode is
-mostly unaffected since scrapes only read the cached result, with one
-exception: a scrape arriving before the very first collection completes
-waits for it, so it can take up to `--collect.timeout` once at startup.
+In synchronous mode, a scrape's collection is also bounded by the scrape
+itself: by the timeout Prometheus advertises for it (minus
+`--web.timeout-offset`, so the answer still reaches Prometheus in time) and
+by the scrape connection's lifetime. A collection that outlives its scrape
+this way is cancelled, and the scrape is answered with
+`nvidia_smi_last_collect_success 0` instead of data. So there is no need to
+keep `--collect.timeout` below the Prometheus `scrape_timeout` manually; if
+you raise it, just keep it below `--web.write-timeout`. The advertised
+timeout only comes from scrapers that send the header (Prometheus and its
+agents do); for anything else, only the connection lifetime and
+`--collect.timeout` bound the collection. Background mode is unaffected
+since scrapes only read the cached result.
+
+## Scrape concurrency
+
+The metrics endpoint serves at most `--web.max-requests` scrapes at once
+(default 40, 0 disables the limit). Scrapes beyond the limit are answered
+with a 503 immediately. Without the bound, scrapes piling up behind a slow or
+wedged collection would each hold a goroutine and a connection indefinitely,
+which is exactly the situation where the exporter should instead fail fast
+and stay otherwise responsive.
+
+## Health endpoints
+
+`/-/healthy` and `/-/ready` answer 200 as long as the exporter process is up
+and serving. Both are process-level on purpose: they do not depend on
+collection success, so a host whose `nvidia-smi` is failing stays scrapeable
+and the failure stays visible in the health metrics, instead of the target
+disappearing from scraping. The Helm chart's liveness and readiness probes
+use these endpoints.
 
 ## Per-process GPU metrics
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,7 +11,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"path"
+	"strconv"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/coreos/go-systemd/v22/activation"
@@ -34,28 +38,14 @@ import (
 
 const appName = "nvidia_gpu_exporter"
 
-const redirectPageTemplate = `<html lang="en">
-<head><title>Nvidia GPU Exporter</title></head>
-<body>
-<h1>Nvidia GPU Exporter</h1>
-<p><a href="%s">Metrics</a></p>%s
-</body>
-</html>
-`
+// scrapeTimeoutHeader is set by Prometheus on every scrape to advertise the
+// timeout it applies to it.
+const scrapeTimeoutHeader = "X-Prometheus-Scrape-Timeout-Seconds"
 
-const pprofLinksHTML = `
-<h2>Profiling</h2>
-<ul>
-<li><a href="/debug/pprof/">Index</a></li>
-<li><a href="/debug/pprof/goroutine">Goroutines</a></li>
-<li><a href="/debug/pprof/heap">Heap</a></li>
-<li><a href="/debug/pprof/threadcreate">Threads</a></li>
-<li><a href="/debug/pprof/block">Block</a></li>
-<li><a href="/debug/pprof/mutex">Mutex</a></li>
-<li><a href="/debug/pprof/profile">CPU Profile</a></li>
-<li><a href="/debug/pprof/trace">Trace</a></li>
-</ul>
-`
+// maxScrapeTimeoutSeconds caps the advertised scrape timeout the exporter
+// honors. Values beyond it are nonsensical (and would overflow the duration
+// conversion), so they are treated like a missing header.
+const maxScrapeTimeoutSeconds = 24 * 60 * 60
 
 // Options carries what the callers inject into a run beyond the command-line
 // arguments.
@@ -80,7 +70,7 @@ type Options struct {
 // Run wires up the exporter from the given command-line arguments and serves
 // metrics until ctx is cancelled.
 //
-//nolint:funlen
+//nolint:funlen,cyclop
 func Run(ctx context.Context, args []string, opts Options) error {
 	app := kingpin.New(appName, "")
 
@@ -107,6 +97,17 @@ func Run(ctx context.Context, args []string, opts Options) error {
 			Default("60s").Duration()
 		metricsPath = app.Flag("web.telemetry-path", "Path under which to expose metrics.").
 				Default("/metrics").String()
+		maxRequests = app.Flag("web.max-requests",
+			"Maximum number of concurrent scrapes of the metrics endpoint. Requests beyond "+
+				"the limit are answered with a 503 immediately instead of queueing up behind "+
+				"a slow collection. 0 disables the limit.").
+			Default("40").Int()
+		timeoutOffset = app.Flag("web.timeout-offset",
+			"Offset subtracted from the scrape timeout Prometheus advertises in the "+
+				scrapeTimeoutHeader+" header, leaving time for the response to reach "+
+				"Prometheus. The advertised timeout minus this offset bounds each scrape's "+
+				"collection, on top of --collect.timeout.").
+			Default("500ms").Duration()
 		nvidiaSmiCommand = app.Flag("nvidia-smi-command",
 			"Path or command to be used for the nvidia-smi executable. "+
 				"Multiple words run the first as the executable with the rest as its arguments "+
@@ -176,6 +177,10 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		return err
 	}
 
+	if err := validateWebFlags(*metricsPath, *maxRequests, *timeoutOffset); err != nil {
+		return err
+	}
+
 	if *collectBackend == backendNVML && *nvidiaSmiCommand != nvidiasmi.DefaultCommand {
 		// a custom command signals intent (ssh wrappers, sudo) the nvml
 		// backend cannot honor, so it is an error rather than a silent ignore
@@ -205,12 +210,20 @@ func Run(ctx context.Context, args []string, opts Options) error {
 
 	registry := prometheus.NewRegistry()
 
-	err := setupExporter(ctx, eg, collectCfg, registry, logger)
+	exp, err := setupExporter(ctx, eg, collectCfg, registry, logger)
 	if err != nil {
 		return err
 	}
 
-	mux := newServeMux(logger, *metricsPath, *enablePprof, registry)
+	mux, err := newServeMux(serveMuxConfig{
+		metricsPath:   *metricsPath,
+		enablePprof:   *enablePprof,
+		maxRequests:   *maxRequests,
+		timeoutOffset: *timeoutOffset,
+	}, registry, exp, logger)
+	if err != nil {
+		return err
+	}
 
 	srv := &http.Server{
 		ReadHeaderTimeout: *readHeaderTimeout,
@@ -218,6 +231,10 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		WriteTimeout:      *writeTimeout,
 		IdleTimeout:       *idleTimeout,
 		Handler:           mux,
+		// request contexts descend from the process context, so shutdown also
+		// cancels the collections running inside in-flight scrapes instead of
+		// waiting out the shutdown grace period behind them
+		BaseContext: func(net.Listener) context.Context { return ctx },
 	}
 
 	serveHTTP(ctx, eg, srv, webConfig, *network, opts.OnListen, logger)
@@ -287,6 +304,72 @@ func validateCollectFlags(interval, timeout time.Duration) error {
 	return nil
 }
 
+// validateWebFlags rejects the web flag values kingpin's types cannot.
+func validateWebFlags(metricsPath string, maxRequests int, timeoutOffset time.Duration) error {
+	if err := validateMetricsPath(metricsPath); err != nil {
+		return err
+	}
+
+	if maxRequests < 0 {
+		return fmt.Errorf("web.max-requests must not be negative, got %d", maxRequests)
+	}
+
+	if timeoutOffset < 0 {
+		return fmt.Errorf("web.timeout-offset must not be negative, got %s", timeoutOffset)
+	}
+
+	return nil
+}
+
+// reservedPaths are the routes the exporter owns, which the telemetry path
+// must not collide with. A trailing slash reserves the whole subtree, no
+// trailing slash reserves exactly that path. The pprof subtree is reserved
+// even in runs that do not enable pprof, so enabling it later cannot turn a
+// working configuration into a startup failure.
+var reservedPaths = []string{"/-/healthy", "/-/ready", "/debug/pprof/"}
+
+// validateMetricsPath rejects telemetry path values that would collide with
+// the exporter's own routes or make the route registration panic at startup.
+func validateMetricsPath(metricsPath string) error {
+	if err := validateMetricsPathShape(metricsPath); err != nil {
+		return err
+	}
+
+	for _, reserved := range reservedPaths {
+		subtree := strings.HasSuffix(reserved, "/")
+		if metricsPath == strings.TrimSuffix(reserved, "/") || (subtree && strings.HasPrefix(metricsPath, reserved)) {
+			return fmt.Errorf("web.telemetry-path %q collides with the exporter's own routes", metricsPath)
+		}
+	}
+
+	return nil
+}
+
+// validateMetricsPathShape rejects malformed telemetry path values. Escapes
+// and mux pattern syntax are rejected wholesale rather than interpreted: the
+// mux unescapes and parses patterns, so a value like "/-/%68ealthy" or
+// "/x{y}" is either a disguised collision or a route that can never be
+// matched the way it reads.
+func validateMetricsPathShape(metricsPath string) error {
+	switch {
+	case !strings.HasPrefix(metricsPath, "/"):
+		return fmt.Errorf("web.telemetry-path must start with a slash, got %q", metricsPath)
+	case metricsPath == "/":
+		return errors.New(`web.telemetry-path must not be "/", it would collide with the landing page`)
+	case strings.HasSuffix(metricsPath, "/"):
+		return fmt.Errorf("web.telemetry-path must not end with a slash, got %q", metricsPath)
+	case path.Clean(metricsPath) != metricsPath:
+		return fmt.Errorf("web.telemetry-path must be a clean path without empty or relative segments, got %q",
+			metricsPath)
+	case strings.ContainsAny(metricsPath, "{}%?#"):
+		return fmt.Errorf("web.telemetry-path must not contain the characters {}%%?#, got %q", metricsPath)
+	case strings.ContainsFunc(metricsPath, unicode.IsSpace):
+		return fmt.Errorf("web.telemetry-path must not contain whitespace, got %q", metricsPath)
+	default:
+		return nil
+	}
+}
+
 // Collection backend names, the values of --collect.backend.
 const (
 	backendExec = "exec"
@@ -314,18 +397,20 @@ type collectConfig struct {
 
 // setupExporter resolves the query fields, builds the collection source
 // (adding the background collector to the errgroup when an interval is set),
-// and registers the exporter on the given registry, along with the collectors
-// the default registry would carry.
+// and builds the exporter. The exporter itself is returned instead of
+// registered: the metrics handler collects it under each scrape's own
+// context, so it lives in a per-scrape registry there. The given registry
+// gets the collectors whose output is scrape-independent.
 func setupExporter(
 	ctx context.Context,
 	eg *errgroup.Group,
 	cfg collectConfig,
 	registry *prometheus.Registry,
 	logger *slog.Logger,
-) error {
+) (*exporter.GPUExporter, error) {
 	resolved, query, exitCodeMetric, err := setupBackend(ctx, eg, cfg, logger)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var src collect.Source
@@ -346,17 +431,16 @@ func setupExporter(
 	// the go and process collectors keep the exposed families identical to
 	// what the default registry used to serve
 	for _, collector := range []prometheus.Collector{
-		exp,
 		clientversion.NewCollector(appName),
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	} {
 		if err = registry.Register(collector); err != nil {
-			return fmt.Errorf("failed to register collector: %w", err)
+			return nil, fmt.Errorf("failed to register collector: %w", err)
 		}
 	}
 
-	return nil
+	return exp, nil
 }
 
 // setupBackend resolves the query fields and builds the collection function
@@ -452,51 +536,167 @@ func buildQueryFunc(
 	}
 }
 
-type RootHandler struct {
-	response []byte
-	logger   *slog.Logger
+// serveMuxConfig carries the web flags into the mux construction.
+type serveMuxConfig struct {
+	metricsPath   string
+	enablePprof   bool
+	maxRequests   int
+	timeoutOffset time.Duration
 }
 
-func NewRootHandler(logger *slog.Logger, metricsPath string, enablePprof bool) *RootHandler {
-	pprofLinks := ""
-	if enablePprof {
-		pprofLinks = pprofLinksHTML
-	}
-
-	return &RootHandler{
-		response: fmt.Appendf(nil, redirectPageTemplate, metricsPath, pprofLinks),
-		logger:   logger,
-	}
-}
-
-func (r *RootHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	if _, err := w.Write(r.response); err != nil {
-		r.logger.Error("failed to write redirect", "err", err)
-	}
-}
-
-// newServeMux builds the HTTP mux serving the root page, metrics and
-// optionally pprof. The metrics handler is instrumented the same way the
-// default promhttp handler is, so the promhttp_* families stay exposed.
+// newServeMux builds the HTTP mux: the landing page on exactly the root path
+// (anything unknown is a 404), the metrics endpoint, the health endpoints and
+// optionally pprof.
 func newServeMux(
-	logger *slog.Logger,
-	metricsPath string,
-	enablePprof bool,
+	cfg serveMuxConfig,
 	registry *prometheus.Registry,
-) *http.ServeMux {
+	exp *exporter.GPUExporter,
+	logger *slog.Logger,
+) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 
-	rootHandler := NewRootHandler(logger, metricsPath, enablePprof)
-	mux.Handle("GET /", rootHandler)
-	mux.Handle("GET "+metricsPath,
-		promhttp.InstrumentMetricHandler(registry, promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
+	landingPage, err := web.NewLandingPage(web.LandingConfig{
+		Name:        "Nvidia GPU Exporter",
+		Description: "Prometheus exporter for Nvidia GPUs, using nvidia-smi.",
+		Version:     version.Info(),
+		Links: []web.LandingLinks{
+			{Address: cfg.metricsPath, Text: "Metrics"},
+		},
+		Profiling: strconv.FormatBool(cfg.enablePprof),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the landing page: %w", err)
+	}
 
-	if enablePprof {
+	mux.Handle("GET /{$}", landingPage)
+	mux.Handle("GET "+cfg.metricsPath, newMetricsHandler(cfg, registry, exp, logger))
+
+	// process-level health checks: reachable means healthy. Deliberately
+	// independent of collection success, a host whose nvidia-smi is failing
+	// must stay scrapeable so the health metrics can report the failure.
+	mux.HandleFunc("GET /-/healthy", healthHandler("Healthy"))
+	mux.HandleFunc("GET /-/ready", healthHandler("Ready"))
+
+	if cfg.enablePprof {
 		logger.Info("pprof endpoints enabled")
 		registerPprof(mux)
 	}
 
-	return mux
+	return mux, nil
+}
+
+// newMetricsHandler builds the metrics endpoint. Each scrape gathers the
+// exporter under the scrape's own context through a per-scrape registry,
+// since the collector interface has no context of its own; the collectors
+// whose output is scrape-independent live in the shared registry, which also
+// carries the promhttp instrumentation and error counter so the handler's
+// own health stays visible in the output.
+func newMetricsHandler(
+	cfg serveMuxConfig,
+	registry *prometheus.Registry,
+	exp *exporter.GPUExporter,
+	logger *slog.Logger,
+) http.Handler {
+	opts := promhttp.HandlerOpts{
+		ErrorLog:      promhttpLogger{logger: logger},
+		ErrorHandling: promhttp.HTTPErrorOnError,
+		Registry:      registry,
+	}
+
+	// the scrape context is derived from the request context, the linter just
+	// cannot see it through the helper
+	//nolint:contextcheck
+	handler := http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		ctx, cancel := scrapeContext(req, cfg.timeoutOffset)
+		defer cancel()
+
+		scrapeRegistry := prometheus.NewRegistry()
+		if err := scrapeRegistry.Register(exp.WithContext(ctx)); err != nil {
+			logger.Error("failed to register the exporter for a scrape", "err", err)
+			http.Error(writer, "failed to register the exporter", http.StatusInternalServerError)
+
+			return
+		}
+
+		// the scrape deadline travels through the context-scoped collector;
+		// stamping it onto the request as well is defensive (promhttp does
+		// not currently read the request context)
+		promhttp.HandlerFor(prometheus.Gatherers{registry, scrapeRegistry}, opts).
+			ServeHTTP(writer, req.WithContext(ctx))
+	})
+
+	return promhttp.InstrumentMetricHandler(registry, limitConcurrency(handler, cfg.maxRequests, logger))
+}
+
+// scrapeContext bounds a scrape by the timeout Prometheus advertises for it,
+// minus the configured offset, on top of the request's own lifetime (which
+// already ends on client disconnect). A missing, malformed or too-small
+// advertised value adds no deadline, leaving the collection timeout as the
+// only bound, so a bad header can never make things stricter than no header.
+func scrapeContext(req *http.Request, offset time.Duration) (context.Context, context.CancelFunc) {
+	raw := req.Header.Get(scrapeTimeoutHeader)
+	if raw == "" {
+		return req.Context(), func() {}
+	}
+
+	seconds, err := strconv.ParseFloat(raw, 64)
+	if err != nil || !(seconds > 0) || seconds > maxScrapeTimeoutSeconds {
+		return req.Context(), func() {}
+	}
+
+	timeout := time.Duration(seconds*float64(time.Second)) - offset
+	if timeout <= 0 {
+		return req.Context(), func() {}
+	}
+
+	return context.WithTimeout(req.Context(), timeout)
+}
+
+// limitConcurrency bounds the number of scrapes served at once, so overload
+// (scrapes piling up behind a slow or wedged collection) turns into immediate
+// 503s instead of an unbounded queue of goroutines and connections.
+func limitConcurrency(next http.Handler, limit int, logger *slog.Logger) http.Handler {
+	if limit <= 0 {
+		return next
+	}
+
+	slots := make(chan struct{}, limit)
+
+	return http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		select {
+		case slots <- struct{}{}:
+			defer func() { <-slots }()
+
+			next.ServeHTTP(writer, req)
+		default:
+			logger.Warn("refused a scrape: concurrent request limit reached", "limit", limit)
+			http.Error(writer, fmt.Sprintf("limit of %d concurrent requests reached, try again later", limit),
+				http.StatusServiceUnavailable)
+		}
+	})
+}
+
+// healthHandler answers a health endpoint. The check is process-level: being
+// served at all is what it reports.
+func healthHandler(status string) http.HandlerFunc {
+	body := []byte("Nvidia GPU Exporter is " + status + ".\n")
+
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+		_, _ = w.Write(body)
+	}
+}
+
+// promhttpLogger adapts the exporter's logger to the promhttp error log
+// interface, so errors gathering or encoding the metrics land in the
+// exporter's own logs instead of vanishing.
+type promhttpLogger struct {
+	logger *slog.Logger
+}
+
+func (l promhttpLogger) Println(v ...any) {
+	l.logger.Error(strings.TrimSuffix(fmt.Sprintln(v...), "\n"))
 }
 
 // registerPprof wires up the net/http/pprof handlers on the given mux.

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMetricsPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path    string
+		wantErr bool
+	}{
+		{path: "/metrics", wantErr: false},
+		{path: "/some/nested/path", wantErr: false},
+		{path: "/-/metrics", wantErr: false},
+		// prefixes of reserved routes that are not the routes themselves are fine
+		{path: "/-/healthy-metrics", wantErr: false},
+		{path: "/debug/pprofile", wantErr: false},
+		{path: "metrics", wantErr: true},
+		{path: "", wantErr: true},
+		{path: "/", wantErr: true},
+		{path: "/metrics/", wantErr: true},
+		{path: "/metrics{a}", wantErr: true},
+		{path: "/met rics", wantErr: true},
+		{path: "/met\trics", wantErr: true},
+		// unclean paths would panic the mux registration as unmatchable
+		{path: "//metrics", wantErr: true},
+		{path: "/foo/../metrics", wantErr: true},
+		{path: "/./metrics", wantErr: true},
+		// escapes could disguise a collision (this one unescapes to /-/healthy)
+		{path: "/-/%68ealthy", wantErr: true},
+		// query and fragment characters would register a route that can never
+		// be reached the way it reads
+		{path: "/metrics?x=1", wantErr: true},
+		{path: "/metrics#frag", wantErr: true},
+		{path: "/-/healthy", wantErr: true},
+		{path: "/-/ready", wantErr: true},
+		{path: "/debug/pprof", wantErr: true},
+		{path: "/debug/pprof/heap", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateMetricsPath(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+//nolint:funlen // a table of header cases, long but flat
+func TestScrapeContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		header       string
+		offset       time.Duration
+		wantDeadline bool
+		// wantTimeout is the expected remaining time when a deadline is set,
+		// asserted loosely to stay clock-safe
+		wantTimeout time.Duration
+	}{
+		{name: "no header means no deadline", header: "", wantDeadline: false},
+		{name: "malformed header means no deadline", header: "not-a-number", wantDeadline: false},
+		{name: "zero means no deadline", header: "0", wantDeadline: false},
+		{name: "negative means no deadline", header: "-5", wantDeadline: false},
+		{name: "nan means no deadline", header: "NaN", wantDeadline: false},
+		{name: "absurdly large means no deadline", header: "1e30", wantDeadline: false},
+		{
+			name:         "smaller than the offset means no deadline",
+			header:       "0.2",
+			offset:       500 * time.Millisecond,
+			wantDeadline: false,
+		},
+		{
+			name:         "equal to the offset means no deadline",
+			header:       "0.5",
+			offset:       500 * time.Millisecond,
+			wantDeadline: false,
+		},
+		{
+			name:         "normal value sets a deadline",
+			header:       "10",
+			offset:       500 * time.Millisecond,
+			wantDeadline: true,
+			wantTimeout:  9500 * time.Millisecond,
+		},
+		{
+			name:         "fractional value sets a deadline",
+			header:       "2.5",
+			offset:       500 * time.Millisecond,
+			wantDeadline: true,
+			wantTimeout:  2 * time.Second,
+		},
+		{
+			name:         "zero offset uses the full advertised timeout",
+			header:       "3",
+			offset:       0,
+			wantDeadline: true,
+			wantTimeout:  3 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+			if tt.header != "" {
+				req.Header.Set(scrapeTimeoutHeader, tt.header)
+			}
+
+			start := time.Now()
+
+			ctx, cancel := scrapeContext(req, tt.offset)
+			defer cancel()
+
+			deadline, hasDeadline := ctx.Deadline()
+			require.Equal(t, tt.wantDeadline, hasDeadline)
+
+			if tt.wantDeadline {
+				remaining := time.Until(deadline) + time.Since(start)
+				assert.InDelta(t, tt.wantTimeout.Seconds(), remaining.Seconds(), 0.2)
+			}
+		})
+	}
+}

--- a/internal/collect/cached.go
+++ b/internal/collect/cached.go
@@ -20,7 +20,6 @@ type Cached struct {
 	logger   *slog.Logger
 
 	cur     atomic.Pointer[Snapshot]
-	ready   chan struct{}
 	started atomic.Bool // Run is single-use; protects the one-collection-in-flight invariant
 
 	// owned solely by the Run goroutine
@@ -45,7 +44,6 @@ func NewCached(
 		timeout:  timeout,
 		onFatal:  onFatal,
 		logger:   logger,
-		ready:    make(chan struct{}),
 	}
 }
 
@@ -58,7 +56,6 @@ func (s *Cached) Run(ctx context.Context) error {
 	}
 
 	s.tick(ctx)
-	close(s.ready) // single-use Run means exactly one close
 
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
@@ -73,17 +70,13 @@ func (s *Cached) Run(ctx context.Context) error {
 	}
 }
 
-// Latest returns the most recent outcome. A call racing the very first
-// collection blocks until that collection completes, bounded by the
-// collection timeout that bounds the first run (and by ctx). If no outcome
-// is available yet, the returned snapshot reports not-ready: not attempted,
-// not successful, no data.
-func (s *Cached) Latest(ctx context.Context) Snapshot {
-	select {
-	case <-s.ready:
-	case <-ctx.Done():
-	}
-
+// Latest returns the most recent outcome, never blocking on collection: a
+// wedged nvidia-smi must not take the metrics endpoint down with it, since
+// the health metrics served here are exactly what explains the situation.
+// Until the first collection completes, the returned snapshot reports
+// not-ready: not attempted, not successful, no data. The data appears once
+// the first successful collection completes.
+func (s *Cached) Latest(_ context.Context) Snapshot {
 	if snapshot := s.cur.Load(); snapshot != nil {
 		return *snapshot
 	}
@@ -95,6 +88,7 @@ func (s *Cached) Latest(ctx context.Context) Snapshot {
 // is immutable: it is never modified after Store, which is what makes the
 // lock-free reads in Latest safe.
 func (s *Cached) tick(ctx context.Context) {
-	snapshot := collectOnce(ctx, s.query, s.timeout, s.onFatal, s.logger, &s.failures, &s.lastOK)
+	snapshot := collectOnce(ctx, s.query, s.timeout, s.onFatal, s.logger)
+	foldCumulative(&snapshot, &s.failures, &s.lastOK)
 	s.cur.Store(&snapshot)
 }

--- a/internal/collect/cached_test.go
+++ b/internal/collect/cached_test.go
@@ -14,6 +14,23 @@ import (
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
 )
 
+// awaitFirstCollection waits until the source has a first outcome to serve:
+// reads never block on collection, so tests interested in a collection's
+// outcome have to poll for it.
+func awaitFirstCollection(t *testing.T, cached *collect.Cached) collect.Snapshot {
+	t.Helper()
+
+	var snapshot collect.Snapshot
+
+	require.Eventually(t, func() bool {
+		snapshot = cached.Latest(t.Context())
+
+		return snapshot.Attempted
+	}, 5*time.Second, time.Millisecond)
+
+	return snapshot
+}
+
 // startCached runs the source in the background and stops it on test cleanup.
 func startCached(t *testing.T, cached *collect.Cached) {
 	t.Helper()
@@ -47,6 +64,7 @@ func TestCachedServesCacheWithoutRecollecting(t *testing.T) {
 
 	cached := collect.NewCached(query, time.Hour, 0, nil, slogt.New(t))
 	startCached(t, cached)
+	awaitFirstCollection(t, cached)
 
 	for range 5 {
 		snapshot := cached.Latest(t.Context())
@@ -68,7 +86,7 @@ func TestCachedFailureDropsTableAndCountsOnce(t *testing.T) {
 	cached := collect.NewCached(query, time.Hour, 0, nil, slogt.New(t))
 	startCached(t, cached)
 
-	first := cached.Latest(t.Context())
+	first := awaitFirstCollection(t, cached)
 	second := cached.Latest(t.Context())
 
 	assert.True(t, first.Attempted)
@@ -99,7 +117,7 @@ func TestCachedCollectsOnTicks(t *testing.T) {
 	}, 5*time.Second, time.Millisecond)
 }
 
-func TestCachedFirstScrapeBlocksUntilFirstCollection(t *testing.T) {
+func TestCachedFirstScrapeServesNotReadyImmediately(t *testing.T) {
 	t.Parallel()
 
 	release := make(chan struct{})
@@ -112,33 +130,32 @@ func TestCachedFirstScrapeBlocksUntilFirstCollection(t *testing.T) {
 		}
 	}
 
-	cached := collect.NewCached(query, time.Hour, 0, nil, slogt.New(t))
+	cached := collect.NewCached(query, time.Millisecond, 0, nil, slogt.New(t))
 	startCached(t, cached)
 
-	got := make(chan collect.Snapshot, 1)
+	// the first collection is in flight; a read must not wait for it and must
+	// report the not-yet-collected state instead
+	snapshot := cached.Latest(t.Context())
 
-	go func() {
-		got <- cached.Latest(t.Context())
-	}()
-
-	// the reader must be blocked while the first collection is in flight
-	select {
-	case <-got:
-		t.Fatal("Latest returned before the first collection completed")
-	case <-time.After(50 * time.Millisecond):
-	}
+	assert.False(t, snapshot.Attempted)
+	assert.False(t, snapshot.Success)
+	assert.Nil(t, snapshot.Table)
+	assert.Equal(t, uint64(0), snapshot.Failures)
 
 	close(release)
 
-	snapshot := <-got
-	assert.True(t, snapshot.Success)
+	assert.Eventually(t, func() bool {
+		return cached.Latest(t.Context()).Success
+	}, 5*time.Second, time.Millisecond)
 }
 
-func TestCachedNotReadyWhenScrapeWinsTheRace(t *testing.T) {
+func TestCachedNeverBlocksOnWedgedCollection(t *testing.T) {
 	t.Parallel()
 
 	query := func(ctx context.Context) (collect.Reading, int, error) {
-		// never completes on its own; unblocked only by shutdown cancellation
+		// never completes on its own; unblocked only by shutdown cancellation.
+		// with a zero collection timeout this simulates an nvidia-smi stuck in
+		// an uninterruptible wait
 		<-ctx.Done()
 
 		return collect.Reading{}, -1, ctx.Err()
@@ -147,12 +164,10 @@ func TestCachedNotReadyWhenScrapeWinsTheRace(t *testing.T) {
 	cached := collect.NewCached(query, time.Hour, 0, nil, slogt.New(t))
 	startCached(t, cached)
 
-	// the reader gives up before the first collection completes
-	readCtx, readCancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
-	defer readCancel()
+	start := time.Now()
+	snapshot := cached.Latest(t.Context())
 
-	snapshot := cached.Latest(readCtx)
-
+	assert.Less(t, time.Since(start), 5*time.Second)
 	assert.False(t, snapshot.Attempted)
 	assert.False(t, snapshot.Success)
 	assert.Nil(t, snapshot.Table)
@@ -166,7 +181,7 @@ func TestCachedRunIsSingleUse(t *testing.T) {
 	startCached(t, cached)
 
 	// wait until the first Run is up and serving
-	snapshot := cached.Latest(t.Context())
+	snapshot := awaitFirstCollection(t, cached)
 	require.True(t, snapshot.Success)
 
 	require.Error(t, cached.Run(t.Context()))
@@ -185,7 +200,9 @@ func TestCachedRunStopsOnCancel(t *testing.T) {
 		done <- cached.Run(ctx)
 	}()
 
-	require.True(t, cached.Latest(ctx).Success)
+	require.Eventually(t, func() bool {
+		return cached.Latest(ctx).Success
+	}, 5*time.Second, time.Millisecond)
 
 	cancel()
 
@@ -209,7 +226,7 @@ func TestCachedTimeoutBoundsCollection(t *testing.T) {
 	cached := collect.NewCached(query, time.Hour, 50*time.Millisecond, nil, slogt.New(t))
 	startCached(t, cached)
 
-	snapshot := cached.Latest(t.Context())
+	snapshot := awaitFirstCollection(t, cached)
 
 	assert.True(t, snapshot.Attempted)
 	assert.False(t, snapshot.Success)
@@ -227,6 +244,7 @@ func TestCachedConcurrentReadsDuringCollections(t *testing.T) {
 		slogt.New(t),
 	)
 	startCached(t, cached)
+	awaitFirstCollection(t, cached)
 
 	done := make(chan struct{})
 

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -95,20 +95,19 @@ func (e *FatalError) Unwrap() error {
 	return e.Err
 }
 
-// collectOnce runs one collection bounded by timeout and folds the outcome
-// into a Snapshot, updating the cumulative failure count and last-success
-// time owned by the caller. A failed attempt is logged here, exactly once,
-// so failures are neither logged per scrape nor lost. The onFatal callback
-// implements shutdown-on-error: it fires only on a genuine non-zero exit of
-// the command, not on a timeout the collector caused itself.
+// collectOnce runs one collection bounded by timeout and returns the outcome
+// as a Snapshot with the cumulative fields (Failures, LastSuccess) not yet
+// folded in: that is the caller's job, via foldCumulative, under whatever
+// synchronization owns those counters. A failed attempt is logged here,
+// exactly once, so failures are neither logged per scrape nor lost. The
+// onFatal callback implements shutdown-on-error: it fires only on a genuine
+// non-zero exit of the command, not on a timeout the collector caused itself.
 func collectOnce(
 	ctx context.Context,
 	query QueryFunc,
 	timeout time.Duration,
 	onFatal func(error),
 	logger *slog.Logger,
-	failures *uint64,
-	lastOK *time.Time,
 ) Snapshot {
 	callCtx, cancel := withOptionalTimeout(ctx, timeout)
 	defer cancel()
@@ -125,14 +124,7 @@ func collectOnce(
 	}
 
 	if err != nil {
-		*failures++
-
 		logger.Error("failed to collect metrics", "err", err)
-
-		snapshot.Success = false
-		snapshot.Table = nil
-		snapshot.LastSuccess = *lastOK
-		snapshot.Failures = *failures
 
 		var exitErr *exec.ExitError
 
@@ -153,17 +145,28 @@ func collectOnce(
 		logger.Warn("failed to collect per-process data", "err", reading.AppsErr)
 	}
 
-	*lastOK = now
-
 	snapshot.Success = true
 	snapshot.Table = reading.Table
 	snapshot.Apps = reading.Apps
 	snapshot.AppsAttempted = reading.AppsAttempted
 	snapshot.AppsSuccess = reading.AppsSuccess
 	snapshot.LastSuccess = now
-	snapshot.Failures = *failures
 
 	return snapshot
+}
+
+// foldCumulative merges one collection outcome into the cumulative failure
+// count and last-success time, and stamps the updated values onto the
+// snapshot. The caller owns the synchronization of the two counters.
+func foldCumulative(snapshot *Snapshot, failures *uint64, lastOK *time.Time) {
+	if snapshot.Success {
+		*lastOK = snapshot.LastSuccess
+	} else {
+		*failures++
+	}
+
+	snapshot.Failures = *failures
+	snapshot.LastSuccess = *lastOK
 }
 
 // withOptionalTimeout bounds ctx by d, where a zero d means no bound. A plain

--- a/internal/collect/live.go
+++ b/internal/collect/live.go
@@ -7,19 +7,33 @@ import (
 	"time"
 )
 
-// Live collects synchronously: every Latest call runs nvidia-smi inline.
-// Concurrent calls are serialized so simultaneous scrapes never launch
-// multiple nvidia-smi processes at once, matching the exporter's historical
-// behavior.
+// Live collects synchronously: a Latest call runs nvidia-smi inline. Calls
+// arriving while a collection is already running do not queue their own runs;
+// they wait for the in-flight one and serve its result, so the number of
+// nvidia-smi runs is independent of how many scrapers hit the exporter at
+// once. The run is bounded by the collection timeout and by its waiters: a
+// single caller giving up does not disturb the others, but a run nobody waits
+// for anymore is cancelled.
 type Live struct {
 	query   QueryFunc
 	timeout time.Duration
 	onFatal func(error)
 	logger  *slog.Logger
 
-	mu       sync.Mutex // serializes collections and guards the fields below
+	mu       sync.Mutex // guards the fields below
+	inflight *flight
 	failures uint64
 	lastOK   time.Time
+}
+
+// flight is one shared collection run. Waiters block on done and read the
+// snapshot only after it is closed; the snapshot is written exactly once,
+// before the close.
+type flight struct {
+	done     chan struct{}
+	cancel   context.CancelFunc
+	waiters  int
+	snapshot Snapshot
 }
 
 // NewLive returns a synchronous source. A zero timeout leaves collections
@@ -33,10 +47,103 @@ func NewLive(query QueryFunc, timeout time.Duration, onFatal func(error), logger
 	}
 }
 
-// Latest runs one collection and returns its outcome.
+// Latest returns the outcome of a collection running during the call: the
+// in-flight one when there is one, a fresh run otherwise. When ctx ends
+// before the collection does, it returns a no-data snapshot carrying the
+// cumulative health state instead, so a scrape on a deadline still reports
+// something truthful.
 func (s *Live) Latest(ctx context.Context) Snapshot {
+	if ctx.Err() != nil {
+		return s.noResult()
+	}
+
+	shared := s.join(ctx)
+
+	select {
+	case <-shared.done:
+		return shared.snapshot
+	case <-ctx.Done():
+		s.leave(shared)
+
+		// the run may have completed in the meantime; prefer its result over
+		// reporting nothing
+		select {
+		case <-shared.done:
+			return shared.snapshot
+		default:
+			return s.noResult()
+		}
+	}
+}
+
+// join registers the caller as a waiter on the in-flight run, starting one
+// when idle.
+func (s *Live) join(ctx context.Context) *flight {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return collectOnce(ctx, s.query, s.timeout, s.onFatal, s.logger, &s.failures, &s.lastOK)
+	if s.inflight == nil {
+		// the run is shared, so its lifetime must not be tied to any single
+		// waiter's context: it is cancelled when its last waiter leaves
+		runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+		s.inflight = &flight{done: make(chan struct{}), cancel: cancel}
+
+		go s.run(runCtx, s.inflight)
+	}
+
+	s.inflight.waiters++
+
+	return s.inflight
+}
+
+// leave unregisters a waiter that gave up on the run; the last one out
+// cancels it and takes it out of the joinable slot, so the next scrape
+// starts a fresh run instead of inheriting the cancellation. That fresh run
+// can briefly overlap the abandoned one while it unwinds; the abandoned
+// process is already being killed at that point, and the cumulative counters
+// are only ever updated under the lock, so the overlap is safe. An unkillable
+// abandoned run (a wedged driver call, an nvidia-smi stuck in the kernel)
+// thus cannot poison later scrapes.
+func (s *Live) leave(shared *flight) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	shared.waiters--
+
+	if shared.waiters == 0 && s.inflight == shared {
+		shared.cancel()
+
+		s.inflight = nil
+	}
+}
+
+// run performs the collection and publishes the outcome. The fold into the
+// cumulative counters, the release of the joinable slot and the publication
+// happen as one locked transition, so a waiter deciding between the result
+// and noResult (in leave) never observes them half-done.
+func (s *Live) run(ctx context.Context, shared *flight) {
+	defer shared.cancel()
+
+	snapshot := collectOnce(ctx, s.query, s.timeout, s.onFatal, s.logger)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	foldCumulative(&snapshot, &s.failures, &s.lastOK)
+
+	if s.inflight == shared {
+		s.inflight = nil
+	}
+
+	shared.snapshot = snapshot
+	close(shared.done)
+}
+
+// noResult is what a caller that could not get a collection outcome serves:
+// no data, no attempt, with the cumulative health state carried over.
+func (s *Live) noResult() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return Snapshot{Failures: s.failures, LastSuccess: s.lastOK}
 }

--- a/internal/collect/live_test.go
+++ b/internal/collect/live_test.go
@@ -253,6 +253,267 @@ func TestLiveAppsSuccessCarriesApps(t *testing.T) {
 	assert.Equal(t, apps, snapshot.Apps)
 }
 
+func TestLiveConcurrentCallsShareOneRun(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	table := &nvidiasmi.Table{}
+	firstIn := make(chan struct{}, 1)
+	release := make(chan struct{})
+	query := func(_ context.Context) (collect.Reading, int, error) {
+		calls.Add(1)
+
+		select {
+		case firstIn <- struct{}{}:
+		default:
+		}
+
+		<-release
+
+		return collect.Reading{Table: table}, 0, nil
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	got := make(chan collect.Snapshot, 3)
+
+	for range 3 {
+		go func() {
+			got <- live.Latest(t.Context())
+		}()
+	}
+
+	// one run is now in flight and holding; give the other callers time to
+	// join it as waiters instead of queueing their own runs
+	<-firstIn
+	time.Sleep(100 * time.Millisecond)
+
+	close(release)
+
+	for range 3 {
+		snapshot := <-got
+
+		assert.True(t, snapshot.Success)
+		assert.Same(t, table, snapshot.Table)
+	}
+
+	assert.Equal(t, int32(1), calls.Load(), "concurrent scrapes must share a single run")
+}
+
+func TestLiveFailedSharedRunCountsOnce(t *testing.T) {
+	t.Parallel()
+
+	firstIn := make(chan struct{}, 1)
+	release := make(chan struct{})
+	query := func(_ context.Context) (collect.Reading, int, error) {
+		select {
+		case firstIn <- struct{}{}:
+		default:
+		}
+
+		<-release
+
+		return collect.Reading{}, -1, errQueryFailed
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	got := make(chan collect.Snapshot, 3)
+
+	for range 3 {
+		go func() {
+			got <- live.Latest(t.Context())
+		}()
+	}
+
+	<-firstIn
+	time.Sleep(100 * time.Millisecond)
+
+	close(release)
+
+	for range 3 {
+		snapshot := <-got
+
+		assert.False(t, snapshot.Success)
+		assert.Equal(t, uint64(1), snapshot.Failures, "a failed shared run must count as one failure")
+	}
+}
+
+func TestLiveDepartingWaiterDoesNotCancelSharedRun(t *testing.T) {
+	t.Parallel()
+
+	table := &nvidiasmi.Table{}
+	firstIn := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	var runCtxAlive atomic.Bool
+
+	query := func(ctx context.Context) (collect.Reading, int, error) {
+		select {
+		case firstIn <- struct{}{}:
+		default:
+		}
+
+		<-release
+
+		runCtxAlive.Store(ctx.Err() == nil)
+
+		return collect.Reading{Table: table}, 0, nil
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	staying := make(chan collect.Snapshot, 1)
+
+	go func() {
+		staying <- live.Latest(t.Context())
+	}()
+
+	<-firstIn
+
+	// a second waiter joins the same run and then gives up
+	leaveCtx, leaveCancel := context.WithCancel(t.Context())
+
+	leaving := make(chan collect.Snapshot, 1)
+
+	go func() {
+		leaving <- live.Latest(leaveCtx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	leaveCancel()
+
+	// the departing waiter serves the no-result state right away
+	left := <-leaving
+	assert.False(t, left.Attempted)
+	assert.Nil(t, left.Table)
+	assert.Equal(t, uint64(0), left.Failures)
+
+	close(release)
+
+	// the remaining waiter still gets the run's result, from a run that was
+	// never cancelled
+	stayed := <-staying
+	assert.True(t, stayed.Success)
+	assert.Same(t, table, stayed.Table)
+	assert.True(t, runCtxAlive.Load(), "the run must not be cancelled while a waiter remains")
+}
+
+func TestLiveRunWithoutWaitersIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{}, 1)
+	query := func(ctx context.Context) (collect.Reading, int, error) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+
+		// completes only through cancellation
+		<-ctx.Done()
+
+		return collect.Reading{}, -1, ctx.Err()
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	got := make(chan collect.Snapshot, 1)
+
+	go func() {
+		got <- live.Latest(ctx)
+	}()
+
+	<-entered
+	cancel()
+
+	// the sole waiter leaves with the no-result state
+	snapshot := <-got
+	assert.False(t, snapshot.Attempted)
+	assert.Nil(t, snapshot.Table)
+
+	// its departure cancels the run, which lands as exactly one failure. The
+	// probe context is already cancelled so the probes read the health state
+	// without starting runs of their own.
+	probeCtx, probeCancel := context.WithCancel(t.Context())
+	probeCancel()
+
+	assert.Eventually(t, func() bool {
+		return live.Latest(probeCtx).Failures == 1
+	}, 5*time.Second, time.Millisecond)
+}
+
+func TestLiveScrapeAfterAbandonedRunStartsFresh(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	firstEntered := make(chan struct{})
+	unwindRelease := make(chan struct{})
+
+	t.Cleanup(func() { close(unwindRelease) })
+
+	// the first run hangs until cancelled and then unwinds slowly, like a
+	// killed process that takes a while to reap; later runs succeed
+	query := func(ctx context.Context) (collect.Reading, int, error) {
+		if calls.Add(1) == 1 {
+			close(firstEntered)
+			<-ctx.Done()
+			<-unwindRelease
+
+			return collect.Reading{}, -1, ctx.Err()
+		}
+
+		return collect.Reading{Table: &nvidiasmi.Table{}}, 0, nil
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	got := make(chan collect.Snapshot, 1)
+
+	go func() {
+		got <- live.Latest(ctx)
+	}()
+
+	<-firstEntered
+	cancel()
+	<-got
+
+	// the abandoned run is still unwinding; a new scrape must get a fresh
+	// run instead of inheriting the cancellation
+	snapshot := live.Latest(t.Context())
+
+	assert.True(t, snapshot.Success)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestLiveAlreadyCancelledContextRunsNothing(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	query := func(_ context.Context) (collect.Reading, int, error) {
+		calls.Add(1)
+
+		return collect.Reading{Table: &nvidiasmi.Table{}}, 0, nil
+	}
+
+	live := collect.NewLive(query, 0, nil, slogt.New(t))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	snapshot := live.Latest(ctx)
+
+	assert.False(t, snapshot.Attempted)
+	assert.Nil(t, snapshot.Table)
+	assert.Equal(t, int32(0), calls.Load(), "a dead scrape must not start a run")
+}
+
 func TestLiveSerializesConcurrentCalls(t *testing.T) {
 	t.Parallel()
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -162,6 +162,18 @@ func newComputeAppDescs(
 	return info, memory, count, success
 }
 
+// WithContext returns a collector that renders the same metrics but bounds
+// its collection by the given context. The HTTP handler uses it to bound each
+// scrape's collection by the scrape's own lifetime. The copy shares all
+// state with the original; only the context differs, and everything shared is
+// immutable after construction or owns its own synchronization.
+func (e *GPUExporter) WithContext(ctx context.Context) *GPUExporter {
+	scoped := *e
+	scoped.ctx = ctx
+
+	return &scoped
+}
+
 // Describe describes all the metrics ever exported by the exporter. It
 // implements prometheus.Collector.
 func (e *GPUExporter) Describe(descCh chan<- *prometheus.Desc) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -124,27 +124,42 @@ func startExporter(t *testing.T, args ...string) string {
 	return ""
 }
 
-// scrape fetches the metrics page.
-func scrape(t *testing.T, baseURL string) string {
+// httpGet fetches a URL and returns the status code and body, with optional
+// header key-value pairs.
+func httpGet(t *testing.T, url string, headers ...string) (int, string) {
 	t.Helper()
+
+	require.Zero(t, len(headers)%2, "headers must be key/value pairs")
 
 	ctx, cancel := context.WithTimeout(t.Context(), startupTimeout)
 	t.Cleanup(cancel)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
+
+	for i := 0; i+1 < len(headers); i += 2 {
+		req.Header.Set(headers[i], headers[i+1])
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	return string(body)
+	return resp.StatusCode, string(body)
+}
+
+// scrape fetches the metrics page.
+func scrape(t *testing.T, baseURL string) string {
+	t.Helper()
+
+	status, body := httpGet(t, baseURL+"/metrics")
+	require.Equal(t, http.StatusOK, status)
+
+	return body
 }
 
 // familyName extracts the metric family a text-exposition line belongs to,
@@ -443,7 +458,9 @@ func TestGPURecoveryActionBadState(t *testing.T) {
 }
 
 // TestCachedModeMatchesLive proves background collection serves the same
-// deterministic content as the synchronous mode, pinned by the same expected output file.
+// deterministic content as the synchronous mode, pinned by the same expected
+// output file. Scrapes do not wait for the first background collection, so
+// the test polls until it has been served.
 func TestCachedModeMatchesLive(t *testing.T) {
 	if *update {
 		t.Skip("expected outputs are being regenerated in this run")
@@ -460,7 +477,312 @@ func TestCachedModeMatchesLive(t *testing.T) {
 		"linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__idle.metrics"))
 	require.NoError(t, err)
 
-	assert.Equal(t, string(want), filterDeterministic(scrape(t, baseURL)))
+	var got string
+
+	require.Eventually(t, func() bool {
+		got = filterDeterministic(scrape(t, baseURL))
+
+		return strings.Contains(got, "nvidia_smi_gpu_info")
+	}, startupTimeout, 50*time.Millisecond)
+
+	assert.Equal(t, string(want), got)
+}
+
+// TestCachedModeFirstScrapeDoesNotBlock proves a scrape arriving while the
+// very first background collection is still running gets an immediate answer
+// reporting the not-yet-collected state, instead of hanging on the
+// collection. The fake's delay is what the scrape must not wait for.
+func TestCachedModeFirstScrapeDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	delay := 5 * time.Second
+
+	baseURL := startExporter(t,
+		"--nvidia-smi-command="+fakeCommand(defaultCapture(t), "--delay", delay.String()),
+		"--collect.interval=50ms")
+
+	start := time.Now()
+	metrics := scrape(t, baseURL)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, delay, "the scrape must not wait for the in-flight collection")
+	assert.Contains(t, metrics, "nvidia_smi_last_collect_success 0")
+	assert.Contains(t, metrics, "nvidia_smi_failed_scrapes_total 0")
+	assert.NotContains(t, metrics, "nvidia_smi_gpu_info")
+	// no made-up exit code or duration before the first collection completes
+	assert.NotContains(t, metrics, "nvidia_smi_command_exit_code")
+	assert.NotContains(t, metrics, "nvidia_smi_last_collect_duration_seconds ")
+}
+
+// TestRoutingAndHealth pins the HTTP surface: the landing page only on the
+// exact root path, 404 for unknown paths, and the process-level health
+// endpoints.
+func TestRoutingAndHealth(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--nvidia-smi-command="+fakeCommand(defaultCapture(t)))
+
+	status, body := httpGet(t, baseURL+"/")
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, body, "Nvidia GPU Exporter")
+	assert.Contains(t, body, `href="/metrics"`)
+
+	status, _ = httpGet(t, baseURL+"/-/healthy")
+	assert.Equal(t, http.StatusOK, status)
+
+	status, _ = httpGet(t, baseURL+"/-/ready")
+	assert.Equal(t, http.StatusOK, status)
+
+	// the handler's own error counter is registered and exposed
+	assert.Contains(t, scrape(t, baseURL), "promhttp_metric_handler_errors_total")
+
+	status, _ = httpGet(t, baseURL+"/no-such-path")
+	assert.Equal(t, http.StatusNotFound, status)
+
+	// pprof is not enabled, so its paths are unknown too
+	status, _ = httpGet(t, baseURL+"/debug/pprof/")
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+// TestTelemetryPathValidation pins the startup validation of the telemetry
+// path: values that would collide with the exporter's own routes or break
+// the route registration fail cleanly instead of panicking or shadowing.
+func TestTelemetryPathValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"/", "metrics", "/-/healthy", "/debug/pprof/heap", "/metrics/", "/met rics"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			err := app.Run(t.Context(), []string{
+				"--web.listen-address=127.0.0.1:0",
+				"--log.level=error",
+				"--nvidia-smi-command=" + fakeCommand(defaultCapture(t)),
+				"--web.telemetry-path=" + path,
+			}, app.Options{})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "web.telemetry-path")
+		})
+	}
+}
+
+// TestCustomTelemetryPath proves a valid custom telemetry path serves the
+// metrics there and nothing on the default path.
+func TestCustomTelemetryPath(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t,
+		"--nvidia-smi-command="+fakeCommand(defaultCapture(t)),
+		"--web.telemetry-path=/custom-metrics")
+
+	status, body := httpGet(t, baseURL+"/custom-metrics")
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, body, "nvidia_smi_gpu_info")
+
+	status, _ = httpGet(t, baseURL+"/metrics")
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+// TestMaxRequestsLimit proves scrapes beyond the concurrency limit are
+// answered with an immediate 503 instead of queueing behind the slow
+// collection holding the only slot.
+func TestMaxRequestsLimit(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t,
+		"--nvidia-smi-command="+fakeCommand(defaultCapture(t), "--delay", "3s"),
+		"--web.max-requests=1")
+
+	first := make(chan int, 1)
+
+	go func() {
+		// plain client instead of the helper: test assertions must not run
+		// off the test goroutine
+		resp, err := http.Get(baseURL + "/metrics") //nolint:noctx
+		if err != nil {
+			first <- 0
+
+			return
+		}
+
+		resp.Body.Close()
+
+		first <- resp.StatusCode
+	}()
+
+	// give the first scrape time to occupy the only slot
+	time.Sleep(500 * time.Millisecond)
+
+	start := time.Now()
+	status, body := httpGet(t, baseURL+"/metrics")
+
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.Contains(t, body, "limit of 1 concurrent requests")
+	assert.Less(t, time.Since(start), 2*time.Second, "the rejection must be immediate, not queued")
+
+	// the health endpoints are not behind the limit
+	healthStatus, _ := httpGet(t, baseURL+"/-/healthy")
+	assert.Equal(t, http.StatusOK, healthStatus)
+
+	assert.Equal(t, http.StatusOK, <-first, "the scrape holding the slot must still succeed")
+}
+
+// TestConcurrentScrapesShareOneCollection proves the single-flight sharing
+// through the real HTTP path: several scrapes fired at once against a slow
+// collection all succeed in roughly one collection's time, not one
+// collection each, and all serve the same snapshot (pinned by the wall-clock
+// families, which differ between distinct collections).
+func TestConcurrentScrapesShareOneCollection(t *testing.T) {
+	t.Parallel()
+
+	const scrapers = 5
+
+	delay := 2 * time.Second
+
+	baseURL := startExporter(t,
+		"--nvidia-smi-command="+fakeCommand(defaultCapture(t), "--delay", delay.String()))
+
+	bodies := make(chan string, scrapers)
+
+	start := time.Now()
+
+	for range scrapers {
+		go func() {
+			// plain client, test assertions must not run off the test goroutine
+			resp, err := http.Get(baseURL + "/metrics") //nolint:noctx
+			if err != nil {
+				bodies <- "error: " + err.Error()
+
+				return
+			}
+
+			defer resp.Body.Close()
+
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				bodies <- "error: " + readErr.Error()
+
+				return
+			}
+
+			bodies <- string(body)
+		}()
+	}
+
+	timestamps := make(map[string]bool)
+
+	for range scrapers {
+		body := <-bodies
+		require.NotContains(t, body, "error: ")
+		assert.Contains(t, body, "nvidia_smi_last_collect_success 1")
+
+		match := regexp.MustCompile(`(?m)^nvidia_smi_last_collect_success_timestamp_seconds .*$`).
+			FindString(body)
+		require.NotEmpty(t, match)
+
+		timestamps[match] = true
+	}
+
+	elapsed := time.Since(start)
+
+	assert.Len(t, timestamps, 1, "all concurrent scrapes must serve the same collection's snapshot")
+	assert.Less(t, elapsed, time.Duration(scrapers-1)*delay,
+		"the scrapes must not have run one collection each, serialized")
+}
+
+// TestShutdownDuringInFlightScrape proves shutting the exporter down while a
+// synchronous scrape is mid-collection cancels that collection and exits
+// promptly and cleanly, instead of waiting out the collection behind the
+// shutdown grace period.
+func TestShutdownDuringInFlightScrape(t *testing.T) {
+	t.Parallel()
+
+	delay := 6 * time.Second
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	listenCh := make(chan []net.Addr, 1)
+	doneCh := make(chan error, 1)
+
+	go func() {
+		doneCh <- app.Run(ctx, []string{
+			"--web.listen-address=127.0.0.1:0",
+			"--log.level=error",
+			"--nvidia-smi-command=" + fakeCommand(defaultCapture(t), "--delay", delay.String()),
+		}, app.Options{
+			OnListen: func(addrs []net.Addr) { listenCh <- addrs },
+		})
+	}()
+
+	var baseURL string
+
+	select {
+	case addrs := <-listenCh:
+		require.Len(t, addrs, 1)
+
+		baseURL = "http://" + addrs[0].String()
+	case <-time.After(startupTimeout):
+		t.Fatal("timed out waiting for the exporter to listen")
+	}
+
+	scrapeDone := make(chan struct{})
+
+	go func() {
+		defer close(scrapeDone)
+
+		// the response may complete or be cut short by the shutdown, only
+		// the run's exit matters; plain client, since test assertions must
+		// not run off the test goroutine
+		resp, err := http.Get(baseURL + "/metrics") //nolint:noctx
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	// let the scrape reach the collection, then shut down mid-collection
+	time.Sleep(time.Second)
+
+	shutdownStart := time.Now()
+
+	cancel()
+
+	select {
+	case err := <-doneCh:
+		require.NoError(t, err, "shutdown during an in-flight scrape must be clean")
+		assert.Less(t, time.Since(shutdownStart), delay-2*time.Second,
+			"shutdown must not wait out the in-flight collection")
+	case <-time.After(startupTimeout):
+		t.Fatal("timed out waiting for the exporter to shut down")
+	}
+
+	<-scrapeDone
+}
+
+// TestScrapeTimeoutHeaderBoundsCollection proves the timeout Prometheus
+// advertises on the scrape bounds the collection: when it fires, the scrape
+// is answered right away with the no-result state instead of waiting out the
+// slow collection.
+func TestScrapeTimeoutHeaderBoundsCollection(t *testing.T) {
+	t.Parallel()
+
+	delay := 5 * time.Second
+
+	baseURL := startExporter(t,
+		"--nvidia-smi-command="+fakeCommand(defaultCapture(t), "--delay", delay.String()),
+		// the startup field detection shares the fake's delay, so the
+		// collection timeout must comfortably exceed it
+		"--collect.timeout=20s",
+		"--web.timeout-offset=100ms")
+
+	start := time.Now()
+	status, body := httpGet(t, baseURL+"/metrics", "X-Prometheus-Scrape-Timeout-Seconds", "1")
+	elapsed := time.Since(start)
+
+	assert.Equal(t, http.StatusOK, status)
+	assert.Less(t, elapsed, delay, "the scrape must not wait out the collection")
+	assert.Contains(t, body, "nvidia_smi_last_collect_success 0")
+	assert.NotContains(t, body, "nvidia_smi_gpu_info")
 }
 
 // TestFieldExclusion proves an excluded field's family disappears while the


### PR DESCRIPTION
Implements #456, #457, #458 and #459 in one change, since they all reshape the same serving path.

## Scrape concurrency and handler errors (#456)

- New `--web.max-requests` flag (default 40, `0` disables): scrapes beyond the limit get an immediate 503 instead of piling up without bound behind a slow or wedged collection. Health and landing endpoints are not behind the limit.
- Errors while gathering or encoding metrics now land in the exporter's logs, and `promhttp_metric_handler_errors_total` is registered and exposed.

## Shared collections and scrape deadlines (#457)

- In synchronous mode, scrapes arriving while a collection is already running wait for that run and serve its result, so the number of `nvidia-smi` runs is independent of how many scrapers hit the exporter at once (HA Prometheus setups).
- Each scrape's collection is additionally bounded by the scrape's own lifetime: the client connection, process shutdown, and the timeout Prometheus advertises via `X-Prometheus-Scrape-Timeout-Seconds`, minus the new `--web.timeout-offset` (default 500ms). Missing or malformed header values fall back to `--collect.timeout` alone.
- One waiter disconnecting does not disturb the others; a run nobody waits for anymore is cancelled and taken out of the way, so an unkillable stuck collection cannot poison later scrapes; a failed shared run counts as one failed collection.

## Non-blocking first scrape in background mode (#458)

- A scrape arriving before the very first background collection completes is answered immediately with `nvidia_smi_last_collect_success 0` and no GPU series, instead of blocking (potentially forever with `--collect.timeout 0`). The staleness docs and alert guidance now account for a reading being up to one interval plus the in-flight collection's duration old.

## Routing, landing page and health endpoints (#459)

- Unknown paths answer 404 instead of the landing page; the landing page is the standard exporter-toolkit one (with native profiling links when pprof is enabled).
- `--web.telemetry-path` is validated at startup: values that collide with the exporter's own routes, or that the route registration cannot represent (unclean paths, escapes, pattern syntax), fail cleanly instead of panicking or being shadowed.
- New `/-/healthy` and `/-/ready` endpoints, deliberately process-level: a host whose `nvidia-smi` is failing stays scrapeable so the health metrics can report the failure.
- The Helm chart probes point at the new endpoints and are now configurable via values (`null` disables a probe).

## Notes

- Reviewed in depth by three independent agents; the notable outcomes folded in: abandoned runs are unlinked so they cannot poison subsequent scrapes, shutdown cancels in-flight collections again (matching the pre-change behavior), and path validation was checked against the actual mux panic behavior.
- Coverage: unit tests for the single-flight lifecycle, cached non-blocking reads, path validation and header parsing; integration tests for routing/404/health, the 503 limit, the header-driven deadline, shared concurrent scrapes, shutdown mid-scrape, and the non-blocking first scrape.

Closes #456. Closes #457. Closes #458. Closes #459.
