### PR TITLE
feat: add NVML-only metrics and expose the CUDA version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ This makes it possible to run it on Windows and get GPU metrics while gaming - n
 
 It can also skip `nvidia-smi` and read the metrics straight from the NVIDIA
 Management Library (NVML), the C library `nvidia-smi` itself is built on. This
-mode is experimental and exports the exact same metrics; see
-[CONFIGURE.md](docs/CONFIGURE.md).
+mode is experimental and exports a superset of the default mode's metrics: the
+same core set plus NVML-only extras like the GPU energy counter and opt-in
+PCIe throughput; see [CONFIGURE.md](docs/CONFIGURE.md).
 
 This project is based on [a0s/nvidia-smi-exporter](https://github.com/a0s/nvidia-smi-exporter).
 However, this one is written in Go to produce a single, static binary.
@@ -58,7 +59,7 @@ probably the better fit; this exporter aims at the cases above.
 - No need for a Docker or Kubernetes environment
 - Auto-discovery of the metric fields `nvidia-smi` can expose (future-compatible)
 - Optional per-process GPU metrics: see which process uses how much GPU memory
-- Experimental NVML mode: reads the driver library directly instead of running `nvidia-smi` (Linux)
+- Experimental NVML mode: reads the driver library directly instead of running `nvidia-smi`, and unlocks metrics `nvidia-smi` cannot provide (Linux)
 - Comes with its own [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
 
 ## Visualization

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -11,7 +11,9 @@ and make sure that RuntimeClass exists.
 
 To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
-variant (for example `1.7.0-nvml`). The `-nvml` images are built for
+variant (for example `1.7.0-nvml`). It exports a superset of the default
+backend's metrics: the same core set plus NVML-only extras like the GPU
+energy counter and opt-in PCIe throughput. The `-nvml` images are built for
 linux/amd64 only, so on mixed-architecture clusters add
 `kubernetes.io/arch: amd64` to `nodeSelector`.
 

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -11,7 +11,9 @@ and make sure that RuntimeClass exists.
 
 To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
-variant (for example `1.7.0-nvml`). The `-nvml` images are built for
+variant (for example `1.7.0-nvml`). It exports a superset of the default
+backend's metrics: the same core set plus NVML-only extras like the GPU
+energy counter and opt-in PCIe throughput. The `-nvml` images are built for
 linux/amd64 only, so on mixed-architecture clusters add
 `kubernetes.io/arch: amd64` to `nodeSelector`.
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -9,6 +9,7 @@ The exporter binary accepts the following arguments:
 ```text
 usage: nvidia_gpu_exporter [<flags>]
 
+
 Flags:
   -h, --[no-]help               Show context-sensitive help (also try
                                 --help-long and --help-man).
@@ -68,25 +69,43 @@ Flags:
                                 (for example `remapped_rows.histogram.*`).
                                 Useful to drop fields that are slow or
                                 unsupported on a given setup.
-      --collect.interval=0      Interval at which nvidia-smi runs in the
-                                background, with scrapes serving the most recent
-                                result. When 0, nvidia-smi runs synchronously on
-                                each scrape instead.
+      --collect.backend=exec    How to collect GPU metrics. `exec` runs
+                                nvidia-smi (the default); `nvml` is experimental
+                                and reads the driver library (libnvidia-ml)
+                                directly, without nvidia-smi. The nvml backend
+                                requires Linux and a build with the backend
+                                compiled in. It exposes every metric the exec
+                                backend exposes, plus NVML-only extras (see the
+                                docs).
+      --collect.interval=0      Interval at which the collection runs in the
+                                background, with scrapes serving the most
+                                recent result. When 0, the collection runs
+                                synchronously on each scrape instead.
       --collect.timeout=10s     Maximum duration a single collection cycle may
-                                take, including all nvidia-smi runs within it
-                                and the runs at startup. 0 disables the bound.
+                                take, including all the work within it (e.g.
+                                the nvidia-smi runs) and the runs at startup.
+                                0 disables the bound.
       --[no-]collect.compute-apps
                                 Also export per-process GPU metrics
-                                from `nvidia-smi --query-compute-apps`.
-                                Adds one nvidia-smi run per collection cycle.
+                                (from `nvidia-smi --query-compute-apps`,
+                                or the equivalent NVML calls in nvml mode).
                                 When the exporter runs in a container, seeing
                                 other workloads' processes requires sharing
                                 the host PID namespace (hostPID in Kubernetes,
                                 --pid=host in Docker).
-      --[no-]shutdown-on-error  Shut down the exporter if there is an error
-                                querying nvidia-smi. When false, exporter will
-                                simply log this error and export it as a metric,
-                                but will not crash.
+      --[no-]collect.pcie-throughput
+                                Also export the PCIe TX/RX throughput per
+                                GPU (requires --collect.backend=nvml). Each
+                                direction is sampled over a separate 20ms driver
+                                counter window, adding roughly 40ms per GPU
+                                to every collection cycle (~320ms on an 8-GPU
+                                node); pairing it with --collect.interval keeps
+                                scrapes unaffected.
+      --[no-]shutdown-on-error  Shut down the exporter if there is a fatal
+                                collection error (a failing nvidia-smi run,
+                                or a lost GPU/driver in nvml mode). When false,
+                                exporter will simply log this error and export
+                                it as a metric, but will not crash.
       --[no-]web.enable-pprof   Enable pprof endpoints for profiling under
                                 /debug/pprof/. Only enable this on a trusted
                                 network, as it exposes runtime internals.
@@ -294,9 +313,34 @@ Things to keep in mind:
 ## Experimental: native NVML backend
 
 `--collect.backend=nvml` reads GPU metrics directly from the driver library
-(`libnvidia-ml.so.1`) instead of running `nvidia-smi`. The exported metrics
-are the same: metric names, labels and values match the default backend on
-the same machine, verified field-by-field against live hardware.
+(`libnvidia-ml.so.1`) instead of running `nvidia-smi`. Its metric surface is
+a superset of the default backend's: every metric derived from the
+`nvidia-smi` query fields is identical in name, labels and value (verified
+field-by-field against live hardware), and on top of that shared core the
+nvml backend serves metric families only the driver library can provide.
+
+What each backend can do:
+
+| Capability | exec | nvml |
+| --- | --- | --- |
+| Query-field metrics (identical names, labels, values) | yes | yes |
+| `gpu_info` with the `cuda_version` label | yes | yes |
+| Per-process metrics (`--collect.compute-apps`) | yes | yes |
+| Collection status metric | `command_exit_code` | `nvml_return_code` |
+| Custom command, remote scraping (`--nvidia-smi-command`, ssh, sudo) | yes | no |
+| Strongest isolation against a wedged driver (killable subprocess) | yes | no |
+| Brand-new driver fields before the catalog catches up (`AUTO`) | yes | no |
+| Total energy counter (`energy_joules_total`) | no | yes |
+| PCIe throughput (`--collect.pcie-throughput`) | no | yes |
+
+The NVML-only families are documented in [METRICS.md](METRICS.md). The PCIe
+throughput family is opt-in via `--collect.pcie-throughput` because of its
+collection cost: the driver samples each direction over its own 20ms counter
+window, so it adds roughly 40ms per GPU to every collection cycle, entirely
+serial (~320ms per cycle on an 8-GPU node). Pairing it with
+`--collect.interval` keeps scrapes unaffected by that cost. The two
+directions are sampled over two consecutive windows, not one simultaneous
+pair.
 
 ```bash
 nvidia_gpu_exporter --collect.backend nvml

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -5,8 +5,36 @@ This is an example output of the returned metrics.
 Note that when `AUTO` query fields mode is used (it is the default),
 the exporter will discover new fields and expose them on a best-effort basis.
 
-The experimental NVML backend exports the same metrics, except it reports
-`nvidia_smi_nvml_return_code` in place of `nvidia_smi_command_exit_code`.
+The experimental NVML backend exports a superset of these metrics: every
+metric below is identical in both backends, except that the NVML backend
+reports `nvidia_smi_nvml_return_code` in place of
+`nvidia_smi_command_exit_code`. On top of that shared core it serves the
+NVML-only families described in the next section.
+
+## NVML-only metrics
+
+Some readings exist in the driver library but not in the `nvidia-smi` query
+interface, so only the NVML backend can export them:
+
+- `nvidia_smi_energy_joules_total{uuid}` (counter): total energy consumed by
+  the GPU in joules since the driver was last loaded. Always on in the NVML
+  backend; absent on GPUs that cannot report it (older than the Volta
+  generation). The counter resets when the driver reloads or the GPU is
+  reset, so read it through `rate()` or `increase()`.
+- `nvidia_smi_pcie_throughput_tx_bytes_per_second{uuid}` and
+  `nvidia_smi_pcie_throughput_rx_bytes_per_second{uuid}` (gauges): PCIe
+  traffic transmitted and received by the GPU. Opt-in via
+  `--collect.pcie-throughput` because of its collection cost; see
+  [CONFIGURE.md](CONFIGURE.md). The driver samples each direction over its
+  own 20ms counter window, so the two values are consecutive samples, not a
+  simultaneous pair.
+
+Both backends also stamp the CUDA version the installed driver supports onto
+`nvidia_smi_gpu_info` as the `cuda_version` label. This is the version of
+the CUDA API the driver carries, not an installed CUDA toolkit. The default
+backend reads it from `nvidia-smi --version` once at startup; the NVML
+backend asks the library directly. When it cannot be read, the label value
+is empty.
 
 ## Enum-valued metrics
 
@@ -229,9 +257,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="471.11",name="NVIDIA GeForce RTX 2080 SUPER",uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa",vbios_version="90.04.7a.40.73",pci_bus_id="00000000:71:00.0",serial="[N/A]",compute_cap="7.5",pci_sub_device_id="0x40051458",index="0"} 1
+nvidia_smi_gpu_info{cuda_version="11.4",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="471.11",name="NVIDIA GeForce RTX 2080 SUPER",uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa",vbios_version="90.04.7a.40.73",pci_bus_id="00000000:71:00.0",serial="[N/A]",compute_cap="7.5",pci_sub_device_id="0x40051458",index="0"} 1
 # HELP nvidia_smi_index index
 # TYPE nvidia_smi_index gauge
 nvidia_smi_index{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -130,21 +130,30 @@ func Run(ctx context.Context, args []string, opts Options) error {
 			"How to collect GPU metrics. `exec` runs nvidia-smi (the default); `nvml` is "+
 				"experimental and reads the driver library (libnvidia-ml) directly, without "+
 				"nvidia-smi. The nvml backend requires Linux and a build with the backend "+
-				"compiled in, and exposes the same metrics as the exec backend.").
+				"compiled in. It exposes every metric the exec backend exposes, plus "+
+				"NVML-only extras (see the docs).").
 			Default(DefaultBackend).Enum("exec", "nvml")
 		collectInterval = app.Flag("collect.interval",
-			"Interval at which nvidia-smi runs in the background, with scrapes serving the most "+
-				"recent result. When 0, nvidia-smi runs synchronously on each scrape instead.").
+			"Interval at which the collection runs in the background, with scrapes serving "+
+				"the most recent result. When 0, the collection runs synchronously on each "+
+				"scrape instead.").
 			Default("0").Duration()
 		collectTimeout = app.Flag("collect.timeout",
-			"Maximum duration a single collection cycle may take, including all nvidia-smi runs "+
-				"within it and the runs at startup. 0 disables the bound.").
+			"Maximum duration a single collection cycle may take, including all the work "+
+				"within it (e.g. the nvidia-smi runs) and the runs at startup. 0 disables "+
+				"the bound.").
 			Default("10s").Duration()
 		collectComputeApps = app.Flag("collect.compute-apps",
-			"Also export per-process GPU metrics from `nvidia-smi --query-compute-apps`. "+
-				"Adds one nvidia-smi run per collection cycle. When the exporter runs in a "+
+			"Also export per-process GPU metrics (from `nvidia-smi --query-compute-apps`, "+
+				"or the equivalent NVML calls in nvml mode). When the exporter runs in a "+
 				"container, seeing other workloads' processes requires sharing the host PID "+
 				"namespace (hostPID in Kubernetes, --pid=host in Docker).").
+			Default("false").Bool()
+		collectPcieThroughput = app.Flag("collect.pcie-throughput",
+			"Also export the PCIe TX/RX throughput per GPU (requires --collect.backend=nvml). "+
+				"Each direction is sampled over a separate 20ms driver counter window, adding "+
+				"roughly 40ms per GPU to every collection cycle (~320ms on an 8-GPU node); "+
+				"pairing it with --collect.interval keeps scrapes unaffected.").
 			Default("false").Bool()
 		shutdownOnErr = app.Flag("shutdown-on-error",
 			"Shut down the exporter if there is a fatal collection error "+
@@ -181,10 +190,8 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		return err
 	}
 
-	if *collectBackend == backendNVML && *nvidiaSmiCommand != nvidiasmi.DefaultCommand {
-		// a custom command signals intent (ssh wrappers, sudo) the nvml
-		// backend cannot honor, so it is an error rather than a silent ignore
-		return errors.New("--nvidia-smi-command cannot be combined with --collect.backend=nvml")
+	if err := validateBackendFlags(*collectBackend, *nvidiaSmiCommand, *collectPcieThroughput); err != nil {
+		return err
 	}
 
 	ctx, serverCancel := context.WithCancelCause(ctx)
@@ -205,6 +212,7 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		interval:         *collectInterval,
 		timeout:          *collectTimeout,
 		computeApps:      *collectComputeApps,
+		pcieThroughput:   *collectPcieThroughput,
 		onFatal:          onFatal,
 	}
 
@@ -289,6 +297,23 @@ func serveHTTP(
 
 		return nil
 	})
+}
+
+// validateBackendFlags rejects flag combinations the chosen backend cannot
+// honor, as errors rather than silent ignores.
+func validateBackendFlags(backend, nvidiaSmiCommand string, pcieThroughput bool) error {
+	if backend == backendNVML && nvidiaSmiCommand != nvidiasmi.DefaultCommand {
+		// a custom command signals intent (ssh wrappers, sudo) the nvml
+		// backend cannot honor
+		return errors.New("--nvidia-smi-command cannot be combined with --collect.backend=nvml")
+	}
+
+	if backend != backendNVML && pcieThroughput {
+		// the throughput counters only exist in the driver library
+		return errors.New("--collect.pcie-throughput requires --collect.backend=nvml")
+	}
+
+	return nil
 }
 
 // validateCollectFlags rejects the flag values kingpin's types cannot.
@@ -392,6 +417,7 @@ type collectConfig struct {
 	interval         time.Duration
 	timeout          time.Duration
 	computeApps      bool
+	pcieThroughput   bool
 	onFatal          func(error)
 }
 
@@ -426,7 +452,14 @@ func setupExporter(
 		src = collect.NewLive(query, cfg.timeout, cfg.onFatal, logger)
 	}
 
-	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, cfg.computeApps, exitCodeMetric, logger)
+	features := exporter.Features{
+		ComputeApps: cfg.computeApps,
+		// the extras families exist only in the nvml backend
+		PCIeThroughput: cfg.pcieThroughput,
+		Energy:         cfg.backend == backendNVML,
+	}
+
+	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, features, exitCodeMetric, logger)
 
 	// the go and process collectors keep the exposed families identical to
 	// what the default registry used to serve
@@ -481,7 +514,13 @@ func setupBackend(
 			return nil
 		})
 
-		return resolved, backend.QueryFunc(resolved, cfg.computeApps), exporter.NVMLReturnCodeMetric, nil
+		opts := nvmlnative.CollectOptions{
+			ComputeApps:    cfg.computeApps,
+			PCIeThroughput: cfg.pcieThroughput,
+			Energy:         true,
+		}
+
+		return resolved, backend.QueryFunc(resolved, opts), exporter.NVMLReturnCodeMetric, nil
 	}
 
 	resolved, err := nvidiasmi.ResolveFields(
@@ -498,7 +537,13 @@ func setupBackend(
 			fmt.Errorf("failed to resolve query fields: %w", err)
 	}
 
-	return resolved, buildQueryFunc(cfg, resolved, logger), exporter.ExecExitCodeMetric, nil
+	// the CUDA version is not a query field and is effectively constant for
+	// the process lifetime (it changes with the driver, which requires the
+	// GPUs to be idle), so it is read once at startup, never per scrape
+	cudaVersion := nvidiasmi.QueryCudaVersion(
+		ctx, cfg.nvidiaSmiCommand, cfg.timeout, nvidiasmi.DefaultRunFunc, logger)
+
+	return resolved, buildQueryFunc(cfg, resolved, cudaVersion, logger), exporter.ExecExitCodeMetric, nil
 }
 
 // buildQueryFunc builds the collection cycle: the GPU query, plus the
@@ -508,6 +553,7 @@ func setupBackend(
 func buildQueryFunc(
 	cfg collectConfig,
 	resolved nvidiasmi.ResolvedFields,
+	cudaVersion string,
 	logger *slog.Logger,
 ) collect.QueryFunc {
 	return func(queryCtx context.Context) (collect.Reading, int, error) {
@@ -518,6 +564,7 @@ func buildQueryFunc(
 		}
 
 		reading := collect.Reading{Table: table}
+		reading.Extras.CUDAVersion = cudaVersion
 
 		if cfg.computeApps {
 			reading.AppsAttempted = true

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -138,3 +138,44 @@ func TestScrapeContext(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBackendFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		backend        string
+		command        string
+		pcieThroughput bool
+		wantErr        string
+	}{
+		{name: "exec defaults", backend: backendExec, command: "nvidia-smi"},
+		{name: "exec with custom command", backend: backendExec, command: "sudo nvidia-smi"},
+		{name: "nvml defaults", backend: backendNVML, command: "nvidia-smi"},
+		{name: "nvml with pcie throughput", backend: backendNVML, command: "nvidia-smi", pcieThroughput: true},
+		{
+			name: "nvml rejects custom command", backend: backendNVML, command: "sudo nvidia-smi",
+			wantErr: "--nvidia-smi-command cannot be combined",
+		},
+		{
+			name: "exec rejects pcie throughput", backend: backendExec, command: "nvidia-smi",
+			pcieThroughput: true,
+			wantErr:        "--collect.pcie-throughput requires --collect.backend=nvml",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateBackendFlags(testCase.backend, testCase.command, testCase.pcieThroughput)
+			if testCase.wantErr == "" {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			assert.ErrorContains(t, err, testCase.wantErr)
+		})
+	}
+}

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -28,6 +28,9 @@ type Snapshot struct {
 	// AppsSuccess reports whether that per-process query succeeded, valid only
 	// when AppsAttempted.
 	AppsSuccess bool
+	// Extras holds the backend-specific readings of the most recent
+	// collection, zero when the latest collection failed.
+	Extras Extras
 	// ExitCode is the exit code of the most recent attempt, valid only when Attempted.
 	ExitCode int
 	// Duration is how long the most recent attempt took, valid only when Attempted.
@@ -62,6 +65,9 @@ type Reading struct {
 	AppsSuccess bool
 	// AppsErr is the per-process query's error, for source-owned logging only.
 	AppsErr error
+	// Extras holds the backend-specific readings outside the query-field
+	// schema. Like Apps, extras fail softly and never fail the collection.
+	Extras Extras
 }
 
 // QueryFunc runs one collection cycle: the nvidia-smi GPU query, plus the
@@ -150,6 +156,7 @@ func collectOnce(
 	snapshot.Apps = reading.Apps
 	snapshot.AppsAttempted = reading.AppsAttempted
 	snapshot.AppsSuccess = reading.AppsSuccess
+	snapshot.Extras = reading.Extras
 	snapshot.LastSuccess = now
 
 	return snapshot

--- a/internal/collect/extras.go
+++ b/internal/collect/extras.go
@@ -1,0 +1,39 @@
+package collect
+
+// Extras carries backend-specific readings that are outside the nvidia-smi
+// query-field schema. Every family follows the Apps contract: it fails
+// softly, so a family the backend cannot serve is nil/empty and never fails
+// the collection. The zero value means "no extras". Backends must build
+// fresh slices on every cycle: snapshots are shallow-copied to concurrent
+// scrapers, so a retained slice must never be mutated in place.
+type Extras struct {
+	// CUDAVersion is the CUDA version the installed driver supports (for
+	// example "13.1"), empty when unknown. Both backends fill it; the
+	// exporter renders it as the cuda_version label on gpu_info.
+	CUDAVersion string
+	// PCIe holds per-GPU PCIe throughput samples. Only the nvml backend
+	// fills it, and only under --collect.pcie-throughput.
+	PCIe []PCIeThroughput
+	// Energy holds per-GPU cumulative energy counters. Only the nvml
+	// backend fills it; devices that cannot report it are absent.
+	Energy []EnergyCounter
+}
+
+// PCIeThroughput is one GPU's sampled PCIe throughput.
+type PCIeThroughput struct {
+	// UUID is the GPU uuid, normalized like every uuid label.
+	UUID string
+	// TXBytesPerSecond and RXBytesPerSecond are sampled by the driver over
+	// two separate, consecutive 20ms windows, not one simultaneous pair.
+	TXBytesPerSecond float64
+	RXBytesPerSecond float64
+}
+
+// EnergyCounter is one GPU's cumulative energy consumption.
+type EnergyCounter struct {
+	// UUID is the GPU uuid, normalized like every uuid label.
+	UUID string
+	// Joules counts since the driver was last loaded. It resets when the
+	// driver reloads or the GPU is reset, both outside this process.
+	Joules float64
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -37,8 +37,25 @@ var NVMLReturnCodeMetric = ExitCodeMetric{
 	Help: "NVML return code of the most recent collection (0 = success)",
 }
 
+// uuidLabel is the GPU identity label every per-GPU metric carries.
+const uuidLabel = "uuid"
+
 // computeAppLabels is the label set on the per-process metrics.
-var computeAppLabels = []string{"uuid", "pid", "process_name"}
+var computeAppLabels = []string{uuidLabel, "pid", "process_name"}
+
+// Features selects the conditionally-described metric families. Each one
+// follows the compute-apps precedent: its descriptors exist only when the
+// feature is enabled, so Describe and Collect stay consistent and a disabled
+// feature leaves no trace in the output.
+type Features struct {
+	// ComputeApps enables the per-process metric families.
+	ComputeApps bool
+	// PCIeThroughput enables the per-GPU PCIe throughput gauges (nvml
+	// backend, --collect.pcie-throughput).
+	PCIeThroughput bool
+	// Energy enables the per-GPU cumulative energy counter (nvml backend).
+	Energy bool
+}
 
 // GPUExporter renders the latest collection as Prometheus metrics. It is
 // agnostic to how the reading is produced: the source may collect inline on
@@ -58,32 +75,40 @@ type GPUExporter struct {
 	appMemoryDesc         *prometheus.Desc
 	appCountDesc          *prometheus.Desc
 	appsSuccessDesc       *prometheus.Desc
+	pcieTxDesc            *prometheus.Desc
+	pcieRxDesc            *prometheus.Desc
+	energyDesc            *prometheus.Desc
 	logger                *slog.Logger
 	ctx                   context.Context //nolint:containedctx
 }
 
-// New builds the exporter. The per-process descriptors exist only when
-// computeApps is set: with the feature off they stay nil and the exporter
-// neither describes nor emits any per-process series.
+// New builds the exporter. A metric family whose feature is off in features
+// gets nil descriptors: the exporter neither describes nor emits its series.
 func New(
 	ctx context.Context,
 	prefix string,
 	fields nvidiasmi.ResolvedFields,
 	source collect.Source,
-	computeApps bool,
+	features Features,
 	exitCodeMetric ExitCodeMetric,
 	logger *slog.Logger,
 ) *GPUExporter {
 	qFieldToMetricInfoMap := BuildQFieldToMetricInfoMap(prefix, fields.Returned, logger)
 
-	infoLabels := make([]string, len(fields.Info))
-	for i, infoField := range fields.Info {
-		infoLabels[i] = infoField.Label
+	// cuda_version rides gpu_info but is not a query field: it comes from the
+	// collection's extras, so it is appended after the resolved info fields
+	// rather than joining them (the qfield schema must not see it)
+	infoLabels := make([]string, 0, len(fields.Info)+1)
+	for _, infoField := range fields.Info {
+		infoLabels = append(infoLabels, infoField.Label)
 	}
 
-	appInfoDesc, appMemoryDesc, appCountDesc, appsSuccessDesc := newComputeAppDescs(prefix, computeApps)
+	infoLabels = append(infoLabels, "cuda_version")
 
-	return &GPUExporter{
+	appInfoDesc, appMemoryDesc, appCountDesc, appsSuccessDesc := newComputeAppDescs(prefix, features.ComputeApps)
+	pcieTxDesc, pcieRxDesc := newPCIeDescs(prefix, features.PCIeThroughput)
+
+	exp := &GPUExporter{
 		ctx:                   ctx,
 		prefix:                prefix,
 		fields:                fields,
@@ -93,32 +118,10 @@ func New(
 		appMemoryDesc:         appMemoryDesc,
 		appCountDesc:          appCountDesc,
 		appsSuccessDesc:       appsSuccessDesc,
+		pcieTxDesc:            pcieTxDesc,
+		pcieRxDesc:            pcieRxDesc,
+		energyDesc:            newEnergyDesc(prefix, features.Energy),
 		logger:                logger,
-		failedScrapesDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "", "failed_scrapes_total"),
-			"Number of failed collections",
-			nil,
-			nil),
-		exitCodeDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "", exitCodeMetric.Name),
-			exitCodeMetric.Help,
-			nil,
-			nil),
-		collectSuccessDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "", "last_collect_success"),
-			"Whether the most recent collection succeeded (1) or not (0)",
-			nil,
-			nil),
-		collectTimestampDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "", "last_collect_success_timestamp_seconds"),
-			"Unix timestamp of the most recent successful collection",
-			nil,
-			nil),
-		collectDurationDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "", "last_collect_duration_seconds"),
-			"Duration of the most recent collection",
-			nil,
-			nil),
 		gpuInfoDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, "", "gpu_info"),
 			fmt.Sprintf("A metric with a constant '1' value labeled by gpu %s.",
@@ -126,6 +129,39 @@ func New(
 			infoLabels,
 			nil),
 	}
+
+	addHealthDescs(exp, prefix, exitCodeMetric)
+
+	return exp
+}
+
+// addHealthDescs builds the collection health descriptors.
+func addHealthDescs(exp *GPUExporter, prefix string, exitCodeMetric ExitCodeMetric) {
+	exp.failedScrapesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "failed_scrapes_total"),
+		"Number of failed collections",
+		nil,
+		nil)
+	exp.exitCodeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", exitCodeMetric.Name),
+		exitCodeMetric.Help,
+		nil,
+		nil)
+	exp.collectSuccessDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "last_collect_success"),
+		"Whether the most recent collection succeeded (1) or not (0)",
+		nil,
+		nil)
+	exp.collectTimestampDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "last_collect_success_timestamp_seconds"),
+		"Unix timestamp of the most recent successful collection",
+		nil,
+		nil)
+	exp.collectDurationDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "last_collect_duration_seconds"),
+		"Duration of the most recent collection",
+		nil,
+		nil)
 }
 
 // newComputeAppDescs builds the per-process metric descriptors (info, memory,
@@ -151,7 +187,7 @@ func newComputeAppDescs(
 	count := prometheus.NewDesc(
 		prometheus.BuildFQName(prefix, "", "compute_apps"),
 		"Number of processes with a compute context on the GPU.",
-		[]string{"uuid"},
+		[]string{uuidLabel},
 		nil)
 	success := prometheus.NewDesc(
 		prometheus.BuildFQName(prefix, "", "compute_apps_last_collect_success"),
@@ -160,6 +196,42 @@ func newComputeAppDescs(
 		nil)
 
 	return info, memory, count, success
+}
+
+// newPCIeDescs builds the PCIe throughput descriptors, nil when the feature
+// is disabled.
+func newPCIeDescs(prefix string, enabled bool) (*prometheus.Desc, *prometheus.Desc) {
+	if !enabled {
+		return nil, nil
+	}
+
+	tx := prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "pcie_throughput_tx_bytes_per_second"),
+		"PCIe traffic transmitted by the GPU, sampled by the driver over a dedicated 20ms window.",
+		[]string{uuidLabel},
+		nil)
+	rx := prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "pcie_throughput_rx_bytes_per_second"),
+		"PCIe traffic received by the GPU, sampled by the driver over a dedicated 20ms window.",
+		[]string{uuidLabel},
+		nil)
+
+	return tx, rx
+}
+
+// newEnergyDesc builds the energy counter descriptor, nil when the feature is
+// disabled.
+func newEnergyDesc(prefix string, enabled bool) *prometheus.Desc {
+	if !enabled {
+		return nil
+	}
+
+	return prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "energy_joules_total"),
+		"Total energy consumed by the GPU in joules since the driver was last loaded. "+
+			"Resets on a driver reload; absent on GPUs that cannot report it.",
+		[]string{uuidLabel},
+		nil)
 }
 
 // WithContext returns a collector that renders the same metrics but bounds
@@ -194,6 +266,15 @@ func (e *GPUExporter) Describe(descCh chan<- *prometheus.Desc) {
 		e.sendDesc(descCh, e.appCountDesc)
 		e.sendDesc(descCh, e.appsSuccessDesc)
 	}
+
+	if e.pcieTxDesc != nil {
+		e.sendDesc(descCh, e.pcieTxDesc)
+		e.sendDesc(descCh, e.pcieRxDesc)
+	}
+
+	if e.energyDesc != nil {
+		e.sendDesc(descCh, e.energyDesc)
+	}
 }
 
 // Collect fetches the latest reading from the source and delivers it as
@@ -208,10 +289,51 @@ func (e *GPUExporter) Collect(metricCh chan<- prometheus.Metric) {
 	}
 
 	for _, currentRow := range snapshot.Table.Rows {
-		e.renderRow(metricCh, currentRow)
+		e.renderRow(metricCh, currentRow, snapshot.Extras.CUDAVersion)
 	}
 
 	e.renderApps(metricCh, snapshot)
+	e.renderExtras(metricCh, snapshot)
+}
+
+// renderExtras emits the backend-specific families carried outside the
+// query-field schema. A nil descriptor (feature off) or an empty family emits
+// nothing: per family, absence is the signal for "could not be read".
+func (e *GPUExporter) renderExtras(metricCh chan<- prometheus.Metric, snapshot collect.Snapshot) {
+	if e.pcieTxDesc != nil {
+		for _, sample := range snapshot.Extras.PCIe {
+			e.sendConstWithUUID(metricCh, e.pcieTxDesc, prometheus.GaugeValue,
+				sample.TXBytesPerSecond, sample.UUID)
+			e.sendConstWithUUID(metricCh, e.pcieRxDesc, prometheus.GaugeValue,
+				sample.RXBytesPerSecond, sample.UUID)
+		}
+	}
+
+	if e.energyDesc != nil {
+		for _, counter := range snapshot.Extras.Energy {
+			e.sendConstWithUUID(metricCh, e.energyDesc, prometheus.CounterValue,
+				counter.Joules, counter.UUID)
+		}
+	}
+}
+
+// sendConstWithUUID emits one constant metric carrying the uuid label,
+// logging instead of failing if it cannot be built.
+func (e *GPUExporter) sendConstWithUUID(
+	metricCh chan<- prometheus.Metric,
+	desc *prometheus.Desc,
+	valueType prometheus.ValueType,
+	value float64,
+	uuid string,
+) {
+	metric, err := prometheus.NewConstMetric(desc, valueType, value, uuid)
+	if err != nil {
+		e.logger.Error("failed to create metric", "err", err, "desc", desc.String(), "uuid", uuid)
+
+		return
+	}
+
+	e.sendMetric(metricCh, metric)
 }
 
 // renderApps emits the per-process metrics. Failure must not look like idle:
@@ -345,11 +467,12 @@ func (e *GPUExporter) sendConst(
 }
 
 // renderRow emits the gpu_info metric and one metric per queried field for a
-// single GPU row.
-func (e *GPUExporter) renderRow(metricCh chan<- prometheus.Metric, row nvidiasmi.Row) {
+// single GPU row. cudaVersion fills the appended cuda_version label, which
+// comes from the collection's extras rather than the row's cells.
+func (e *GPUExporter) renderRow(metricCh chan<- prometheus.Metric, row nvidiasmi.Row, cudaVersion string) {
 	uuid := nvidiasmi.NormalizeUUID(row.QFieldToCells[nvidiasmi.UUIDQField].RawValue)
 
-	labelValues := make([]string, len(e.fields.Info))
+	labelValues := make([]string, len(e.fields.Info)+1)
 
 	for idx, infoField := range e.fields.Info {
 		if infoField.QField == nvidiasmi.UUIDQField {
@@ -360,6 +483,8 @@ func (e *GPUExporter) renderRow(metricCh chan<- prometheus.Metric, row nvidiasmi
 
 		labelValues[idx] = row.QFieldToCells[infoField.QField].RawValue
 	}
+
+	labelValues[len(e.fields.Info)] = cudaVersion
 
 	infoMetric, infoMetricErr := prometheus.NewConstMetric(e.gpuInfoDesc, prometheus.GaugeValue,
 		1, labelValues...)
@@ -444,7 +569,7 @@ func BuildQFieldToMetricInfoMap(
 
 func BuildMetricInfo(prefix string, rField nvidiasmi.RField, logger *slog.Logger) MetricInfo {
 	fqName, multiplier := BuildFQNameAndMultiplier(prefix, rField, logger)
-	desc := prometheus.NewDesc(fqName, string(rField), []string{"uuid"}, nil)
+	desc := prometheus.NewDesc(fqName, string(rField), []string{uuidLabel}, nil)
 
 	return MetricInfo{
 		desc:            desc,

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -208,7 +208,7 @@ func newTestExporter(
 
 	source := collect.NewLive(query, 0, nil, logger)
 
-	return exporter.New(ctx, prefix, resolved, source, false, exporter.ExecExitCodeMetric, logger)
+	return exporter.New(ctx, prefix, resolved, source, exporter.Features{}, exporter.ExecExitCodeMetric, logger)
 }
 
 // staticSource serves a fixed snapshot, for driving the render paths directly.
@@ -236,7 +236,29 @@ func newAppsExporter(t *testing.T, snapshot collect.Snapshot) *exporter.GPUExpor
 		"aaa",
 		resolved,
 		&staticSource{snapshot: snapshot},
-		true,
+		exporter.Features{ComputeApps: true},
+		exporter.ExecExitCodeMetric,
+		logger,
+	)
+}
+
+// newExtrasExporter wires an exporter with the given features to a fixed
+// snapshot, for driving the extras render paths directly.
+func newExtrasExporter(t *testing.T, features exporter.Features, snapshot collect.Snapshot) *exporter.GPUExporter {
+	t.Helper()
+
+	logger := slogt.New(t)
+
+	resolved, err := nvidiasmi.ResolveFields(
+		t.Context(), "bbb", "fan.speed", "", 0, nvidiasmi.DefaultRunFunc, logger)
+	require.NoError(t, err)
+
+	return exporter.New(
+		t.Context(),
+		"aaa",
+		resolved,
+		&staticSource{snapshot: snapshot},
+		features,
 		exporter.ExecExitCodeMetric,
 		logger,
 	)
@@ -451,7 +473,7 @@ func TestCollectDeliversMetricsOnFatalError(t *testing.T) {
 	}
 
 	source := collect.NewLive(query, 0, func(fatalErr error) { cancel(fatalErr) }, logger)
-	exp := exporter.New(ctx, "aaa", resolved, source, false, exporter.ExecExitCodeMetric, logger)
+	exp := exporter.New(ctx, "aaa", resolved, source, exporter.Features{}, exporter.ExecExitCodeMetric, logger)
 
 	families := gatherFamilies(t, exp)
 
@@ -552,7 +574,7 @@ func TestCollectComputeAppsDisabled(t *testing.T) {
 	// the feature is off
 	apps := []nvidiasmi.ComputeApp{{GPUUUID: "abc", PID: "42", ProcessName: "x", UsedMemory: "1 MiB"}}
 	source := &staticSource{snapshot: appsSnapshot(gpuTable("GPU-ABC"), apps, true)}
-	exp := exporter.New(t.Context(), "aaa", resolved, source, false, exporter.ExecExitCodeMetric, logger)
+	exp := exporter.New(t.Context(), "aaa", resolved, source, exporter.Features{}, exporter.ExecExitCodeMetric, logger)
 
 	families := gatherFamilies(t, exp)
 
@@ -560,4 +582,104 @@ func TestCollectComputeAppsDisabled(t *testing.T) {
 	assert.NotContains(t, families, "aaa_compute_apps")
 	assert.NotContains(t, families, "aaa_compute_app_info")
 	assert.NotContains(t, families, "aaa_compute_app_used_memory_bytes")
+}
+
+// extrasSnapshot builds a successful snapshot carrying the given extras.
+func extrasSnapshot(table *nvidiasmi.Table, extras collect.Extras) collect.Snapshot {
+	return collect.Snapshot{
+		Attempted:   true,
+		Success:     true,
+		Table:       table,
+		Extras:      extras,
+		LastSuccess: time.Now(),
+	}
+}
+
+// labelValue reads one label's value off a rendered metric.
+func labelValue(t *testing.T, metric *dto.Metric, name string) string {
+	t.Helper()
+
+	for _, label := range metric.GetLabel() {
+		if label.GetName() == name {
+			return label.GetValue()
+		}
+	}
+
+	t.Fatalf("label %s not found", name)
+
+	return ""
+}
+
+func TestExtrasRendered(t *testing.T) {
+	t.Parallel()
+
+	extras := collect.Extras{
+		CUDAVersion: "13.1",
+		PCIe: []collect.PCIeThroughput{
+			{UUID: "abc", TXBytesPerSecond: 123000, RXBytesPerSecond: 456000},
+		},
+		Energy: []collect.EnergyCounter{{UUID: "abc", Joules: 12345.678}},
+	}
+
+	features := exporter.Features{PCIeThroughput: true, Energy: true}
+	exp := newExtrasExporter(t, features, extrasSnapshot(gpuTable("GPU-ABC"), extras))
+
+	families := gatherFamilies(t, exp)
+
+	tx, ok := families["aaa_pcie_throughput_tx_bytes_per_second"]
+	require.True(t, ok)
+	assertFloat(t, 123000, tx.GetMetric()[0].GetGauge().GetValue())
+	assert.Equal(t, "abc", labelValue(t, tx.GetMetric()[0], "uuid"))
+
+	rx, ok := families["aaa_pcie_throughput_rx_bytes_per_second"]
+	require.True(t, ok)
+	assertFloat(t, 456000, rx.GetMetric()[0].GetGauge().GetValue())
+
+	energy, ok := families["aaa_energy_joules_total"]
+	require.True(t, ok)
+	assert.Equal(t, dto.MetricType_COUNTER, energy.GetType())
+	assertFloat(t, 12345.678, energy.GetMetric()[0].GetCounter().GetValue())
+	assert.Equal(t, "abc", labelValue(t, energy.GetMetric()[0], "uuid"))
+
+	info, ok := families["aaa_gpu_info"]
+	require.True(t, ok)
+	assert.Equal(t, "13.1", labelValue(t, info.GetMetric()[0], "cuda_version"))
+}
+
+func TestExtrasSuppressedWhenFeaturesOff(t *testing.T) {
+	t.Parallel()
+
+	// even a snapshot carrying extras data produces none of the gated
+	// families when the features are off
+	extras := collect.Extras{
+		CUDAVersion: "13.1",
+		PCIe:        []collect.PCIeThroughput{{UUID: "abc", TXBytesPerSecond: 1, RXBytesPerSecond: 2}},
+		Energy:      []collect.EnergyCounter{{UUID: "abc", Joules: 3}},
+	}
+
+	exp := newExtrasExporter(t, exporter.Features{}, extrasSnapshot(gpuTable("GPU-ABC"), extras))
+
+	families := gatherFamilies(t, exp)
+
+	assert.NotContains(t, families, "aaa_pcie_throughput_tx_bytes_per_second")
+	assert.NotContains(t, families, "aaa_pcie_throughput_rx_bytes_per_second")
+	assert.NotContains(t, families, "aaa_energy_joules_total")
+
+	// the cuda_version label is not feature-gated: it rides gpu_info in both
+	// backends
+	info, ok := families["aaa_gpu_info"]
+	require.True(t, ok)
+	assert.Equal(t, "13.1", labelValue(t, info.GetMetric()[0], "cuda_version"))
+}
+
+func TestCudaVersionLabelEmptyWhenUnknown(t *testing.T) {
+	t.Parallel()
+
+	exp := newExtrasExporter(t, exporter.Features{}, extrasSnapshot(gpuTable("GPU-ABC"), collect.Extras{}))
+
+	families := gatherFamilies(t, exp)
+
+	info, ok := families["aaa_gpu_info"]
+	require.True(t, ok)
+	assert.Empty(t, labelValue(t, info.GetMetric()[0], "cuda_version"))
 }

--- a/internal/integration/gpuparity_test.go
+++ b/internal/integration/gpuparity_test.go
@@ -5,6 +5,7 @@ package integration_test
 import (
 	"context"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -51,7 +52,7 @@ func TestBackendParityOnRealGPU(t *testing.T) {
 
 	// bracketed sampling: exec, native, exec
 	execBefore := queryExec(ctx, t, resolved)
-	nativeReading, _, err := backend.QueryFunc(nativeResolved, false)(ctx)
+	nativeReading, _, err := backend.QueryFunc(nativeResolved, nvmlnative.CollectOptions{})(ctx)
 	require.NoError(t, err)
 	execAfter := queryExec(ctx, t, resolved)
 
@@ -363,6 +364,35 @@ func TestBackendMetricFamilyParityOnRealGPU(t *testing.T) {
 	delete(execFamilies, "nvidia_smi_command_exit_code")
 	delete(nativeFamilies, "nvidia_smi_nvml_return_code")
 
+	// the always-on nvml-only families must be present, not merely allowed:
+	// a silently broken extras path must not pass as an accepted absence
+	// (the energy counter requires Volta or newer, which every GPU box
+	// qualifies as)
+	if !hasFamilyWithPrefix(nativeFamilies, "nvidia_smi_energy_joules_total") {
+		t.Error("nvml-only metric family missing from the nvml backend: nvidia_smi_energy_joules_total")
+	}
+
+	// cuda_version is derived independently per backend (the nvidia-smi
+	// --version text vs the NVML call), so a mismatch would fail the whole
+	// gpu_info family with a message that never mentions it; compare the
+	// label explicitly instead
+	execCuda := cudaVersionValues(execFamilies)
+	require.NotContains(t, execCuda, "",
+		"the exec backend parsed no CUDA version from nvidia-smi --version")
+	require.Equal(t, execCuda, cudaVersionValues(nativeFamilies),
+		"the two backends disagree on the cuda_version label")
+
+	// the opt-in PCIe throughput family is exercised under its flag
+	pcieFamilies := scrapeBackend(t, "nvml", "--collect.pcie-throughput")
+	for _, family := range []string{
+		"nvidia_smi_pcie_throughput_tx_bytes_per_second",
+		"nvidia_smi_pcie_throughput_rx_bytes_per_second",
+	} {
+		if _, ok := pcieFamilies[family]; !ok {
+			t.Errorf("metric family missing with --collect.pcie-throughput: %s", family)
+		}
+	}
+
 	for family, execSeries := range execFamilies {
 		nativeSeries, ok := nativeFamilies[family]
 		if !ok {
@@ -392,10 +422,66 @@ func TestBackendMetricFamilyParityOnRealGPU(t *testing.T) {
 	}
 
 	for family := range nativeFamilies {
-		if _, ok := execFamilies[family]; !ok {
+		if _, ok := execFamilies[family]; !ok && !isNVMLOnlyFamily(family) {
 			t.Errorf("metric family only the nvml backend exports\n  family: %s", family)
 		}
 	}
+}
+
+// nvmlOnlyFamilyPrefixes lists the metric family prefixes only the nvml
+// backend serves (the extras families). They are exempt from the family
+// parity requirement in the nvml direction, nothing more: presence is
+// asserted per scenario (always-on families in the default scrape, opt-in
+// families under their flag), since a single list doing both would force
+// every entry to appear in every scrape. Exec-only families remain a hard
+// failure.
+//
+//nolint:gochecknoglobals // shared test fixture
+var nvmlOnlyFamilyPrefixes = []string{
+	"nvidia_smi_energy_joules_total",
+	"nvidia_smi_pcie_throughput_",
+}
+
+func isNVMLOnlyFamily(family string) bool {
+	for _, prefix := range nvmlOnlyFamilyPrefixes {
+		if strings.HasPrefix(family, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasFamilyWithPrefix(families map[string]map[string]bool, prefix string) bool {
+	for family := range families {
+		if strings.HasPrefix(family, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// cudaVersionValues extracts the sorted set of cuda_version label values off
+// the gpu_info series.
+func cudaVersionValues(families map[string]map[string]bool) []string {
+	pattern := regexp.MustCompile(`cuda_version="([^"]*)"`)
+	seen := map[string]bool{}
+
+	for series := range families["nvidia_smi_gpu_info"] {
+		if match := pattern.FindStringSubmatch(series); match != nil {
+			seen[match[1]] = true
+		}
+	}
+
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+
+	slices.Sort(values)
+
+	return values
 }
 
 func anySeries(series map[string]bool) string {
@@ -408,14 +494,13 @@ func anySeries(series map[string]bool) string {
 
 // scrapeBackend runs the exporter in-process with the given backend and
 // returns nvidia_smi_* family -> set of series signatures (name{labels}).
-func scrapeBackend(t *testing.T, backend string) map[string]map[string]bool {
+func scrapeBackend(t *testing.T, backend string, extraArgs ...string) map[string]map[string]bool {
 	t.Helper()
 
-	baseURL := startExporter(t,
-		"--web.listen-address=127.0.0.1:0",
-		"--log.level=error",
-		"--collect.backend="+backend,
-	)
+	// startExporter injects the listen address and log level itself
+	args := append([]string{"--collect.backend=" + backend}, extraArgs...)
+
+	baseURL := startExporter(t, args...)
 	body := scrape(t, baseURL)
 
 	families := map[string]map[string]bool{}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -924,6 +924,23 @@ func TestNVMLBackendRejectsCustomCommand(t *testing.T) {
 	assert.Contains(t, err.Error(), "--nvidia-smi-command cannot be combined")
 }
 
+// TestExecBackendRejectsPcieThroughput pins the flag-validation contract in
+// the other direction: the PCIe throughput counters only exist in the driver
+// library, so requesting them with the exec backend must fail at startup.
+func TestExecBackendRejectsPcieThroughput(t *testing.T) {
+	t.Parallel()
+
+	err := app.Run(t.Context(), []string{
+		"--web.listen-address=127.0.0.1:0",
+		"--log.level=error",
+		"--collect.pcie-throughput",
+		"--nvidia-smi-command=" + fakeCommand(defaultCapture(t)),
+	}, app.Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--collect.pcie-throughput requires --collect.backend=nvml")
+}
+
 // TestNVMLBackendStartupFailureWithoutDriver pins the startup behavior on
 // machines without a usable NVML setup: builds without the backend fail with
 // the unavailability message, cgo builds fail initializing the absent

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__idle.metrics
@@ -112,9 +112,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7A.40.73"} 1
+nvidia_smi_gpu_info{compute_cap="7.5",cuda_version="13.2",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7A.40.73"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-2080-super__595.71.05__load.metrics
@@ -120,9 +120,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7A.40.73"} 1
+nvidia_smi_gpu_info{compute_cap="7.5",cuda_version="13.2",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7A.40.73"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__idle.metrics
@@ -148,9 +148,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 4080 SUPER",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x51101462",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.03.44.00.B2"} 1
+nvidia_smi_gpu_info{compute_cap="8.9",cuda_version="13.2",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 4080 SUPER",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x51101462",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.03.44.00.B2"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05__load.metrics
@@ -152,9 +152,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 4080 SUPER",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x51101462",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.03.44.00.B2"} 1
+nvidia_smi_gpu_info{compute_cap="8.9",cuda_version="13.2",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.71.05",index="0",name="NVIDIA GeForce RTX 4080 SUPER",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x51101462",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.03.44.00.B2"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h100-80gb-hbm3__590.48.01__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h100-80gb-hbm3__590.48.01__idle.metrics
@@ -205,9 +205,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h100-80gb-hbm3__590.48.01__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h100-80gb-hbm3__590.48.01__load.metrics
@@ -215,9 +215,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h100-mig__590.48.01__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h100-mig__590.48.01__idle.metrics
@@ -205,9 +205,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h100-mig__590.48.01__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h100-mig__590.48.01__load.metrics
@@ -215,9 +215,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H100 80GB HBM3",pci_bus_id="00000000:00:09.0",pci_sub_device_id="0x16C110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.01"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__idle.metrics
@@ -205,9 +205,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200-mig__590.48.01__load.metrics
@@ -215,9 +215,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__idle.metrics
@@ -205,9 +205,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-h200__590.48.01__load.metrics
@@ -215,9 +215,9 @@ nvidia_smi_fabric_state{uuid="00000000-0000-0000-0000-000000000000"} 3
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="9.0",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:83:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="96.00.A5.00.03"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__idle.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__idle.metrics
@@ -196,9 +196,9 @@ nvidia_smi_enforced_power_limit_watts{uuid="00000000-0000-0000-0000-000000000000
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.80",index="0",name="NVIDIA L40S",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x185110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.02.66.00.02"} 1
+nvidia_smi_gpu_info{compute_cap="8.9",cuda_version="13.2",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.80",index="0",name="NVIDIA L40S",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x185110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.02.66.00.02"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__load.metrics
+++ b/internal/integration/testdata/linux-x86_64__nvidia-l40s__595.80__load.metrics
@@ -204,9 +204,9 @@ nvidia_smi_enforced_power_limit_watts{uuid="00000000-0000-0000-0000-000000000000
 # HELP nvidia_smi_failed_scrapes_total Number of failed collections
 # TYPE nvidia_smi_failed_scrapes_total counter
 nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="8.9",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.80",index="0",name="NVIDIA L40S",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x185110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.02.66.00.02"} 1
+nvidia_smi_gpu_info{compute_cap="8.9",cuda_version="13.2",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="595.80",index="0",name="NVIDIA L40S",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x185110DE",serial="0000000000000",uuid="00000000-0000-0000-0000-000000000000",vbios_version="95.02.66.00.02"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__idle.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__idle.metrics
@@ -127,9 +127,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.37
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="591.86",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+nvidia_smi_gpu_info{compute_cap="7.5",cuda_version="13.1",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="591.86",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__load.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__591.86__load.metrics
@@ -129,9 +129,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="591.86",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+nvidia_smi_gpu_info{compute_cap="7.5",cuda_version="13.1",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="591.86",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__idle.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__idle.metrics
@@ -136,9 +136,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="610.62",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+nvidia_smi_gpu_info{compute_cap="7.5",cuda_version="13.3",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="610.62",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__load.metrics
+++ b/internal/integration/testdata/windows-x86_64__nvidia-geforce-rtx-2080-super__610.62__load.metrics
@@ -138,9 +138,9 @@ nvidia_smi_failed_scrapes_total 0
 # HELP nvidia_smi_fan_speed_ratio fan.speed [%]
 # TYPE nvidia_smi_fan_speed_ratio gauge
 nvidia_smi_fan_speed_ratio{uuid="00000000-0000-0000-0000-000000000000"} 0.38
-# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index.
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{compute_cap="7.5",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="610.62",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
+nvidia_smi_gpu_info{compute_cap="7.5",cuda_version="13.3",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="610.62",index="0",name="NVIDIA GeForce RTX 2080 SUPER",pci_bus_id="00000000:0C:00.0",pci_sub_device_id="0x40051458",serial="[N/A]",uuid="00000000-0000-0000-0000-000000000000",vbios_version="90.04.7a.40.73"} 1
 # HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
 # TYPE nvidia_smi_gpu_recovery_action gauge
 nvidia_smi_gpu_recovery_action{uuid="00000000-0000-0000-0000-000000000000"} 0

--- a/internal/nvidiasmi/version.go
+++ b/internal/nvidiasmi/version.go
@@ -1,0 +1,79 @@
+package nvidiasmi
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// cudaVersionValue is the shape of a plausible CUDA version value. Newer
+// drivers replace the value of a renamed line with prose (for example
+// `CUDA version : Deprecated, see "CUDA UMD version" instead`), so anything
+// that does not look like a version number must be ignored, not exported.
+var cudaVersionValue = regexp.MustCompile(`^[0-9]+\.[0-9]+$`)
+
+// QueryCudaVersion runs `nvidia-smi --version` once and extracts the CUDA
+// version the driver supports. It is best-effort: any failure returns the
+// empty string (logged once), which renders as an empty cuda_version label.
+// It runs at startup only, never per scrape.
+func QueryCudaVersion(
+	ctx context.Context,
+	command string,
+	timeout time.Duration,
+	run RunFunc,
+	logger *slog.Logger,
+) string {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	stdout, _, err := execQuery(ctx, command, run, "--version")
+	if err != nil {
+		logger.Warn("failed to read the CUDA version from nvidia-smi, "+
+			"the cuda_version label stays empty", "err", err)
+
+		return ""
+	}
+
+	version := ParseCudaVersion(stdout)
+	if version == "" {
+		logger.Warn("no CUDA version found in the nvidia-smi --version output, " +
+			"the cuda_version label stays empty")
+	}
+
+	return version
+}
+
+// ParseCudaVersion extracts the CUDA version from `nvidia-smi --version`
+// output. Drivers of the 610 branch and later rename the line to
+// "CUDA UMD version" and turn the old "CUDA version" line into a deprecation
+// pointer, so the UMD spelling wins and the legacy spelling is the fallback.
+func ParseCudaVersion(output string) string {
+	legacy := ""
+
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+
+		value = strings.TrimSpace(value)
+		if !cudaVersionValue.MatchString(value) {
+			continue
+		}
+
+		switch strings.ToLower(strings.Join(strings.Fields(key), " ")) {
+		case "cuda umd version":
+			return value
+		case "cuda version":
+			legacy = value
+		}
+	}
+
+	return legacy
+}

--- a/internal/nvidiasmi/version_test.go
+++ b/internal/nvidiasmi/version_test.go
@@ -1,0 +1,98 @@
+package nvidiasmi_test
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+// The parse cases replicate recorded `nvidia-smi --version` outputs from the
+// capture corpus verbatim: the classic spelling (Linux, driver 590) and the
+// renamed spelling of driver 610, where the legacy line carries a
+// deprecation pointer instead of a value.
+func TestParseCudaVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name: "classic spelling (driver 590, h100 capture)",
+			output: `NVIDIA-SMI version  : 590.48.01
+NVML version        : 590.48
+DRIVER version      : 590.48.01
+CUDA Version        : 13.1
+`,
+			want: "13.1",
+		},
+		{
+			name: "renamed UMD spelling (driver 610 capture)",
+			output: `NVIDIA-SMI version  : 610.62
+KMD version         : 610.62
+DRIVER version      : Deprecated, see "KMD version" instead
+CUDA version        : Deprecated, see "CUDA UMD version" instead
+CUDA UMD version    : 13.3
+`,
+			want: "13.3",
+		},
+		{
+			name: "UMD wins over a legacy line that still carries a value",
+			output: `CUDA version        : 13.2
+CUDA UMD version    : 13.3
+`,
+			want: "13.3",
+		},
+		{name: "empty output", output: "", want: ""},
+		{name: "no cuda line", output: "NVIDIA-SMI version  : 590.48.01\n", want: ""},
+		{
+			name:   "deprecation prose without a UMD line stays empty",
+			output: `CUDA version        : Deprecated, see "CUDA UMD version" instead` + "\n",
+			want:   "",
+		},
+		{
+			name:   "non-version value is not exported",
+			output: "CUDA Version        : N/A\n",
+			want:   "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, nvidiasmi.ParseCudaVersion(testCase.output))
+		})
+	}
+}
+
+func TestQueryCudaVersion(t *testing.T) {
+	t.Parallel()
+
+	run := func(cmd *exec.Cmd) error {
+		assert.Equal(t, []string{"--version"}, cmd.Args[1:])
+
+		_, err := cmd.Stdout.Write([]byte("CUDA Version        : 13.1\n"))
+
+		return err //nolint:wrapcheck // test stub
+	}
+
+	got := nvidiasmi.QueryCudaVersion(t.Context(), "nvidia-smi", time.Second, run, slogt.New(t))
+	assert.Equal(t, "13.1", got)
+}
+
+func TestQueryCudaVersionCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	run := func(*exec.Cmd) error { return errors.New("boom") }
+
+	got := nvidiasmi.QueryCudaVersion(t.Context(), "nvidia-smi", time.Second, run, slogt.New(t))
+	assert.Empty(t, got)
+}

--- a/internal/nvmlnative/backend_nvml.go
+++ b/internal/nvmlnative/backend_nvml.go
@@ -26,24 +26,30 @@ const Available = true
 // the lifecycle and collection logic is testable with the go-nvml mock
 // device. Device-level getters are already behind the nvml.Device interface.
 type nvmlAPI struct {
-	init            func() nvml.Return
-	shutdown        func() nvml.Return
-	deviceCount     func() (int, nvml.Return)
-	deviceByIndex   func(int) (nvml.Device, nvml.Return)
-	driverVersion   func() (string, nvml.Return)
-	processName     func(int) (string, nvml.Return)
-	validateInforom func(nvml.Device) nvml.Return
+	init              func() nvml.Return
+	shutdown          func() nvml.Return
+	deviceCount       func() (int, nvml.Return)
+	deviceByIndex     func(int) (nvml.Device, nvml.Return)
+	driverVersion     func() (string, nvml.Return)
+	cudaDriverVersion func() (int, nvml.Return)
+	processName       func(int) (string, nvml.Return)
+	validateInforom   func(nvml.Device) nvml.Return
 }
 
 func realNVML() nvmlAPI {
 	return nvmlAPI{
-		init:            nvml.Init,
-		shutdown:        nvml.Shutdown,
-		deviceCount:     nvml.DeviceGetCount,
-		deviceByIndex:   func(i int) (nvml.Device, nvml.Return) { return nvml.DeviceGetHandleByIndex(i) },
-		driverVersion:   nvml.SystemGetDriverVersion,
-		processName:     nvml.SystemGetProcessName,
-		validateInforom: nvml.DeviceValidateInforom,
+		init:          nvml.Init,
+		shutdown:      nvml.Shutdown,
+		deviceCount:   nvml.DeviceGetCount,
+		deviceByIndex: func(i int) (nvml.Device, nvml.Return) { return nvml.DeviceGetHandleByIndex(i) },
+		driverVersion: nvml.SystemGetDriverVersion,
+		// deliberately the unversioned entry point: the _v2 variant asks
+		// libcuda and fails without it, while this one falls back to the
+		// driver's known supported version. The utility-only container
+		// capability (the documented deployment) injects no libcuda.
+		cudaDriverVersion: nvml.SystemGetCudaDriverVersion,
+		processName:       nvml.SystemGetProcessName,
+		validateInforom:   nvml.DeviceValidateInforom,
 	}
 }
 
@@ -56,7 +62,15 @@ type Backend struct {
 	initialized bool
 	permLogged  bool
 	fnfLogged   bool
-	logger      *slog.Logger
+	// lastCUDAVersion retains the most recent successfully read CUDA version
+	// so a transient per-cycle failure does not flap the gpu_info series to
+	// an empty cuda_version label. Guarded by mu like the rest of the cycle
+	// state.
+	lastCUDAVersion string
+	// extrasWarned makes a persistent extras failure visible exactly once
+	// per family, mirroring permLogged/fnfLogged.
+	extrasWarned map[string]bool
+	logger       *slog.Logger
 }
 
 // New dlopens and initializes NVML. Failure here is a startup error: the
@@ -156,7 +170,7 @@ func tok(ret nvml.Return) string {
 // piling up behind the stuck call. A FatalError surfaced by the abandoned
 // goroutine after abandonment is discarded with the rest of its result;
 // shutdown-on-error then fires one cycle later, when the re-detection runs.
-func (b *Backend) QueryFunc(fields nvidiasmi.ResolvedFields, computeApps bool) collect.QueryFunc {
+func (b *Backend) QueryFunc(fields nvidiasmi.ResolvedFields, opts CollectOptions) collect.QueryFunc {
 	return func(ctx context.Context) (collect.Reading, int, error) {
 		type outcome struct {
 			reading collect.Reading
@@ -167,7 +181,7 @@ func (b *Backend) QueryFunc(fields nvidiasmi.ResolvedFields, computeApps bool) c
 		resultCh := make(chan outcome, 1)
 
 		go func() {
-			reading, code, err := b.collectCycle(ctx, fields, computeApps)
+			reading, code, err := b.collectCycle(ctx, fields, opts)
 			resultCh <- outcome{reading: reading, code: code, err: err}
 		}()
 
@@ -188,7 +202,7 @@ func (b *Backend) QueryFunc(fields nvidiasmi.ResolvedFields, computeApps bool) c
 func (b *Backend) collectCycle(
 	ctx context.Context,
 	fields nvidiasmi.ResolvedFields,
-	computeApps bool,
+	opts CollectOptions,
 ) (collect.Reading, int, error) {
 	if !b.mu.TryLock() {
 		return collect.Reading{}, -1,
@@ -203,7 +217,7 @@ func (b *Backend) collectCycle(
 
 	reading := collect.Reading{Table: table}
 
-	if computeApps {
+	if opts.ComputeApps {
 		reading.AppsAttempted = true
 
 		apps, appsErr := b.collectComputeApps(ctx)
@@ -214,6 +228,8 @@ func (b *Backend) collectCycle(
 			reading.AppsSuccess = true
 		}
 	}
+
+	reading.Extras = b.collectExtras(ctx, opts)
 
 	return reading, code, nil
 }
@@ -1248,4 +1264,182 @@ func (b *Backend) softLifecycle(ret nvml.Return, err error) error {
 	}
 
 	return fmt.Errorf("%w: %s", err, ret.String())
+}
+
+// pcieThroughputKBMultiplier converts the driver's PCIe throughput reading
+// to bytes per second. NVML documents the unit as "KB/s"; whether that is
+// 1000 or 1024 bytes is pending live calibration, 1000 until proven
+// otherwise.
+const pcieThroughputKBMultiplier = 1000
+
+// collectExtras gathers the backend-specific readings that live outside the
+// query-field schema. Extras fail softly per the Reading contract: a family
+// that cannot be read is simply absent and the collection stays green. A
+// lifecycle-class return still marks the backend for re-initialization and
+// aborts the remaining extras work, since after markLost the library is
+// already shut down; whatever was collected before the abort is kept. The
+// caller holds the backend lock.
+//
+//nolint:cyclop // one linear pass over the extras families with per-device fallbacks
+func (b *Backend) collectExtras(ctx context.Context, opts CollectOptions) collect.Extras {
+	extras := collect.Extras{CUDAVersion: b.lastCUDAVersion}
+
+	if !b.initialized {
+		// a lifecycle error earlier in this cycle already tore NVML down
+		return extras
+	}
+
+	version, ret := b.api.cudaDriverVersion()
+
+	switch {
+	case ret == nvml.SUCCESS:
+		b.lastCUDAVersion = cudaVersionStr(version)
+		extras.CUDAVersion = b.lastCUDAVersion
+	case isLifecycleError(ret):
+		b.markLost()
+
+		return extras
+	default:
+		b.warnOnce("cuda-version", "cannot read the CUDA version", ret)
+	}
+
+	if !opts.Energy && !opts.PCIeThroughput {
+		return extras
+	}
+
+	count, ret := b.api.deviceCount()
+	if ret != nvml.SUCCESS {
+		b.extrasFailure("extras", "failed to enumerate devices for the extra metrics", ret)
+
+		return extras
+	}
+
+	for deviceIdx := range count {
+		if ctx.Err() != nil {
+			return extras
+		}
+
+		if !b.collectDeviceExtras(ctx, deviceIdx, opts, &extras) {
+			return extras
+		}
+	}
+
+	return extras
+}
+
+// collectDeviceExtras gathers one device's extras families. Reports whether
+// extras collection may continue: a non-lifecycle failure skips just this
+// device, a lifecycle-class one aborts the pass.
+func (b *Backend) collectDeviceExtras(
+	ctx context.Context,
+	deviceIdx int,
+	opts CollectOptions,
+	extras *collect.Extras,
+) bool {
+	dev, ret := b.api.deviceByIndex(deviceIdx)
+	if ret != nvml.SUCCESS {
+		return b.extrasFailure("extras", "failed to get a device for the extra metrics", ret)
+	}
+
+	uuid, ret := dev.GetUUID()
+	if ret != nvml.SUCCESS {
+		return b.extrasFailure("extras", "failed to get a device uuid for the extra metrics", ret)
+	}
+
+	uuid = nvidiasmi.NormalizeUUID(uuid)
+
+	if opts.Energy && !b.collectEnergy(dev, uuid, extras) {
+		return false
+	}
+
+	if opts.PCIeThroughput && !b.collectPcie(ctx, dev, uuid, extras) {
+		return false
+	}
+
+	return true
+}
+
+// collectEnergy appends one device's cumulative energy reading. A device
+// that cannot report it (pre-Volta) is skipped silently; other persistent
+// failures are logged once. Reports whether extras collection may continue.
+func (b *Backend) collectEnergy(dev nvml.Device, uuid string, extras *collect.Extras) bool {
+	millijoules, ret := dev.GetTotalEnergyConsumption()
+
+	//nolint:exhaustive // every other return is a plain failure
+	switch ret {
+	case nvml.SUCCESS:
+		extras.Energy = append(extras.Energy, collect.EnergyCounter{
+			UUID:   uuid,
+			Joules: float64(millijoules) / 1000.0,
+		})
+	case nvml.ERROR_NOT_SUPPORTED:
+	default:
+		return b.extrasFailure("energy", "cannot read the GPU energy counter", ret)
+	}
+
+	return true
+}
+
+// collectPcie appends one device's PCIe throughput sample. The two
+// directions are sampled over two consecutive 20ms driver windows, not one
+// simultaneous pair. Reports whether extras collection may continue.
+func (b *Backend) collectPcie(
+	ctx context.Context,
+	dev nvml.Device,
+	uuid string,
+	extras *collect.Extras,
+) bool {
+	tx, ret := dev.GetPcieThroughput(nvml.PCIE_UTIL_TX_BYTES)
+	if ret != nvml.SUCCESS {
+		return b.extrasFailure("pcie", "cannot sample the PCIe throughput", ret)
+	}
+
+	if ctx.Err() != nil {
+		return false
+	}
+
+	rx, ret := dev.GetPcieThroughput(nvml.PCIE_UTIL_RX_BYTES)
+	if ret != nvml.SUCCESS {
+		return b.extrasFailure("pcie", "cannot sample the PCIe throughput", ret)
+	}
+
+	extras.PCIe = append(extras.PCIe, collect.PCIeThroughput{
+		UUID:             uuid,
+		TXBytesPerSecond: float64(tx) * pcieThroughputKBMultiplier,
+		RXBytesPerSecond: float64(rx) * pcieThroughputKBMultiplier,
+	})
+
+	return true
+}
+
+// extrasFailure folds a failed extras call: a lifecycle-class return marks
+// the backend for re-initialization and stops the remaining extras work,
+// anything else skips just this reading. Either way the failure is logged
+// once per family. Reports whether extras collection may continue.
+func (b *Backend) extrasFailure(family, msg string, ret nvml.Return) bool {
+	b.warnOnce(family, msg, ret)
+
+	if isLifecycleError(ret) {
+		b.markLost()
+
+		return false
+	}
+
+	return true
+}
+
+// warnOnce logs a warning the first time a family fails, so a persistent
+// extras failure stays visible without flooding the log on every cycle.
+func (b *Backend) warnOnce(family, msg string, ret nvml.Return) {
+	if b.extrasWarned[family] {
+		return
+	}
+
+	if b.extrasWarned == nil {
+		b.extrasWarned = map[string]bool{}
+	}
+
+	b.extrasWarned[family] = true
+
+	b.logger.Warn(msg, "family", family, "nvml_return", ret.String())
 }

--- a/internal/nvmlnative/backend_nvml_internal_test.go
+++ b/internal/nvmlnative/backend_nvml_internal_test.go
@@ -48,9 +48,10 @@ func (f *fakeAPI) api() nvmlAPI {
 
 			return f.devices[i], nvml.SUCCESS
 		},
-		driverVersion:   func() (string, nvml.Return) { return "590.48.01", nvml.SUCCESS },
-		processName:     func(int) (string, nvml.Return) { return "/usr/bin/burn", nvml.SUCCESS },
-		validateInforom: func(nvml.Device) nvml.Return { return nvml.SUCCESS },
+		driverVersion:     func() (string, nvml.Return) { return "590.48.01", nvml.SUCCESS },
+		cudaDriverVersion: func() (int, nvml.Return) { return 13010, nvml.SUCCESS },
+		processName:       func(int) (string, nvml.Return) { return "/usr/bin/burn", nvml.SUCCESS },
+		validateInforom:   func(nvml.Device) nvml.Return { return nvml.SUCCESS },
 	}
 }
 
@@ -115,7 +116,7 @@ func TestCollectHappyPath(t *testing.T) {
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
 
-	reading, code, err := backend.QueryFunc(resolveFields(t, "power.draw"), false)(t.Context())
+	reading, code, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 0, code)
 	assert.Equal(t, "12.34 W", cellValue(t, reading.Table, "power.draw"))
@@ -133,7 +134,7 @@ func TestNotSupportedBecomesAbsentToken(t *testing.T) {
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
 
-	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), false)(t.Context())
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "[N/A]", cellValue(t, reading.Table, "power.draw"))
 }
@@ -153,7 +154,7 @@ func TestLifecycleErrorFailsCollectionAndReinitializes(t *testing.T) {
 
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
-	query := backend.QueryFunc(resolveFields(t, "power.draw"), false)
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})
 
 	_, code, err := query(t.Context())
 	require.Error(t, err)
@@ -179,7 +180,7 @@ func TestZeroDevicesIsAFailedCollection(t *testing.T) {
 	fake := &fakeAPI{}
 	backend := newTestBackend(t, fake)
 
-	_, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), false)(t.Context())
+	_, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})(t.Context())
 	require.ErrorContains(t, err, "no NVML devices")
 
 	var fatal *collect.FatalError
@@ -203,7 +204,7 @@ func TestUnknownFieldValueTypeDoesNotPanic(t *testing.T) {
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
 
-	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw.average"), false)(t.Context())
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw.average"), CollectOptions{})(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "[N/A]", cellValue(t, reading.Table, "power.draw.average"))
 }
@@ -220,7 +221,12 @@ func TestComputeAppsFailSoftlyButMarkLifecycle(t *testing.T) {
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
 
-	reading, code, err := backend.QueryFunc(resolveFields(t, "power.draw"), true)(t.Context())
+	reading, code, err := backend.QueryFunc(
+		resolveFields(t, "power.draw"),
+		CollectOptions{ComputeApps: true},
+	)(
+		t.Context(),
+	)
 	require.NoError(t, err, "per-process failures must not fail the collection")
 	assert.Equal(t, 0, code)
 	assert.True(t, reading.AppsAttempted)
@@ -241,7 +247,7 @@ func TestComputeAppsHappyPath(t *testing.T) {
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
 
-	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), true)(t.Context())
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{ComputeApps: true})(t.Context())
 	require.NoError(t, err)
 	require.Len(t, reading.Apps, 1)
 	assert.Equal(t, "4242", reading.Apps[0].PID)
@@ -263,7 +269,7 @@ func TestAbandonedCollectionFailsFastAndRecovers(t *testing.T) {
 
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
-	query := backend.QueryFunc(resolveFields(t, "power.draw"), false)
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})
 
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
@@ -311,7 +317,7 @@ func TestCloseSkipsWhenCollectionHoldsTheDriver(t *testing.T) {
 
 	fake := &fakeAPI{devices: []nvml.Device{dev}}
 	backend := newTestBackend(t, fake)
-	query := backend.QueryFunc(resolveFields(t, "power.draw"), false)
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})
 
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
@@ -347,7 +353,7 @@ func TestFunctionNotFoundIsLoggedOnce(t *testing.T) {
 	backend, err := newWithAPI(fake.api(), slog.New(handler))
 	require.NoError(t, err)
 
-	query := backend.QueryFunc(resolveFields(t, "power.draw"), false)
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})
 
 	reading, _, err := query(t.Context())
 	require.NoError(t, err, "a missing optional function must not fail the collection")
@@ -360,4 +366,248 @@ func TestFunctionNotFoundIsLoggedOnce(t *testing.T) {
 	handler.AssertMessage("required NVML functions are unavailable in this driver; " +
 		"the affected fields will be absent - please report this on the project's issue tracker")
 	handler.AssertEmpty()
+}
+
+func TestExtrasCudaVersionRetainedAcrossTransientFailure(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+
+	failing := false
+	api := fake.api()
+	api.cudaDriverVersion = func() (int, nvml.Return) {
+		if failing {
+			return 0, nvml.ERROR_UNKNOWN
+		}
+
+		return 13010, nvml.SUCCESS
+	}
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})
+
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "13.1", reading.Extras.CUDAVersion)
+
+	// a transient failure must not flap the label to empty
+	failing = true
+
+	reading, _, err = query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "13.1", reading.Extras.CUDAVersion)
+}
+
+func TestExtrasCudaVersionUnavailable(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+
+	api := fake.api()
+	api.cudaDriverVersion = func() (int, nvml.Return) { return 0, nvml.ERROR_FUNCTION_NOT_FOUND }
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{})(t.Context())
+	require.NoError(t, err, "an unreadable CUDA version must not fail the collection")
+	assert.Empty(t, reading.Extras.CUDAVersion)
+}
+
+func TestExtrasEnergyCounter(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetTotalEnergyConsumptionFunc = func() (uint64, nvml.Return) { return 12345678, nvml.SUCCESS }
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	opts := CollectOptions{Energy: true}
+
+	reading, code, err := backend.QueryFunc(resolveFields(t, "power.draw"), opts)(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+
+	require.Len(t, reading.Extras.Energy, 1)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", reading.Extras.Energy[0].UUID)
+	assert.InDelta(t, 12345.678, reading.Extras.Energy[0].Joules, 1e-9)
+	// the pcie getter has no stub: reaching it would have panicked, so this
+	// test also proves the disabled extras are never collected
+}
+
+func TestExtrasEnergyNotSupportedSkipsDevice(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetTotalEnergyConsumptionFunc = func() (uint64, nvml.Return) {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{Energy: true})(t.Context())
+	require.NoError(t, err, "a pre-Volta GPU must not fail the collection")
+	assert.Empty(t, reading.Extras.Energy)
+}
+
+func TestExtrasPcieThroughput(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetPcieThroughputFunc = func(counter nvml.PcieUtilCounter) (uint32, nvml.Return) {
+		if counter == nvml.PCIE_UTIL_TX_BYTES {
+			return 100, nvml.SUCCESS
+		}
+
+		return 200, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	opts := CollectOptions{PCIeThroughput: true}
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), opts)(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, reading.Extras.PCIe, 1)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", reading.Extras.PCIe[0].UUID)
+	assert.InDelta(t, 100000, reading.Extras.PCIe[0].TXBytesPerSecond, 1e-9)
+	assert.InDelta(t, 200000, reading.Extras.PCIe[0].RXBytesPerSecond, 1e-9)
+}
+
+func TestExtrasLifecycleErrorStaysSoftAndMarksLost(t *testing.T) {
+	t.Parallel()
+
+	lost := true
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetTotalEnergyConsumptionFunc = func() (uint64, nvml.Return) {
+		if lost {
+			return 0, nvml.ERROR_GPU_IS_LOST
+		}
+
+		return 1000, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{Energy: true})
+
+	// the cycle stays green: extras never fail the collection, but the
+	// lifecycle-class return still marks the backend for re-initialization
+	reading, code, err := query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, reading.Extras.Energy)
+	assert.Equal(t, "12.34 W", cellValue(t, reading.Table, "power.draw"))
+
+	lost = false
+
+	reading, _, err = query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, fake.inits, "the next cycle must re-initialize NVML")
+	require.Len(t, reading.Extras.Energy, 1)
+}
+
+func TestExtrasNonLifecycleFailureSkipsOnlyThatDevice(t *testing.T) {
+	t.Parallel()
+
+	// device 0's uuid reads fine during the table pass but fails with a
+	// non-lifecycle error during the extras pass: only that device's extras
+	// may be dropped, device 1 must still report
+	dev0 := identityDevice()
+	dev0.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+
+	uuidCalls := 0
+	dev0.GetUUIDFunc = func() (string, nvml.Return) {
+		uuidCalls++
+		if uuidCalls > 1 {
+			return "", nvml.ERROR_UNKNOWN
+		}
+
+		return "GPU-11111111-2222-3333-4444-555555555555", nvml.SUCCESS
+	}
+
+	dev1 := identityDevice()
+	dev1.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev1.GetUUIDFunc = func() (string, nvml.Return) {
+		return "GPU-99999999-2222-3333-4444-555555555555", nvml.SUCCESS
+	}
+	dev1.GetTotalEnergyConsumptionFunc = func() (uint64, nvml.Return) { return 2000, nvml.SUCCESS }
+
+	fake := &fakeAPI{devices: []nvml.Device{dev0, dev1}}
+	backend := newTestBackend(t, fake)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), CollectOptions{Energy: true})(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, reading.Extras.Energy, 1, "device 1 must survive device 0's non-lifecycle failure")
+	assert.Equal(t, "99999999-2222-3333-4444-555555555555", reading.Extras.Energy[0].UUID)
+	assert.Equal(t, 0, fake.shutdowns, "a non-lifecycle failure must not tear NVML down")
+}
+
+func TestExtrasLifecycleAbortsRemainingDevices(t *testing.T) {
+	t.Parallel()
+
+	// device 0's energy read hits a lifecycle error with PCIe also enabled:
+	// device 0's pcie getter and device 1's energy getter have no stubs, so
+	// reaching either would panic, proving the abort covers the rest of the
+	// device and all later devices
+	dev0 := identityDevice()
+	dev0.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev0.GetTotalEnergyConsumptionFunc = func() (uint64, nvml.Return) {
+		return 0, nvml.ERROR_GPU_IS_LOST
+	}
+
+	dev1 := identityDevice()
+	dev1.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev1.GetUUIDFunc = func() (string, nvml.Return) {
+		return "GPU-99999999-2222-3333-4444-555555555555", nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev0, dev1}}
+	backend := newTestBackend(t, fake)
+
+	opts := CollectOptions{Energy: true, PCIeThroughput: true}
+
+	reading, code, err := backend.QueryFunc(resolveFields(t, "power.draw"), opts)(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Empty(t, reading.Extras.Energy)
+	assert.Empty(t, reading.Extras.PCIe)
+	assert.Equal(t, 1, fake.shutdowns, "the lifecycle error must mark the backend for re-init")
+}
+
+func TestExtrasPcieNotSupportedSkipsDevice(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetPcieThroughputFunc = func(nvml.PcieUtilCounter) (uint32, nvml.Return) {
+		return 0, nvml.ERROR_NOT_SUPPORTED
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	opts := CollectOptions{PCIeThroughput: true}
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), opts)(t.Context())
+	require.NoError(t, err, "an unsupported PCIe counter must not fail the collection")
+	assert.Empty(t, reading.Extras.PCIe)
+	assert.Equal(t, 0, fake.shutdowns, "NOT_SUPPORTED is not a lifecycle error")
 }

--- a/internal/nvmlnative/backend_unavailable.go
+++ b/internal/nvmlnative/backend_unavailable.go
@@ -35,6 +35,6 @@ func (b *Backend) Close() {}
 func (b *Backend) DriverVersion() string { return "" }
 
 // QueryFunc is never reachable: New always fails first.
-func (b *Backend) QueryFunc(_ nvidiasmi.ResolvedFields, _ bool) collect.QueryFunc {
+func (b *Backend) QueryFunc(_ nvidiasmi.ResolvedFields, _ CollectOptions) collect.QueryFunc {
 	panic("nvml backend is not available in this build")
 }

--- a/internal/nvmlnative/format.go
+++ b/internal/nvmlnative/format.go
@@ -40,6 +40,13 @@ func yesNo(b bool) string {
 
 func milliwatts(mw uint32) string { return fmt.Sprintf("%.2f W", float64(mw)/1000.0) }
 
+// cudaVersionStr renders the encoded integer from
+// nvmlSystemGetCudaDriverVersion (major*1000 + minor*10) the way nvidia-smi
+// prints the CUDA version: 13010 -> "13.1".
+func cudaVersionStr(version int) string {
+	return fmt.Sprintf("%d.%d", version/1000, (version%1000)/10)
+}
+
 func mhz(v uint32) string { return fmt.Sprintf("%d MHz", v) }
 
 // mib formats a byte count the way nvidia-smi prints MiB values: CEILED, not

--- a/internal/nvmlnative/format_internal_test.go
+++ b/internal/nvmlnative/format_internal_test.go
@@ -69,3 +69,13 @@ func TestUUIDBytes(t *testing.T) {
 	assert.Equal(t, "01020304-0506-0708-090a-0b0c0d0e0f10",
 		uuidBytes([16]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
 }
+
+func TestCudaVersionStr(t *testing.T) {
+	t.Parallel()
+
+	// 13010 is the encoded form of the capture-verified "13.1" (driver 590)
+	assert.Equal(t, "13.1", cudaVersionStr(13010))
+	assert.Equal(t, "13.3", cudaVersionStr(13030))
+	assert.Equal(t, "12.8", cudaVersionStr(12080))
+	assert.Equal(t, "0.0", cudaVersionStr(0))
+}

--- a/internal/nvmlnative/options.go
+++ b/internal/nvmlnative/options.go
@@ -1,0 +1,16 @@
+package nvmlnative
+
+// CollectOptions selects the optional per-cycle work beyond the resolved
+// query fields. The extras it enables are outside the nvidia-smi query-field
+// schema, so they are gated here at startup rather than through the
+// per-cycle field plan.
+type CollectOptions struct {
+	// ComputeApps enables the per-process query.
+	ComputeApps bool
+	// PCIeThroughput enables per-GPU PCIe throughput sampling. Each reading
+	// blocks inside the driver for a 20ms sampling window per direction, so
+	// this is a deliberate opt-in (--collect.pcie-throughput).
+	PCIeThroughput bool
+	// Energy enables the per-GPU cumulative energy counter.
+	Energy bool
+}

--- a/internal/nvmlnative/symbols.go
+++ b/internal/nvmlnative/symbols.go
@@ -27,7 +27,22 @@ var nvmlSymbolRequirements = []symbolRequirement{
 		serves: "device enumeration",
 	},
 	{goCall: "driverVersion", anyOf: []string{"nvmlSystemGetDriverVersion"}, serves: "driver_version"},
+	{
+		goCall: "cudaDriverVersion",
+		anyOf:  []string{"nvmlSystemGetCudaDriverVersion"},
+		serves: "gpu_info cuda_version label",
+	},
 	{goCall: "processName", anyOf: []string{"nvmlSystemGetProcessName"}, serves: "per-process metrics"},
+	{
+		goCall: "GetTotalEnergyConsumption",
+		anyOf:  []string{"nvmlDeviceGetTotalEnergyConsumption"},
+		serves: "energy_joules_total",
+	},
+	{
+		goCall: "GetPcieThroughput",
+		anyOf:  []string{"nvmlDeviceGetPcieThroughput"},
+		serves: "pcie_throughput_*_bytes_per_second",
+	},
 	{goCall: "validateInforom", anyOf: []string{"nvmlDeviceValidateInforom"}, serves: "inforom.checksum_validation"},
 	{
 		goCall: "GetName",


### PR DESCRIPTION
The nvml backend now exports metrics the nvidia-smi interface cannot provide, making its metric surface a superset of the default backend. A total energy counter is always on, and PCIe TX/RX throughput gauges sit behind a new opt-in flag whose help text documents the per-collection sampling cost. The docs describe the two backends with a capabilities matrix instead of claiming identical output, and the command line reference is regenerated from the current help output.

Both backends also report the CUDA version the installed driver supports as a new label on the GPU info metric. The default backend reads it once at startup from the nvidia-smi version output, understanding both the classic spelling and the renamed spelling of driver 610 and later, and never adds a per-scrape process run. The nvml backend asks the library directly and keeps the last known value across transient failures.

The extra readings ride the collection pipeline the same way the per-process data does. They fail softly and never fail a collection, while a driver lifecycle error during their collection still schedules a re-initialization for the next cycle.

Closes #391. Closes #127.