### PR TITLE
feat: complete the helm chart rollout, security, and scheduling knobs

### DIFF
--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -11,7 +11,9 @@ and make sure that RuntimeClass exists.
 
 To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
-variant (for example `1.7.0-nvml`).
+variant (for example `1.7.0-nvml`). The `-nvml` images are built for
+linux/amd64 only, so on mixed-architecture clusters add
+`kubernetes.io/arch: amd64` to `nodeSelector`.
 
 The exporter deliberately requests no `nvidia.com/gpu` resource. The device
 plugin allocates whole GPUs exclusively, so a monitoring pod that requested
@@ -80,6 +82,77 @@ run privileged with the `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable
 GPU-level memory fields read `[Insufficient Permissions]`. Processes are
 attributed to the parent GPU's UUID, not to individual MIG instances.
 
+## Scheduling on GPU nodes
+
+By default the DaemonSet runs on every Linux node, including nodes without a
+GPU, where the pods come up but report `nvidia_smi_last_collect_success 0`.
+On mixed clusters, restrict it to GPU nodes via `nodeSelector`. There is no
+universal GPU node label, so use whatever your cluster has:
+
+- `nvidia.com/gpu.present: "true"` with GPU Feature Discovery (installed by
+  the NVIDIA GPU Operator, among others),
+- `feature.node.kubernetes.io/pci-0302_10de.present: "true"` with plain Node
+  Feature Discovery (the class segment varies by GPU model: `0302` for
+  datacenter 3D controllers, `0300` for display-class cards, so check your
+  node labels),
+- a cloud or in-house label of your own, e.g. `cloud.google.com/gke-accelerator`
+  on GKE (any value, so use `affinity` with an `Exists` match for that one).
+
+GPU node pools are also commonly tainted (for example
+`nvidia.com/gpu=present:NoSchedule`) so that only GPU workloads land on them.
+The exporter deliberately requests no `nvidia.com/gpu` resource, so it does
+not tolerate such taints by itself and will silently skip those nodes. Add a
+matching toleration:
+
+```yaml
+nodeSelector:
+  nvidia.com/gpu.present: "true"
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+```
+
+## Running next to the NVIDIA GPU Operator
+
+The GPU Operator and this chart coexist without conflicts. The Operator's
+own dcgm-exporter listens on a different port (9400 vs 9835) and exports a
+different metric namespace (`DCGM_FI_*` vs `nvidia_smi_*`), so nothing
+clashes; running both just means the GPUs are polled twice. The Operator
+also installs the pieces this chart needs anyway: the NVIDIA Container
+Toolkit, a `nvidia` RuntimeClass to set `runtimeClassName` to, and GPU
+Feature Discovery labels for the `nodeSelector` shown above.
+
+To replace dcgm-exporter instead of running both, disable it with
+`dcgmExporter.enabled=false` in the GPU Operator chart.
+
+## Restricted namespaces
+
+The pods run unprivileged, but the default security contexts are empty and
+the image runs as root, which the `restricted`
+[Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+rejects at admission. GPU access via the NVIDIA runtime does not require
+root (the injected device nodes are world-accessible on standard driver
+installs), so in enforcing namespaces set a compliant security context:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+Note that `hostNetwork` and `hostPort` are rejected in such namespaces no
+matter the security context (the `baseline` level already forbids them), and
+`computeApps` needs `hostPID`, which they forbid too. On OpenShift, leave
+`runAsUser` unset and let the namespace SCC assign one; the default
+`restricted-v2` SCC fits this workload.
+
 ## Upgrading from chart 1.x
 
 Chart 1.x lived in a [separate repository](https://github.com/utkuozdemir/helm-charts)
@@ -106,16 +179,43 @@ require the Prometheus Operator CRDs (enable one of them, not both).
 `prometheusRule` adds alerts on the exporter's collection health metrics: if
 the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU
 nodes via `nodeSelector` or `affinity` before enabling it, otherwise the
-alerts fire for nodes that cannot collect GPU metrics by design.
+alerts fire for nodes that cannot collect GPU metrics by design. The alert
+expressions select all `nvidia_smi_*` series, so when installing multiple
+releases of this chart, enable the rules in only one of them.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
 and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
 as a ConfigMap labeled for the Grafana sidecar.
+
+With [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack),
+enabling a monitor is usually not enough: by default its Prometheus only
+selects monitors carrying the stack's release label. Two more things bite in
+practice: the default `instance` label is the pod IP, which changes on every
+restart and splits the per-GPU series, so relabel it to the node name. And
+the Grafana sidecar only reads dashboard ConfigMaps from other namespaces
+when it runs with `sidecar.dashboards.searchNamespace=ALL`.
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack # your stack's release name
+  relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      targetLabel: instance
+prometheusRule:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+grafanaDashboard:
+  enabled: true
+```
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the pods |
+| automountServiceAccountToken | bool | `false` | Mount the service account token into the pods. The exporter never talks to the Kubernetes API, so it is off by default. Enable it only if something injected into the pods (e.g. a service mesh sidecar) needs the token. |
 | computeApps.enabled | bool | `false` | Also export per-process GPU metrics (`nvidia_smi_compute_app_*`). To see processes of other pods and containers, the exporter must share the host PID namespace: enable `hostPID` along with this. Note that the pid label churns with the processes, creating short-lived series. |
 | extraArgs | list | `[]` | Extra command line arguments for the exporter, e.g. `--collect.interval=30s` |
 | extraEnv | list | `[]` | Extra environment variables for the exporter container |
@@ -124,23 +224,24 @@ as a ConfigMap labeled for the Grafana sidecar.
 | grafanaDashboard.enabled | bool | `false` | Create a ConfigMap with the Grafana dashboards (single-GPU detail and multi-GPU overview), labeled for the Grafana sidecar to pick up |
 | grafanaDashboard.label | string | `"grafana_dashboard"` | Label that the Grafana sidecar watches for |
 | grafanaDashboard.labelValue | string | `"1"` | Value of the sidecar label |
-| hostNetwork | bool | `false` | Use the host network for the pods |
+| hostNetwork | bool | `false` | Use the host network for the pods. Also switches their DNS policy to `ClusterFirstWithHostNet` so that cluster DNS keeps working. |
 | hostPID | bool | `false` | Share the host PID namespace with the pods. Required for computeApps to see processes of other pods and containers, but it also lets the exporter pod see all host process names, which some security policies forbid. |
 | hostPort.enabled | bool | `false` | Expose the metrics port on the host |
 | hostPort.port | int | `9835` | The host port to expose the metrics on |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"docker.io/utkuozdemir/nvidia_gpu_exporter"` | Image repository |
 | image.tag | string | `""` | Image tag (if not specified, defaults to the chart's appVersion) |
-| imagePullSecrets | list | `[]` | Image pull secrets |
+| imagePullSecrets | list | `[]` | Image pull secrets, used by both the exporter and the `helm test` pods |
 | livenessProbe | object | `{"httpGet":{"path":"/-/healthy","port":"http"}}` | Liveness probe for the exporter container. The default checks that the process serves HTTP at all; it deliberately does not depend on collection success, so a failing nvidia-smi keeps the pod scrapeable and the failure visible in the metrics. Set to `null` to disable the probe. |
 | log.format | string | `"logfmt"` | Log format: logfmt, json |
 | log.level | string | `"info"` | Log level: debug, info, warn, error |
 | nameOverride | string | `""` | Override the chart name |
-| nodeSelector | object | `{}` | Node selector for the pods, e.g. to restrict the DaemonSet to GPU nodes |
+| nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the pods. The images are Linux-only, hence the default. Add a GPU node label to keep the DaemonSet off non-GPU nodes, e.g. `nvidia.com/gpu.present: "true"` on clusters with GPU Feature Discovery (see the README section on scheduling). Helm merges maps key by key, so overriding with `{}` does not clear the default; set the whole value to `null` to remove it. |
 | nvidiaDriverCapabilities | string | `"utility"` | NVIDIA driver capability tier to request. `utility` is the nvidia-smi/NVML tier, which is all the exporter needs. |
 | nvidiaSmiCommand | string | `"nvidia-smi"` | The command to run to get `nvidia-smi` compatible output. Can be a custom path and/or args. |
 | nvidiaVisibleDevices | string | `"all"` | Which GPUs to make visible to the exporter. `all` monitors every GPU on the node. |
 | podAnnotations | object | `{}` | Annotations to add to the pods |
+| podLabels | object | `{}` | Extra labels to add to the pods |
 | podMonitor.additionalLabels | object | `{}` | Additional labels for the PodMonitor |
 | podMonitor.enabled | bool | `false` | Create a Prometheus Operator PodMonitor instead of a ServiceMonitor (requires the Prometheus Operator CRDs). Enable either this or the ServiceMonitor, not both, otherwise the targets are scraped twice. |
 | podMonitor.interval | string | `"15s"` | Scrape interval |
@@ -162,8 +263,10 @@ as a ConfigMap labeled for the Grafana sidecar.
 | queryFieldNamesExclude | list | `[]` | `nvidia-smi` fields to exclude from being queried. Names match literally, with `*` as a wildcard for any sequence of characters. |
 | readinessProbe | object | `{"httpGet":{"path":"/-/ready","port":"http"}}` | Readiness probe for the exporter container, process-level like the liveness probe. Set to `null` to disable the probe. |
 | resources | object | `{}` | Resources for the exporter container |
+| revisionHistoryLimit | string | `""` | How many old DaemonSet history revisions to retain for rollbacks. Empty means the Kubernetes default (10). |
 | runtimeClassName | string | `""` | Name of the RuntimeClass to run the pods with. GPU access is injected by the NVIDIA container runtime, so the pods must run with it: either set this to the name of your NVIDIA RuntimeClass (usually `nvidia`), or leave it empty if the NVIDIA runtime is the default runtime of your nodes. If neither is the case, the exporter will come up but serve no GPU metrics, reporting `nvidia_smi_last_collect_success 0`. |
 | securityContext | object | `{}` | Security context for the exporter container. The default is unprivileged: GPU access comes from the NVIDIA runtime, which requires no privileges. |
+| service.annotations | object | `{}` | Annotations to add to the Service |
 | service.enabled | bool | `true` | Create a Service for the exporter |
 | service.nodePort | string | `""` | Node port to use for NodePort/LoadBalancer service types |
 | service.port | int | `9835` | Service port |
@@ -181,7 +284,11 @@ as a ConfigMap labeled for the Grafana sidecar.
 | serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout |
 | serviceMonitor.tlsConfig | object | `{}` | TLS configuration for scraping |
 | telemetryPath | string | `"/metrics"` | The path to expose the metrics from |
-| tolerations | list | `[]` | Tolerations for the pods |
+| test.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `helm test` pod |
+| test.image.repository | string | `"docker.io/library/busybox"` | Image repository for the `helm test` connection-check pod |
+| test.image.tag | string | `"1.37"` | Image tag for the `helm test` pod |
+| tolerations | list | `[]` | Tolerations for the pods. GPU node pools are often tainted (e.g. `nvidia.com/gpu=present:NoSchedule`) so that only GPU workloads land on them. This chart deliberately requests no GPU resource, so add a matching toleration here or the exporter will not schedule on those nodes. |
+| updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Update strategy of the DaemonSet. Raise `rollingUpdate.maxUnavailable` (absolute or percentage) to roll out faster on large clusters, or use `type: OnDelete` for manually staged rollouts. |
 | volumeMounts | list | `[]` | Extra volume mounts for the exporter container |
 | volumes | list | `[]` | Extra volumes for the pods |
 

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -11,7 +11,9 @@ and make sure that RuntimeClass exists.
 
 To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
-variant (for example `1.7.0-nvml`).
+variant (for example `1.7.0-nvml`). The `-nvml` images are built for
+linux/amd64 only, so on mixed-architecture clusters add
+`kubernetes.io/arch: amd64` to `nodeSelector`.
 
 The exporter deliberately requests no `nvidia.com/gpu` resource. The device
 plugin allocates whole GPUs exclusively, so a monitoring pod that requested
@@ -80,6 +82,77 @@ run privileged with the `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable
 GPU-level memory fields read `[Insufficient Permissions]`. Processes are
 attributed to the parent GPU's UUID, not to individual MIG instances.
 
+## Scheduling on GPU nodes
+
+By default the DaemonSet runs on every Linux node, including nodes without a
+GPU, where the pods come up but report `nvidia_smi_last_collect_success 0`.
+On mixed clusters, restrict it to GPU nodes via `nodeSelector`. There is no
+universal GPU node label, so use whatever your cluster has:
+
+- `nvidia.com/gpu.present: "true"` with GPU Feature Discovery (installed by
+  the NVIDIA GPU Operator, among others),
+- `feature.node.kubernetes.io/pci-0302_10de.present: "true"` with plain Node
+  Feature Discovery (the class segment varies by GPU model: `0302` for
+  datacenter 3D controllers, `0300` for display-class cards, so check your
+  node labels),
+- a cloud or in-house label of your own, e.g. `cloud.google.com/gke-accelerator`
+  on GKE (any value, so use `affinity` with an `Exists` match for that one).
+
+GPU node pools are also commonly tainted (for example
+`nvidia.com/gpu=present:NoSchedule`) so that only GPU workloads land on them.
+The exporter deliberately requests no `nvidia.com/gpu` resource, so it does
+not tolerate such taints by itself and will silently skip those nodes. Add a
+matching toleration:
+
+```yaml
+nodeSelector:
+  nvidia.com/gpu.present: "true"
+tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+```
+
+## Running next to the NVIDIA GPU Operator
+
+The GPU Operator and this chart coexist without conflicts. The Operator's
+own dcgm-exporter listens on a different port (9400 vs 9835) and exports a
+different metric namespace (`DCGM_FI_*` vs `nvidia_smi_*`), so nothing
+clashes; running both just means the GPUs are polled twice. The Operator
+also installs the pieces this chart needs anyway: the NVIDIA Container
+Toolkit, a `nvidia` RuntimeClass to set `runtimeClassName` to, and GPU
+Feature Discovery labels for the `nodeSelector` shown above.
+
+To replace dcgm-exporter instead of running both, disable it with
+`dcgmExporter.enabled=false` in the GPU Operator chart.
+
+## Restricted namespaces
+
+The pods run unprivileged, but the default security contexts are empty and
+the image runs as root, which the `restricted`
+[Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+rejects at admission. GPU access via the NVIDIA runtime does not require
+root (the injected device nodes are world-accessible on standard driver
+installs), so in enforcing namespaces set a compliant security context:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+Note that `hostNetwork` and `hostPort` are rejected in such namespaces no
+matter the security context (the `baseline` level already forbids them), and
+`computeApps` needs `hostPID`, which they forbid too. On OpenShift, leave
+`runAsUser` unset and let the namespace SCC assign one; the default
+`restricted-v2` SCC fits this workload.
+
 ## Upgrading from chart 1.x
 
 Chart 1.x lived in a [separate repository](https://github.com/utkuozdemir/helm-charts)
@@ -106,10 +179,36 @@ require the Prometheus Operator CRDs (enable one of them, not both).
 `prometheusRule` adds alerts on the exporter's collection health metrics: if
 the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU
 nodes via `nodeSelector` or `affinity` before enabling it, otherwise the
-alerts fire for nodes that cannot collect GPU metrics by design.
+alerts fire for nodes that cannot collect GPU metrics by design. The alert
+expressions select all `nvidia_smi_*` series, so when installing multiple
+releases of this chart, enable the rules in only one of them.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
 and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
 as a ConfigMap labeled for the Grafana sidecar.
+
+With [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack),
+enabling a monitor is usually not enough: by default its Prometheus only
+selects monitors carrying the stack's release label. Two more things bite in
+practice: the default `instance` label is the pod IP, which changes on every
+restart and splits the per-GPU series, so relabel it to the node name. And
+the Grafana sidecar only reads dashboard ConfigMaps from other namespaces
+when it runs with `sidecar.dashboards.searchNamespace=ALL`.
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack # your stack's release name
+  relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      targetLabel: instance
+prometheusRule:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+grafanaDashboard:
+  enabled: true
+```
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/nvidia-gpu-exporter/ci/default-values.yaml
+++ b/charts/nvidia-gpu-exporter/ci/default-values.yaml
@@ -3,7 +3,7 @@
 # install and the connection test to pass. The image tag is pinned because the
 # in-repo appVersion is a placeholder.
 image:
-  tag: "1.7.0"
+  tag: "1.11.0"
 serviceMonitor:
   enabled: false
 podMonitor:

--- a/charts/nvidia-gpu-exporter/templates/daemonset.yaml
+++ b/charts/nvidia-gpu-exporter/templates/daemonset.yaml
@@ -5,6 +5,14 @@ metadata:
   labels:
     {{- include "nvidia-gpu-exporter.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- /* explicit emptiness check: `with` would swallow a literal 0 */}}
+  {{- if and (not (kindIs "invalid" .Values.revisionHistoryLimit)) (ne (.Values.revisionHistoryLimit | toString) "") }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "nvidia-gpu-exporter.selectorLabels" . | nindent 6 }}
@@ -15,13 +23,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "nvidia-gpu-exporter.selectorLabels" . | nindent 8 }}
+        {{- /* merged so that the selector labels always win: overriding them
+        would desync the pod template from the immutable selector */}}
+        {{- merge (include "nvidia-gpu-exporter.selectorLabels" . | fromYaml) (.Values.podLabels | default dict) | toYaml | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "nvidia-gpu-exporter.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken | default false }}
       {{- with .Values.runtimeClassName }}
       runtimeClassName: {{ . }}
       {{- end }}
@@ -50,24 +61,24 @@ spec:
             {{- end }}
           args:
             - --web.listen-address
-            - :{{ .Values.port }}
+            - ":{{ .Values.port }}"
             - --web.telemetry-path
-            - {{ .Values.telemetryPath }}
+            - {{ .Values.telemetryPath | quote }}
             - --nvidia-smi-command
-            - {{ .Values.nvidiaSmiCommand }}
+            - {{ .Values.nvidiaSmiCommand | quote }}
             - --query-field-names
-            - {{ join "," .Values.queryFieldNames }}
+            - {{ join "," .Values.queryFieldNames | quote }}
             {{- with .Values.queryFieldNamesExclude }}
             - --query-field-names-exclude
-            - {{ join "," . }}
+            - {{ join "," . | quote }}
             {{- end }}
             {{- if .Values.computeApps.enabled }}
             - --collect.compute-apps
             {{- end }}
             - --log.level
-            - {{ .Values.log.level }}
+            - {{ .Values.log.level | quote }}
             - --log.format
-            - {{ .Values.log.format }}
+            - {{ .Values.log.format | quote }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -111,4 +122,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      {{- if .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       hostPID: {{ .Values.hostPID }}

--- a/charts/nvidia-gpu-exporter/templates/service.yaml
+++ b/charts/nvidia-gpu-exporter/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "nvidia-gpu-exporter.fullname" . }}
   labels:
     {{- include "nvidia-gpu-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/nvidia-gpu-exporter/templates/tests/test-connection.yaml
+++ b/charts/nvidia-gpu-exporter/templates/tests/test-connection.yaml
@@ -11,9 +11,30 @@ metadata:
   annotations:
     helm.sh/hook: test
 spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  automountServiceAccountToken: false
   containers:
+    {{- /* nil-safe lookups with inline fallbacks: upgrades with
+    --reuse-values keep the previous release's values, where the test
+    subtree may not exist yet */}}
+    {{- $testImage := dig "image" (dict) (.Values.test | default dict) }}
     - name: wget
-      image: busybox
+      image: "{{ $testImage.repository | default "docker.io/library/busybox" }}:{{ $testImage.tag | default "1.37" }}"
+      imagePullPolicy: {{ $testImage.pullPolicy | default "IfNotPresent" }}
+      # restricted-profile security context so the test pod passes admission
+      # in namespaces enforcing the "restricted" Pod Security Standard
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       command:
         - sh
         - -c
@@ -21,7 +42,7 @@ spec:
       # startup field detection and begins listening
       args:
         - |
-          url="http://{{ include "nvidia-gpu-exporter.fullname" . }}:{{ .Values.service.port }}{{ .Values.telemetryPath }}"
+          url='http://{{ include "nvidia-gpu-exporter.fullname" . }}:{{ .Values.service.port }}{{ .Values.telemetryPath }}'
           for attempt in $(seq 1 30); do
             wget -qO- "$url" && exit 0
             echo "attempt $attempt failed, retrying"

--- a/charts/nvidia-gpu-exporter/values.schema.json
+++ b/charts/nvidia-gpu-exporter/values.schema.json
@@ -138,6 +138,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "type": {
           "type": "string",
           "enum": [
@@ -180,6 +186,9 @@
         }
       },
       "additionalProperties": false
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
     },
     "serviceMonitor": {
       "type": "object",
@@ -307,6 +316,12 @@
     "podAnnotations": {
       "type": "object"
     },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "podSecurityContext": {
       "type": "object"
     },
@@ -334,8 +349,93 @@
     "priorityClassName": {
       "type": "string"
     },
+    "updateStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "RollingUpdate",
+            "OnDelete"
+          ]
+        },
+        "rollingUpdate": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "maxUnavailable": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^[0-9]+%$"
+                }
+              ]
+            },
+            "maxSurge": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^[0-9]+%$"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "revisionHistoryLimit": {
+      "oneOf": [
+        {
+          "const": ""
+        },
+        {
+          "type": "integer",
+          "minimum": 0
+        }
+      ]
+    },
     "imagePullSecrets": {
       "type": "array"
+    },
+    "test": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "minLength": 1
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "nameOverride": {
       "type": "string"

--- a/charts/nvidia-gpu-exporter/values.yaml
+++ b/charts/nvidia-gpu-exporter/values.yaml
@@ -73,7 +73,8 @@ readinessProbe:
 # -- Extra command line arguments for the exporter, e.g. `--collect.interval=30s`
 extraArgs: []
 
-# -- Use the host network for the pods
+# -- Use the host network for the pods. Also switches their DNS policy to
+# `ClusterFirstWithHostNet` so that cluster DNS keeps working.
 hostNetwork: false
 
 # -- Share the host PID namespace with the pods. Required for computeApps to
@@ -90,6 +91,8 @@ hostPort:
 service:
   # -- Create a Service for the exporter
   enabled: true
+  # -- Annotations to add to the Service
+  annotations: {}
   # -- Service type
   type: ClusterIP
   # -- Service port
@@ -104,6 +107,11 @@ serviceAccount:
   annotations: {}
   # -- The name of the service account to use. If not set and create is true, a name is generated.
   name: ""
+
+# -- Mount the service account token into the pods. The exporter never talks
+# to the Kubernetes API, so it is off by default. Enable it only if something
+# injected into the pods (e.g. a service mesh sidecar) needs the token.
+automountServiceAccountToken: false
 
 serviceMonitor:
   # -- Create a Prometheus Operator ServiceMonitor (requires the Prometheus Operator CRDs)
@@ -179,6 +187,9 @@ grafanaDashboard:
 # -- Annotations to add to the pods
 podAnnotations: {}
 
+# -- Extra labels to add to the pods
+podLabels: {}
+
 # -- Security context for the pods
 podSecurityContext: {}
 
@@ -195,10 +206,19 @@ volumes: []
 # -- Extra volume mounts for the exporter container
 volumeMounts: []
 
-# -- Node selector for the pods, e.g. to restrict the DaemonSet to GPU nodes
-nodeSelector: {}
+# -- Node selector for the pods. The images are Linux-only, hence the default.
+# Add a GPU node label to keep the DaemonSet off non-GPU nodes, e.g.
+# `nvidia.com/gpu.present: "true"` on clusters with GPU Feature Discovery
+# (see the README section on scheduling). Helm merges maps key by key, so
+# overriding with `{}` does not clear the default; set the whole value to
+# `null` to remove it.
+nodeSelector:
+  kubernetes.io/os: linux
 
-# -- Tolerations for the pods
+# -- Tolerations for the pods. GPU node pools are often tainted (e.g.
+# `nvidia.com/gpu=present:NoSchedule`) so that only GPU workloads land on
+# them. This chart deliberately requests no GPU resource, so add a matching
+# toleration here or the exporter will not schedule on those nodes.
 tolerations: []
 
 # -- Affinity for the pods
@@ -207,8 +227,29 @@ affinity: {}
 # -- Priority class name for the pods
 priorityClassName: ""
 
-# -- Image pull secrets
+# -- Update strategy of the DaemonSet. Raise `rollingUpdate.maxUnavailable`
+# (absolute or percentage) to roll out faster on large clusters, or use
+# `type: OnDelete` for manually staged rollouts.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
+# -- How many old DaemonSet history revisions to retain for rollbacks.
+# Empty means the Kubernetes default (10).
+revisionHistoryLimit: ""
+
+# -- Image pull secrets, used by both the exporter and the `helm test` pods
 imagePullSecrets: []
+
+test:
+  image:
+    # -- Image repository for the `helm test` connection-check pod
+    repository: docker.io/library/busybox
+    # -- Image tag for the `helm test` pod
+    tag: "1.37"
+    # -- Image pull policy for the `helm test` pod
+    pullPolicy: IfNotPresent
 
 # -- Override the chart name
 nameOverride: ""


### PR DESCRIPTION
Final completeness pass on the chart. Closes #430.

## Rollout and metadata knobs (#430)

- `updateStrategy` (typo-proofed schema, `maxUnavailable`/`maxSurge` as int or percentage) and `revisionHistoryLimit` (an explicit `0` renders instead of being swallowed by `with` truthiness).
- `podLabels`, merged so the chart's selector labels always win: a user label colliding with them would desync the pod template from the immutable selector, which the API server rejects.
- `service.annotations`; both new maps schema-validate values as strings, so `--set podLabels.x=5` fails at render time instead of at apply time.

## Security defaults

- `automountServiceAccountToken: false` on the exporter and test pods: the exporter never talks to the Kubernetes API. Knob to re-enable for setups that inject sidecars needing a token.
- All user-controlled string args are quoted: a value containing `: ` (e.g. a quoted `nvidiaSmiCommand`) used to render as a nested YAML mapping inside `args`, which the API rejects.

## Scheduling

- `nodeSelector` defaults to `kubernetes.io/os: linux`, matching the published images (a mixed-OS cluster used to get failing pods on Windows nodes).
- `hostNetwork: true` now pairs with `dnsPolicy: ClusterFirstWithHostNet`.

## Test pod and CI

- The `helm test` pod image is configurable and pinned (air-gap friendly), honors `imagePullSecrets`, and carries a restricted-PSS-compliant security context.
- Its value lookups are nil-safe with inline fallbacks: `helm upgrade --reuse-values` replaces the new chart's defaults with the old release's values (verified against the Helm 3 and 4 sources), so the new subtree may not exist at render time.
- The CI install pin moves 1.7.0 → 1.11.0: 1.10's catch-all root handler answered 200 for any path, so the probe endpoints were not actually exercised.

## Docs

New README sections: scheduling on GPU nodes (GFD/NFD/GKE labels and GPU-pool taints), running next to the NVIDIA GPU Operator and dcgm-exporter (no port or metric-namespace clash; `dcgmExporter.enabled=false` when replacing it), restricted Pod Security Standard guidance with a working securityContext example, and a kube-prometheus-stack recipe (release label, stable `instance` via node-name relabeling, sidecar namespace discovery).

## Notes

- Reviewed in two rounds by three independent agents; notable outcomes folded in: the NFD label example corrected to the `pci-<class>_<vendor>.present` form, the `podLabels`/selector merge, the reuse-values nil-safety, and the `revisionHistoryLimit: 0` fix.
- Verified empirically: `ct lint`, full render matrix, hostile-value renders, schema rejections, helm-docs regeneration is byte-clean.