### PR TITLE
feat(nvml): add per-MIG-instance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This makes it possible to run it on Windows and get GPU metrics while gaming - n
 It can also skip `nvidia-smi` and read the metrics straight from the NVIDIA
 Management Library (NVML), the C library `nvidia-smi` itself is built on. This
 mode is experimental and exports a superset of the default mode's metrics: the
-same core set plus NVML-only extras like the GPU energy counter and opt-in
-PCIe throughput; see [CONFIGURE.md](docs/CONFIGURE.md).
+same core set plus NVML-only extras like the GPU energy counter, per-MIG-instance
+metrics and opt-in PCIe throughput; see [CONFIGURE.md](docs/CONFIGURE.md).
 
 This project is based on [a0s/nvidia-smi-exporter](https://github.com/a0s/nvidia-smi-exporter).
 However, this one is written in Go to produce a single, static binary.

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -13,7 +13,8 @@ To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
 variant (for example `1.7.0-nvml`). It exports a superset of the default
 backend's metrics: the same core set plus NVML-only extras like the GPU
-energy counter and opt-in PCIe throughput. The `-nvml` images are built for
+energy counter, per-MIG-instance metrics and opt-in PCIe throughput. The
+`-nvml` images are built for
 linux/amd64 only, so on mixed-architecture clusters add
 `kubernetes.io/arch: amd64` to `nodeSelector`.
 
@@ -81,8 +82,14 @@ helm upgrade nvidia-gpu-exporter oci://ghcr.io/utkuozdemir/charts/nvidia-gpu-exp
 On MIG-enabled GPUs the requirements are steeper: the exporter container must
 run privileged with the `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable
 (via `securityContext` and `extraEnv`) on top of `hostPID`, otherwise even
-GPU-level memory fields read `[Insufficient Permissions]`. Processes are
-attributed to the parent GPU's UUID, not to individual MIG instances.
+GPU-level memory fields read `[Insufficient Permissions]`. By default
+processes are attributed to the parent GPU's UUID, not to individual MIG
+instances; on the `-nvml` image the attribution labels can be added with
+
+```yaml
+extraArgs:
+  - --collect.compute-apps-mig
+```
 
 ## Scheduling on GPU nodes
 

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -13,7 +13,8 @@ To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
 variant (for example `1.7.0-nvml`). It exports a superset of the default
 backend's metrics: the same core set plus NVML-only extras like the GPU
-energy counter and opt-in PCIe throughput. The `-nvml` images are built for
+energy counter, per-MIG-instance metrics and opt-in PCIe throughput. The
+`-nvml` images are built for
 linux/amd64 only, so on mixed-architecture clusters add
 `kubernetes.io/arch: amd64` to `nodeSelector`.
 
@@ -81,8 +82,14 @@ helm upgrade nvidia-gpu-exporter oci://ghcr.io/utkuozdemir/charts/nvidia-gpu-exp
 On MIG-enabled GPUs the requirements are steeper: the exporter container must
 run privileged with the `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable
 (via `securityContext` and `extraEnv`) on top of `hostPID`, otherwise even
-GPU-level memory fields read `[Insufficient Permissions]`. Processes are
-attributed to the parent GPU's UUID, not to individual MIG instances.
+GPU-level memory fields read `[Insufficient Permissions]`. By default
+processes are attributed to the parent GPU's UUID, not to individual MIG
+instances; on the `-nvml` image the attribution labels can be added with
+
+```yaml
+extraArgs:
+  - --collect.compute-apps-mig
+```
 
 ## Scheduling on GPU nodes
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -93,6 +93,12 @@ Flags:
                                 other workloads' processes requires sharing
                                 the host PID namespace (hostPID in Kubernetes,
                                 --pid=host in Docker).
+      --[no-]collect.compute-apps-mig
+                                Add MIG attribution labels (gpu_instance_id,
+                                compute_instance_id) to the per-process
+                                metrics (requires --collect.compute-apps and
+                                --collect.backend=nvml). Opt-in because it
+                                changes the label set of the per-process series.
       --[no-]collect.pcie-throughput
                                 Also export the PCIe TX/RX throughput per
                                 GPU (requires --collect.backend=nvml). Each
@@ -299,8 +305,11 @@ Things to keep in mind:
   manage the memory there, so `used_gpu_memory` is not available: the
   `compute_app_info` and `compute_apps` metrics still work, the
   `used_memory_bytes` metric is absent.
-- **MIG limits both attribution and container access.** Processes are
-  attributed to the parent GPU's UUID, not to MIG instances. A containerized
+- **MIG limits both attribution and container access.** By default (and
+  always with the exec backend) processes are attributed to the parent GPU's
+  UUID, not to MIG instances; the nvml backend can add per-instance
+  attribution labels via `--collect.compute-apps-mig` (see
+  [METRICS.md](METRICS.md)). A containerized
   exporter on a MIG-enabled GPU additionally needs to run privileged with the
   `NVIDIA_MIG_MONITOR_DEVICES=all` environment variable (plus host PID
   sharing), otherwise the per-process list and even some GPU-level fields
@@ -332,6 +341,8 @@ What each backend can do:
 | Brand-new driver fields before the catalog catches up (`AUTO`) | yes | no |
 | Total energy counter (`energy_joules_total`) | no | yes |
 | PCIe throughput (`--collect.pcie-throughput`) | no | yes |
+| Per-MIG-instance metrics (`mig_info`, `mig_memory_*`, `mig_*_ratio`) | no | yes |
+| Per-process MIG attribution (`--collect.compute-apps-mig`) | no | yes |
 
 The NVML-only families are documented in [METRICS.md](METRICS.md). The PCIe
 throughput family is opt-in via `--collect.pcie-throughput` because of its

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -29,6 +29,49 @@ interface, so only the NVML backend can export them:
   own 20ms counter window, so the two values are consecutive samples, not a
   simultaneous pair.
 
+On GPUs with MIG mode enabled, the NVML backend also exports per-MIG-instance
+metrics (nothing to configure, they appear when MIG instances exist):
+
+- `nvidia_smi_mig_info{uuid, mig_uuid, gpu_instance_id, compute_instance_id, profile}`
+  (constant `1`): the identity of each MIG device. `uuid` is the parent
+  GPU's, so MIG series join with all per-GPU series; `mig_uuid` is the MIG
+  device's own.
+- `nvidia_smi_mig_memory_{total,used,free,reserved}_bytes{uuid, gpu_instance_id}`
+  (gauges): the GPU instance's memory. The framebuffer belongs to the GPU
+  instance and is shared by its compute instances, so memory is reported
+  once per GPU instance (labeling it per MIG device would double-count on
+  instances hosting several compute slices).
+- `nvidia_smi_mig_{graphics_activity,sm_activity,sm_occupancy,tensor_activity}_ratio{uuid, gpu_instance_id}`
+  and `nvidia_smi_mig_pcie_throughput_{tx,rx}_bytes_per_second{uuid, gpu_instance_id}`
+  (gauges): the GPU instance's activity, computed over the window between
+  the two most recent collections. They appear from the second collection
+  that sees a GPU instance, and only on GPUs whose driver supports the GPM
+  interface (the Hopper generation and later; A100-class MIG gets inventory
+  and memory only). The window is guarded on both ends: collections less
+  than a second apart keep serving the previous values over the anchored
+  window, and after a gap longer than ten minutes the sampling reseeds (the
+  next collection emits nothing for that instance, like a first sight). The utilization is attributed per GPU instance, not per
+  MIG device: a GPU instance hosting several compute instances reports one
+  set of values, and joining `mig_info` on `(uuid, gpu_instance_id)` maps
+  them back to the MIG devices. With several independent scrapers the
+  window follows whoever collected last, so for stable windows pair this
+  with `--collect.interval`. Destroying a GPU instance and recreating a
+  different shape under the same numeric id is detected and reseeds the
+  activity sampling; recreating the exact same shape in the same placement
+  is indistinguishable (MIG uuids are deterministic), so the one window
+  spanning such a swap may blend the two instances before self-correcting.
+
+With `--collect.compute-apps-mig` (requires `--collect.compute-apps` and the
+NVML backend) the per-process metrics additionally carry `gpu_instance_id`
+and `compute_instance_id` labels attributing each process to its MIG
+instance (empty for processes on non-MIG GPUs). It is opt-in because it
+changes the label set of the per-process series.
+
+Container note: like the per-process metrics under MIG, full function needs
+generous privileges (the exporter container may need to run privileged with
+`NVIDIA_MIG_MONITOR_DEVICES=all` and share the host PID namespace); MIG
+inventory and memory worked unprivileged in testing.
+
 Both backends also stamp the CUDA version the installed driver supports onto
 `nvidia_smi_gpu_info` as the `cuda_version` label. This is the version of
 the CUDA API the driver carries, not an installed CUDA toolkit. The default

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -149,6 +149,12 @@ func Run(ctx context.Context, args []string, opts Options) error {
 				"container, seeing other workloads' processes requires sharing the host PID "+
 				"namespace (hostPID in Kubernetes, --pid=host in Docker).").
 			Default("false").Bool()
+		collectComputeAppsMIG = app.Flag("collect.compute-apps-mig",
+			"Add MIG attribution labels (gpu_instance_id, compute_instance_id) to the "+
+				"per-process metrics (requires --collect.compute-apps and "+
+				"--collect.backend=nvml). Opt-in because it changes the label set of the "+
+				"per-process series.").
+			Default("false").Bool()
 		collectPcieThroughput = app.Flag("collect.pcie-throughput",
 			"Also export the PCIe TX/RX throughput per GPU (requires --collect.backend=nvml). "+
 				"Each direction is sampled over a separate 20ms driver counter window, adding "+
@@ -190,7 +196,15 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		return err
 	}
 
-	if err := validateBackendFlags(*collectBackend, *nvidiaSmiCommand, *collectPcieThroughput); err != nil {
+	backendFlags := backendFlagSet{
+		backend:          *collectBackend,
+		nvidiaSmiCommand: *nvidiaSmiCommand,
+		pcieThroughput:   *collectPcieThroughput,
+		computeApps:      *collectComputeApps,
+		computeAppsMIG:   *collectComputeAppsMIG,
+	}
+
+	if err := validateBackendFlags(backendFlags); err != nil {
 		return err
 	}
 
@@ -212,6 +226,7 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		interval:         *collectInterval,
 		timeout:          *collectTimeout,
 		computeApps:      *collectComputeApps,
+		computeAppsMIG:   *collectComputeAppsMIG,
 		pcieThroughput:   *collectPcieThroughput,
 		onFatal:          onFatal,
 	}
@@ -299,18 +314,37 @@ func serveHTTP(
 	})
 }
 
+// backendFlagSet carries the flags whose combinations depend on the chosen
+// backend.
+type backendFlagSet struct {
+	backend          string
+	nvidiaSmiCommand string
+	pcieThroughput   bool
+	computeApps      bool
+	computeAppsMIG   bool
+}
+
 // validateBackendFlags rejects flag combinations the chosen backend cannot
 // honor, as errors rather than silent ignores.
-func validateBackendFlags(backend, nvidiaSmiCommand string, pcieThroughput bool) error {
-	if backend == backendNVML && nvidiaSmiCommand != nvidiasmi.DefaultCommand {
+func validateBackendFlags(flags backendFlagSet) error {
+	if flags.backend == backendNVML && flags.nvidiaSmiCommand != nvidiasmi.DefaultCommand {
 		// a custom command signals intent (ssh wrappers, sudo) the nvml
 		// backend cannot honor
 		return errors.New("--nvidia-smi-command cannot be combined with --collect.backend=nvml")
 	}
 
-	if backend != backendNVML && pcieThroughput {
+	if flags.backend != backendNVML && flags.pcieThroughput {
 		// the throughput counters only exist in the driver library
 		return errors.New("--collect.pcie-throughput requires --collect.backend=nvml")
+	}
+
+	if flags.computeAppsMIG && flags.backend != backendNVML {
+		// the per-process query output has no MIG attribution to parse
+		return errors.New("--collect.compute-apps-mig requires --collect.backend=nvml")
+	}
+
+	if flags.computeAppsMIG && !flags.computeApps {
+		return errors.New("--collect.compute-apps-mig requires --collect.compute-apps")
 	}
 
 	return nil
@@ -417,6 +451,7 @@ type collectConfig struct {
 	interval         time.Duration
 	timeout          time.Duration
 	computeApps      bool
+	computeAppsMIG   bool
 	pcieThroughput   bool
 	onFatal          func(error)
 }
@@ -453,10 +488,12 @@ func setupExporter(
 	}
 
 	features := exporter.Features{
-		ComputeApps: cfg.computeApps,
+		ComputeApps:         cfg.computeApps,
+		ComputeAppMIGLabels: cfg.computeAppsMIG,
 		// the extras families exist only in the nvml backend
 		PCIeThroughput: cfg.pcieThroughput,
 		Energy:         cfg.backend == backendNVML,
+		MIG:            cfg.backend == backendNVML,
 	}
 
 	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, features, exitCodeMetric, logger)
@@ -518,6 +555,7 @@ func setupBackend(
 			ComputeApps:    cfg.computeApps,
 			PCIeThroughput: cfg.pcieThroughput,
 			Energy:         true,
+			MIG:            true,
 		}
 
 		return resolved, backend.QueryFunc(resolved, opts), exporter.NVMLReturnCodeMetric, nil

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -139,28 +139,56 @@ func TestScrapeContext(t *testing.T) {
 	}
 }
 
+//nolint:funlen // table-driven flag matrix
 func TestValidateBackendFlags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		backend        string
-		command        string
-		pcieThroughput bool
-		wantErr        string
+		name    string
+		flags   backendFlagSet
+		wantErr string
 	}{
-		{name: "exec defaults", backend: backendExec, command: "nvidia-smi"},
-		{name: "exec with custom command", backend: backendExec, command: "sudo nvidia-smi"},
-		{name: "nvml defaults", backend: backendNVML, command: "nvidia-smi"},
-		{name: "nvml with pcie throughput", backend: backendNVML, command: "nvidia-smi", pcieThroughput: true},
+		{name: "exec defaults", flags: backendFlagSet{backend: backendExec, nvidiaSmiCommand: "nvidia-smi"}},
 		{
-			name: "nvml rejects custom command", backend: backendNVML, command: "sudo nvidia-smi",
+			name:  "exec with custom command",
+			flags: backendFlagSet{backend: backendExec, nvidiaSmiCommand: "sudo nvidia-smi"},
+		},
+		{name: "nvml defaults", flags: backendFlagSet{backend: backendNVML, nvidiaSmiCommand: "nvidia-smi"}},
+		{
+			name:  "nvml with pcie throughput",
+			flags: backendFlagSet{backend: backendNVML, nvidiaSmiCommand: "nvidia-smi", pcieThroughput: true},
+		},
+		{
+			name: "nvml with compute apps mig",
+			flags: backendFlagSet{
+				backend: backendNVML, nvidiaSmiCommand: "nvidia-smi",
+				computeApps: true, computeAppsMIG: true,
+			},
+		},
+		{
+			name:    "nvml rejects custom command",
+			flags:   backendFlagSet{backend: backendNVML, nvidiaSmiCommand: "sudo nvidia-smi"},
 			wantErr: "--nvidia-smi-command cannot be combined",
 		},
 		{
-			name: "exec rejects pcie throughput", backend: backendExec, command: "nvidia-smi",
-			pcieThroughput: true,
-			wantErr:        "--collect.pcie-throughput requires --collect.backend=nvml",
+			name:    "exec rejects pcie throughput",
+			flags:   backendFlagSet{backend: backendExec, nvidiaSmiCommand: "nvidia-smi", pcieThroughput: true},
+			wantErr: "--collect.pcie-throughput requires --collect.backend=nvml",
+		},
+		{
+			name: "exec rejects compute apps mig",
+			flags: backendFlagSet{
+				backend: backendExec, nvidiaSmiCommand: "nvidia-smi",
+				computeApps: true, computeAppsMIG: true,
+			},
+			wantErr: "--collect.compute-apps-mig requires --collect.backend=nvml",
+		},
+		{
+			name: "compute apps mig requires compute apps",
+			flags: backendFlagSet{
+				backend: backendNVML, nvidiaSmiCommand: "nvidia-smi", computeAppsMIG: true,
+			},
+			wantErr: "--collect.compute-apps-mig requires --collect.compute-apps",
 		},
 	}
 
@@ -168,7 +196,7 @@ func TestValidateBackendFlags(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateBackendFlags(testCase.backend, testCase.command, testCase.pcieThroughput)
+			err := validateBackendFlags(testCase.flags)
 			if testCase.wantErr == "" {
 				assert.NoError(t, err)
 

--- a/internal/collect/extras.go
+++ b/internal/collect/extras.go
@@ -17,6 +17,9 @@ type Extras struct {
 	// Energy holds per-GPU cumulative energy counters. Only the nvml
 	// backend fills it; devices that cannot report it are absent.
 	Energy []EnergyCounter
+	// MIG holds per-MIG-instance readings. Only the nvml backend fills it,
+	// and only for GPUs with MIG mode enabled.
+	MIG []MIGInstance
 }
 
 // PCIeThroughput is one GPU's sampled PCIe throughput.
@@ -36,4 +39,55 @@ type EnergyCounter struct {
 	// Joules counts since the driver was last loaded. It resets when the
 	// driver reloads or the GPU is reset, both outside this process.
 	Joules float64
+}
+
+// MIGInstance is one MIG device: a compute instance inside a GPU instance of
+// a MIG-partitioned GPU.
+type MIGInstance struct {
+	// ParentUUID is the parent GPU's uuid, normalized like every uuid
+	// label, so MIG series join with the per-GPU ones.
+	ParentUUID string
+	// UUID is the MIG device's own uuid, normalized the same way.
+	UUID string
+	// GPUInstanceID and ComputeInstanceID are the numeric MIG topology ids,
+	// carried as strings because they are only ever labels.
+	GPUInstanceID     string
+	ComputeInstanceID string
+	// Profile is the MIG profile name (for example "1g.10gb"), parsed from
+	// the device name, or the full device name when the shape is unknown.
+	Profile string
+	// Memory holds the memory readings in bytes, nil when they could not be
+	// read. The framebuffer belongs to the GPU instance: sibling compute
+	// instances report identical values (verified live), so the exporter
+	// renders memory once per GPU instance.
+	Memory *MIGMemory
+	// Utilization holds the GPU instance's activity readings, nil when the
+	// GPU does not support them (pre-Hopper), on the first cycle a GPU
+	// instance is seen, or when the reading failed. All compute instances
+	// of one GPU instance share the same values.
+	Utilization *MIGUtilization
+}
+
+// MIGMemory is one MIG device's memory, in bytes.
+type MIGMemory struct {
+	Total    uint64
+	Used     uint64
+	Free     uint64
+	Reserved uint64
+}
+
+// MIGUtilization is one GPU instance's activity over the window between the
+// two most recent collections. Each value is nil when that particular metric
+// could not be read.
+type MIGUtilization struct {
+	// GraphicsActivityRatio, SMActivityRatio, SMOccupancyRatio and
+	// TensorActivityRatio are fractions of the window, 0 to 1.
+	GraphicsActivityRatio *float64
+	SMActivityRatio       *float64
+	SMOccupancyRatio      *float64
+	TensorActivityRatio   *float64
+	// PCIeTXBytesPerSecond and PCIeRXBytesPerSecond are the instance's PCIe
+	// traffic over the window.
+	PCIeTXBytesPerSecond *float64
+	PCIeRXBytesPerSecond *float64
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -43,6 +43,10 @@ const uuidLabel = "uuid"
 // computeAppLabels is the label set on the per-process metrics.
 var computeAppLabels = []string{uuidLabel, "pid", "process_name"}
 
+// computeAppMIGLabels is the per-process label set with MIG attribution
+// (opt-in: adding labels changes the series identity of a shipped family).
+var computeAppMIGLabels = []string{uuidLabel, "pid", "process_name", "gpu_instance_id", "compute_instance_id"}
+
 // Features selects the conditionally-described metric families. Each one
 // follows the compute-apps precedent: its descriptors exist only when the
 // feature is enabled, so Describe and Collect stay consistent and a disabled
@@ -50,11 +54,16 @@ var computeAppLabels = []string{uuidLabel, "pid", "process_name"}
 type Features struct {
 	// ComputeApps enables the per-process metric families.
 	ComputeApps bool
+	// ComputeAppMIGLabels adds the MIG attribution labels to the
+	// per-process metrics (nvml backend, --collect.compute-apps-mig).
+	ComputeAppMIGLabels bool
 	// PCIeThroughput enables the per-GPU PCIe throughput gauges (nvml
 	// backend, --collect.pcie-throughput).
 	PCIeThroughput bool
 	// Energy enables the per-GPU cumulative energy counter (nvml backend).
 	Energy bool
+	// MIG enables the per-MIG-instance metric families (nvml backend).
+	MIG bool
 }
 
 // GPUExporter renders the latest collection as Prometheus metrics. It is
@@ -78,8 +87,35 @@ type GPUExporter struct {
 	pcieTxDesc            *prometheus.Desc
 	pcieRxDesc            *prometheus.Desc
 	energyDesc            *prometheus.Desc
+	migDescs              *migDescs
+	appMIGLabels          bool
 	logger                *slog.Logger
 	ctx                   context.Context //nolint:containedctx
+}
+
+// migDescs bundles the per-MIG-instance descriptors, nil as a whole when the
+// feature is off.
+type migDescs struct {
+	info             *prometheus.Desc
+	memTotal         *prometheus.Desc
+	memUsed          *prometheus.Desc
+	memFree          *prometheus.Desc
+	memReserved      *prometheus.Desc
+	graphicsActivity *prometheus.Desc
+	smActivity       *prometheus.Desc
+	smOccupancy      *prometheus.Desc
+	tensorActivity   *prometheus.Desc
+	pcieTx           *prometheus.Desc
+	pcieRx           *prometheus.Desc
+}
+
+// all lists the bundled descriptors, for Describe.
+func (m *migDescs) all() []*prometheus.Desc {
+	return []*prometheus.Desc{
+		m.info, m.memTotal, m.memUsed, m.memFree, m.memReserved,
+		m.graphicsActivity, m.smActivity, m.smOccupancy, m.tensorActivity,
+		m.pcieTx, m.pcieRx,
+	}
 }
 
 // New builds the exporter. A metric family whose feature is off in features
@@ -105,7 +141,8 @@ func New(
 
 	infoLabels = append(infoLabels, "cuda_version")
 
-	appInfoDesc, appMemoryDesc, appCountDesc, appsSuccessDesc := newComputeAppDescs(prefix, features.ComputeApps)
+	appInfoDesc, appMemoryDesc, appCountDesc, appsSuccessDesc := newComputeAppDescs(
+		prefix, features.ComputeApps, features.ComputeAppMIGLabels)
 	pcieTxDesc, pcieRxDesc := newPCIeDescs(prefix, features.PCIeThroughput)
 
 	exp := &GPUExporter{
@@ -121,6 +158,8 @@ func New(
 		pcieTxDesc:            pcieTxDesc,
 		pcieRxDesc:            pcieRxDesc,
 		energyDesc:            newEnergyDesc(prefix, features.Energy),
+		migDescs:              newMIGDescs(prefix, features.MIG),
+		appMIGLabels:          features.ComputeAppMIGLabels,
 		logger:                logger,
 		gpuInfoDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, "", "gpu_info"),
@@ -169,20 +208,26 @@ func addHealthDescs(exp *GPUExporter, prefix string, exitCodeMetric ExitCodeMetr
 func newComputeAppDescs(
 	prefix string,
 	enabled bool,
+	migLabels bool,
 ) (*prometheus.Desc, *prometheus.Desc, *prometheus.Desc, *prometheus.Desc) {
 	if !enabled {
 		return nil, nil, nil, nil
 	}
 
+	labels := computeAppLabels
+	if migLabels {
+		labels = computeAppMIGLabels
+	}
+
 	info := prometheus.NewDesc(
 		prometheus.BuildFQName(prefix, "", "compute_app_info"),
 		"A metric with a constant '1' value labeled by the identity of a process with a compute context on a GPU.",
-		computeAppLabels,
+		labels,
 		nil)
 	memory := prometheus.NewDesc(
 		prometheus.BuildFQName(prefix, "", "compute_app_used_memory_bytes"),
 		"GPU memory used by the process. Absent when the driver cannot report it (e.g. Windows WDDM).",
-		computeAppLabels,
+		labels,
 		nil)
 	count := prometheus.NewDesc(
 		prometheus.BuildFQName(prefix, "", "compute_apps"),
@@ -234,6 +279,62 @@ func newEnergyDesc(prefix string, enabled bool) *prometheus.Desc {
 		nil)
 }
 
+// newMIGDescs builds the per-MIG-instance descriptors, nil when the feature
+// is disabled. Memory belongs to the MIG device (mig_uuid); utilization is
+// attributed per GPU instance, which may host several MIG devices.
+func newMIGDescs(prefix string, enabled bool) *migDescs {
+	if !enabled {
+		return nil
+	}
+
+	instanceLabels := []string{uuidLabel, "gpu_instance_id"}
+
+	memDesc := func(kind string) *prometheus.Desc {
+		return prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "", "mig_memory_"+kind+"_bytes"),
+			"Memory of the GPU instance ("+kind+"). The framebuffer belongs to the GPU "+
+				"instance and is shared by its compute instances (verified live: sibling "+
+				"compute instances report identical values).",
+			instanceLabels,
+			nil)
+	}
+
+	activityDesc := func(name, help string) *prometheus.Desc {
+		return prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "", name),
+			help+" Computed over the window between the two most recent collections; "+
+				"absent on the first collection that sees the GPU instance.",
+			instanceLabels,
+			nil)
+	}
+
+	return &migDescs{
+		info: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "", "mig_info"),
+			"A metric with a constant '1' value labeled by the identity of a MIG device: "+
+				"the parent GPU's uuid, the MIG device's own uuid, its GPU instance and "+
+				"compute instance ids, and its profile.",
+			[]string{uuidLabel, "mig_uuid", "gpu_instance_id", "compute_instance_id", "profile"},
+			nil),
+		memTotal:    memDesc("total"),
+		memUsed:     memDesc("used"),
+		memFree:     memDesc("free"),
+		memReserved: memDesc("reserved"),
+		graphicsActivity: activityDesc("mig_graphics_activity_ratio",
+			"Fraction of time the GPU instance's graphics/compute engines were active."),
+		smActivity: activityDesc("mig_sm_activity_ratio",
+			"Fraction of time the GPU instance's SMs were active."),
+		smOccupancy: activityDesc("mig_sm_occupancy_ratio",
+			"Fraction of the GPU instance's resident warp slots that were occupied."),
+		tensorActivity: activityDesc("mig_tensor_activity_ratio",
+			"Fraction of time the GPU instance's tensor pipes were active."),
+		pcieTx: activityDesc("mig_pcie_throughput_tx_bytes_per_second",
+			"PCIe traffic transmitted by the GPU instance."),
+		pcieRx: activityDesc("mig_pcie_throughput_rx_bytes_per_second",
+			"PCIe traffic received by the GPU instance."),
+	}
+}
+
 // WithContext returns a collector that renders the same metrics but bounds
 // its collection by the given context. The HTTP handler uses it to bound each
 // scrape's collection by the scrape's own lifetime. The copy shares all
@@ -275,6 +376,12 @@ func (e *GPUExporter) Describe(descCh chan<- *prometheus.Desc) {
 	if e.energyDesc != nil {
 		e.sendDesc(descCh, e.energyDesc)
 	}
+
+	if e.migDescs != nil {
+		for _, desc := range e.migDescs.all() {
+			e.sendDesc(descCh, desc)
+		}
+	}
 }
 
 // Collect fetches the latest reading from the source and delivers it as
@@ -315,6 +422,86 @@ func (e *GPUExporter) renderExtras(metricCh chan<- prometheus.Metric, snapshot c
 				counter.Joules, counter.UUID)
 		}
 	}
+
+	if e.migDescs != nil {
+		// utilization is per GPU instance while the entries are per MIG
+		// device (compute instance): emit each GPU instance's series once
+		emittedGIs := map[string]bool{}
+
+		for _, instance := range snapshot.Extras.MIG {
+			e.renderMIGInstance(metricCh, instance, emittedGIs)
+		}
+	}
+}
+
+// renderMIGInstance emits one MIG device's info series, plus its GPU
+// instance's memory and utilization when the GPU instance was not rendered
+// yet this scrape: memory and activity belong to the GPU instance (its
+// compute instances share both), so one series per GPU instance.
+func (e *GPUExporter) renderMIGInstance(
+	metricCh chan<- prometheus.Metric,
+	instance collect.MIGInstance,
+	emittedGIs map[string]bool,
+) {
+	e.sendLabeledGauge(metricCh, e.migDescs.info, 1,
+		instance.ParentUUID, instance.UUID, instance.GPUInstanceID, instance.ComputeInstanceID, instance.Profile)
+
+	giKey := instance.ParentUUID + "/" + instance.GPUInstanceID
+	if emittedGIs[giKey] {
+		return
+	}
+
+	emittedGIs[giKey] = true
+
+	instanceLabels := []string{instance.ParentUUID, instance.GPUInstanceID}
+
+	if memory := instance.Memory; memory != nil {
+		e.sendLabeledGauge(metricCh, e.migDescs.memTotal, float64(memory.Total), instanceLabels...)
+		e.sendLabeledGauge(metricCh, e.migDescs.memUsed, float64(memory.Used), instanceLabels...)
+		e.sendLabeledGauge(metricCh, e.migDescs.memFree, float64(memory.Free), instanceLabels...)
+		e.sendLabeledGauge(metricCh, e.migDescs.memReserved, float64(memory.Reserved), instanceLabels...)
+	}
+
+	util := instance.Utilization
+	if util == nil {
+		return
+	}
+
+	for _, entry := range []struct {
+		desc  *prometheus.Desc
+		value *float64
+	}{
+		{e.migDescs.graphicsActivity, util.GraphicsActivityRatio},
+		{e.migDescs.smActivity, util.SMActivityRatio},
+		{e.migDescs.smOccupancy, util.SMOccupancyRatio},
+		{e.migDescs.tensorActivity, util.TensorActivityRatio},
+		{e.migDescs.pcieTx, util.PCIeTXBytesPerSecond},
+		{e.migDescs.pcieRx, util.PCIeRXBytesPerSecond},
+	} {
+		if entry.value == nil {
+			continue
+		}
+
+		e.sendLabeledGauge(metricCh, entry.desc, *entry.value, instanceLabels...)
+	}
+}
+
+// sendLabeledGauge emits one constant gauge with the given label values,
+// logging instead of failing if it cannot be built.
+func (e *GPUExporter) sendLabeledGauge(
+	metricCh chan<- prometheus.Metric,
+	desc *prometheus.Desc,
+	value float64,
+	labelValues ...string,
+) {
+	metric, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, value, labelValues...)
+	if err != nil {
+		e.logger.Error("failed to create metric", "err", err, "desc", desc.String())
+
+		return
+	}
+
+	e.sendMetric(metricCh, metric)
 }
 
 // sendConstWithUUID emits one constant metric carrying the uuid label,
@@ -411,8 +598,12 @@ func (e *GPUExporter) sendAppMetric(
 	value float64,
 	app nvidiasmi.ComputeApp,
 ) {
-	metric, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, value,
-		app.GPUUUID, app.PID, app.ProcessName)
+	labelValues := []string{app.GPUUUID, app.PID, app.ProcessName}
+	if e.appMIGLabels {
+		labelValues = append(labelValues, app.GPUInstanceID, app.ComputeInstanceID)
+	}
+
+	metric, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, value, labelValues...)
 	if err != nil {
 		e.logger.Error("failed to create per-process metric", "err", err, "pid", app.PID)
 

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -683,3 +683,122 @@ func TestCudaVersionLabelEmptyWhenUnknown(t *testing.T) {
 	require.True(t, ok)
 	assert.Empty(t, labelValue(t, info.GetMetric()[0], "cuda_version"))
 }
+
+func migExtras() collect.Extras {
+	util := func(v float64) *float64 { return &v }
+
+	shared := &collect.MIGUtilization{
+		GraphicsActivityRatio: util(0.5),
+		SMActivityRatio:       util(0.9),
+		// SMOccupancy deliberately nil: a per-metric gap must render nothing
+		TensorActivityRatio:  util(0.1),
+		PCIeTXBytesPerSecond: util(1048576),
+		PCIeRXBytesPerSecond: util(2097152),
+	}
+
+	return collect.Extras{
+		MIG: []collect.MIGInstance{
+			{
+				ParentUUID: "abc", UUID: "mig-a", GPUInstanceID: "1", ComputeInstanceID: "0",
+				Profile: "1g.10gb",
+				Memory:  &collect.MIGMemory{Total: 1000, Used: 100, Free: 900, Reserved: 50},
+				// two compute instances of the same GPU instance share the
+				// utilization values
+				Utilization: shared,
+			},
+			{
+				ParentUUID: "abc", UUID: "mig-b", GPUInstanceID: "1", ComputeInstanceID: "1",
+				Profile: "1g.10gb",
+				// same GPU instance: the framebuffer is shared, the values
+				// repeat (as on real hardware)
+				Memory:      &collect.MIGMemory{Total: 1000, Used: 100, Free: 900, Reserved: 50},
+				Utilization: shared,
+			},
+			{
+				ParentUUID: "abc", UUID: "mig-c", GPUInstanceID: "2", ComputeInstanceID: "0",
+				Profile: "2g.20gb",
+				// memory and utilization unreadable: only the info series
+			},
+		},
+	}
+}
+
+func TestMIGExtrasRendered(t *testing.T) {
+	t.Parallel()
+
+	exp := newExtrasExporter(t, exporter.Features{MIG: true}, extrasSnapshot(gpuTable("GPU-ABC"), migExtras()))
+
+	families := gatherFamilies(t, exp)
+
+	info, ok := families["aaa_mig_info"]
+	require.True(t, ok)
+	require.Len(t, info.GetMetric(), 3)
+
+	first := info.GetMetric()[0]
+	assert.Equal(t, "abc", labelValue(t, first, "uuid"))
+	assert.Equal(t, "mig-a", labelValue(t, first, "mig_uuid"))
+	assert.Equal(t, "1", labelValue(t, first, "gpu_instance_id"))
+	assert.Equal(t, "0", labelValue(t, first, "compute_instance_id"))
+	assert.Equal(t, "1g.10gb", labelValue(t, first, "profile"))
+
+	memUsed, ok := families["aaa_mig_memory_used_bytes"]
+	require.True(t, ok)
+	require.Len(t, memUsed.GetMetric(), 1,
+		"memory is per GPU instance: one series for the two-slice instance, none for the unreadable one")
+	assert.Equal(t, "1", labelValue(t, memUsed.GetMetric()[0], "gpu_instance_id"))
+	assertFloat(t, 100, memUsed.GetMetric()[0].GetGauge().GetValue())
+
+	smActivity, ok := families["aaa_mig_sm_activity_ratio"]
+	require.True(t, ok)
+	require.Len(t, smActivity.GetMetric(), 1,
+		"one GPU instance hosting two compute instances must emit its utilization once")
+	assert.Equal(t, "1", labelValue(t, smActivity.GetMetric()[0], "gpu_instance_id"))
+	assertFloat(t, 0.9, smActivity.GetMetric()[0].GetGauge().GetValue())
+
+	_, ok = families["aaa_mig_sm_occupancy_ratio"]
+	assert.False(t, ok, "a nil per-metric value must render nothing")
+
+	pcieTx, ok := families["aaa_mig_pcie_throughput_tx_bytes_per_second"]
+	require.True(t, ok)
+	assertFloat(t, 1048576, pcieTx.GetMetric()[0].GetGauge().GetValue())
+}
+
+func TestMIGSuppressedWhenOff(t *testing.T) {
+	t.Parallel()
+
+	exp := newExtrasExporter(t, exporter.Features{}, extrasSnapshot(gpuTable("GPU-ABC"), migExtras()))
+
+	families := gatherFamilies(t, exp)
+
+	for family := range families {
+		assert.NotContains(t, family, "mig_", "MIG families must not render when the feature is off")
+	}
+}
+
+func TestComputeAppMIGLabels(t *testing.T) {
+	t.Parallel()
+
+	apps := []nvidiasmi.ComputeApp{{
+		GPUUUID: "abc", PID: "42", ProcessName: "python",
+		UsedMemory: "1 MiB", GPUInstanceID: "3", ComputeInstanceID: "0",
+	}}
+
+	snapshot := appsSnapshot(gpuTable("GPU-ABC"), apps, true)
+
+	withLabels := newExtrasExporter(t,
+		exporter.Features{ComputeApps: true, ComputeAppMIGLabels: true}, snapshot)
+	families := gatherFamilies(t, withLabels)
+
+	info, ok := families["aaa_compute_app_info"]
+	require.True(t, ok)
+	assert.Equal(t, "3", labelValue(t, info.GetMetric()[0], "gpu_instance_id"))
+	assert.Equal(t, "0", labelValue(t, info.GetMetric()[0], "compute_instance_id"))
+
+	// without the opt-in, the label set stays the shipped 3-label one
+	withoutLabels := newExtrasExporter(t, exporter.Features{ComputeApps: true}, snapshot)
+	families = gatherFamilies(t, withoutLabels)
+
+	info, ok = families["aaa_compute_app_info"]
+	require.True(t, ok)
+	require.Len(t, info.GetMetric()[0].GetLabel(), 3)
+}

--- a/internal/integration/gpuparity_test.go
+++ b/internal/integration/gpuparity_test.go
@@ -440,6 +440,16 @@ func TestBackendMetricFamilyParityOnRealGPU(t *testing.T) {
 var nvmlOnlyFamilyPrefixes = []string{
 	"nvidia_smi_energy_joules_total",
 	"nvidia_smi_pcie_throughput_",
+	// deliberately NOT a bare "nvidia_smi_mig_" prefix: the shared
+	// mig.mode.* query fields render as nvidia_smi_mig_mode_*, and those
+	// must stay under the parity requirement
+	"nvidia_smi_mig_info",
+	"nvidia_smi_mig_memory_",
+	"nvidia_smi_mig_graphics_activity_ratio",
+	"nvidia_smi_mig_sm_activity_ratio",
+	"nvidia_smi_mig_sm_occupancy_ratio",
+	"nvidia_smi_mig_tensor_activity_ratio",
+	"nvidia_smi_mig_pcie_throughput_",
 }
 
 func isNVMLOnlyFamily(family string) bool {

--- a/internal/nvidiasmi/computeapps.go
+++ b/internal/nvidiasmi/computeapps.go
@@ -36,6 +36,12 @@ type ComputeApp struct {
 	// because it is not always a number: "[N/A]" on Windows WDDM,
 	// "[Insufficient Permissions]" in restricted containers.
 	UsedMemory string
+	// GPUInstanceID and ComputeInstanceID attribute the process to a MIG
+	// instance. Only the nvml backend fills them, and only for processes on
+	// MIG-partitioned GPUs; they stay empty otherwise (this query's fixed
+	// field set predates MIG and is never extended, per the comment above).
+	GPUInstanceID     string
+	ComputeInstanceID string
 }
 
 // QueryComputeApps runs nvidia-smi --query-compute-apps and parses the CSV

--- a/internal/nvmlnative/backend_nvml.go
+++ b/internal/nvmlnative/backend_nvml.go
@@ -34,6 +34,13 @@ type nvmlAPI struct {
 	cudaDriverVersion func() (int, nvml.Return)
 	processName       func(int) (string, nvml.Return)
 	validateInforom   func(nvml.Device) nvml.Return
+	// the GPM entry points are package-level in go-nvml AND its sample
+	// mock cannot pass through the real metrics call (a private concrete
+	// type assertion), so they must live on the seam
+	gpmSampleAlloc  func() (nvml.GpmSample, nvml.Return)
+	gpmSampleFree   func(nvml.GpmSample) nvml.Return
+	gpmMigSampleGet func(nvml.Device, int, nvml.GpmSample) nvml.Return
+	gpmMetricsGet   func(*nvml.GpmMetricsGetType) nvml.Return
 }
 
 func realNVML() nvmlAPI {
@@ -50,6 +57,10 @@ func realNVML() nvmlAPI {
 		cudaDriverVersion: nvml.SystemGetCudaDriverVersion,
 		processName:       nvml.SystemGetProcessName,
 		validateInforom:   nvml.DeviceValidateInforom,
+		gpmSampleAlloc:    nvml.GpmSampleAlloc,
+		gpmSampleFree:     nvml.GpmSampleFree,
+		gpmMigSampleGet:   nvml.GpmMigSampleGet,
+		gpmMetricsGet:     nvml.GpmMetricsGet,
 	}
 }
 
@@ -70,7 +81,14 @@ type Backend struct {
 	// extrasWarned makes a persistent extras failure visible exactly once
 	// per family, mirroring permLogged/fnfLogged.
 	extrasWarned map[string]bool
-	logger       *slog.Logger
+	// gpm retains one activity sample per GPU instance across cycles, so
+	// utilization can be computed over the inter-collection window. Guarded
+	// by mu like the rest of the cycle state; every sample is freed before
+	// any NVML shutdown.
+	gpm map[string]*gpmState
+	// now is the clock, injectable so the GPM window guards are testable.
+	now    func() time.Time
+	logger *slog.Logger
 }
 
 // New dlopens and initializes NVML. Failure here is a startup error: the
@@ -80,7 +98,7 @@ func New(logger *slog.Logger) (*Backend, error) {
 }
 
 func newWithAPI(api nvmlAPI, logger *slog.Logger) (*Backend, error) {
-	backend := &Backend{api: api, logger: logger}
+	backend := &Backend{api: api, now: time.Now, logger: logger}
 	if ret := backend.api.init(); ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("failed to initialize NVML: %s", ret.String())
 	}
@@ -114,6 +132,8 @@ func (b *Backend) Close() {
 	defer b.mu.Unlock()
 
 	if b.initialized {
+		b.freeGPMSamples()
+
 		_ = b.api.shutdown()
 		b.initialized = false
 	}
@@ -344,9 +364,13 @@ func (b *Backend) lifecycle(ret nvml.Return, err error) error {
 	return err
 }
 
-// markLost flags the backend for re-initialization on the next cycle.
+// markLost flags the backend for re-initialization on the next cycle. The
+// retained GPM samples die with the NVML generation, so they are freed
+// (best-effort) before the shutdown.
 func (b *Backend) markLost() {
 	if b.initialized {
+		b.freeGPMSamples()
+
 		b.initialized = false
 
 		_ = b.api.shutdown()
@@ -1244,10 +1268,12 @@ func (b *Backend) collectComputeApps(ctx context.Context) ([]nvidiasmi.ComputeAp
 			}
 
 			apps = append(apps, nvidiasmi.ComputeApp{
-				GPUUUID:     nvidiasmi.NormalizeUUID(uuid),
-				PID:         strconv.FormatUint(uint64(proc.Pid), 10),
-				ProcessName: name,
-				UsedMemory:  usedMemory,
+				GPUUUID:           nvidiasmi.NormalizeUUID(uuid),
+				PID:               strconv.FormatUint(uint64(proc.Pid), 10),
+				ProcessName:       name,
+				UsedMemory:        usedMemory,
+				GPUInstanceID:     migAppID(proc.GpuInstanceId),
+				ComputeInstanceID: migAppID(proc.ComputeInstanceId),
 			})
 		}
 	}
@@ -1303,7 +1329,7 @@ func (b *Backend) collectExtras(ctx context.Context, opts CollectOptions) collec
 		b.warnOnce("cuda-version", "cannot read the CUDA version", ret)
 	}
 
-	if !opts.Energy && !opts.PCIeThroughput {
+	if !opts.Energy && !opts.PCIeThroughput && !opts.MIG {
 		return extras
 	}
 
@@ -1314,14 +1340,22 @@ func (b *Backend) collectExtras(ctx context.Context, opts CollectOptions) collec
 		return extras
 	}
 
+	seenGIs := map[string]bool{}
+
 	for deviceIdx := range count {
 		if ctx.Err() != nil {
 			return extras
 		}
 
-		if !b.collectDeviceExtras(ctx, deviceIdx, opts, &extras) {
+		if !b.collectDeviceExtras(ctx, deviceIdx, opts, &extras, seenGIs) {
 			return extras
 		}
+	}
+
+	if opts.MIG {
+		// only after a complete pass: an aborted cycle must not mistake
+		// unvisited GPU instances for disappeared ones
+		b.dropOrphanGPMStates(seenGIs)
 	}
 
 	return extras
@@ -1335,6 +1369,7 @@ func (b *Backend) collectDeviceExtras(
 	deviceIdx int,
 	opts CollectOptions,
 	extras *collect.Extras,
+	seenGIs map[string]bool,
 ) bool {
 	dev, ret := b.api.deviceByIndex(deviceIdx)
 	if ret != nvml.SUCCESS {
@@ -1353,6 +1388,10 @@ func (b *Backend) collectDeviceExtras(
 	}
 
 	if opts.PCIeThroughput && !b.collectPcie(ctx, dev, uuid, extras) {
+		return false
+	}
+
+	if opts.MIG && !b.collectMIG(dev, uuid, extras, seenGIs) {
 		return false
 	}
 

--- a/internal/nvmlnative/mig_nvml.go
+++ b/internal/nvmlnative/mig_nvml.go
@@ -1,0 +1,446 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import (
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+)
+
+// The GPM metric ids this backend samples, from the NVML metric catalog.
+// Activity metrics report percentages (0-100), the PCIe metrics MiB/s.
+const (
+	gpmMetricGraphicsUtil  = 1
+	gpmMetricSMUtil        = 2
+	gpmMetricSMOccupancy   = 3
+	gpmMetricAnyTensorUtil = 5
+	gpmMetricPcieTxPerSec  = 20
+	gpmMetricPcieRxPerSec  = 21
+)
+
+// gpmMibMultiplier converts the GPM PCIe metrics (documented as MiB/sec, a
+// different unit from the whole-GPU KB/s throughput call) to bytes/s.
+const gpmMibMultiplier = 1024 * 1024
+
+// gpmMinWindow keeps the sampling window from collapsing when several
+// scrapers hit the exporter in quick succession: below it the retained
+// sample is not rotated and the previous computed values are served again,
+// so the window stays anchored instead of shrinking to a meaningless size.
+const gpmMinWindow = time.Second
+
+// gpmMaxWindow bounds how stale a retained sample may grow (a scraper that
+// vanished for a long time): beyond it the sample is reseeded and the cycle
+// emits no utilization, exactly like a first sight.
+const gpmMaxWindow = 10 * time.Minute
+
+// migInvalidID is how NVML reports "not a MIG process" in the per-process
+// instance id fields.
+const migInvalidID = 0xFFFFFFFF
+
+// gpmState is the retained previous GPM sample of one GPU instance.
+type gpmState struct {
+	sample nvml.GpmSample
+	taken  time.Time
+	// fingerprint identifies the GPU instance generation: numeric GI ids
+	// are reused immediately across MIG reconfigurations, and diffing
+	// samples across two different instances that happen to share an id
+	// would produce a plausible-looking wrong value.
+	fingerprint string
+	// last holds the most recent computed utilization, served again while
+	// the window guard keeps the sample anchored.
+	last *collect.MIGUtilization
+}
+
+// migGroup accumulates one GPU instance's members during enumeration, to
+// build the generation fingerprint.
+type migGroup struct {
+	gi      int
+	members []string
+}
+
+// collectMIG gathers one parent device's MIG inventory, memory and GPM
+// utilization into extras. seenGIs records the GPM state keys touched this
+// cycle for orphan cleanup. Reports whether extras collection may continue.
+//
+//nolint:cyclop // one linear pass: mode gate, enumeration, GPM per instance
+func (b *Backend) collectMIG(
+	dev nvml.Device,
+	parentUUID string,
+	extras *collect.Extras,
+	seenGIs map[string]bool,
+) bool {
+	mode, _, ret := dev.GetMigMode()
+
+	switch {
+	case ret == nvml.ERROR_NOT_SUPPORTED:
+		// not a MIG-capable GPU: nothing to report
+		return true
+	case ret != nvml.SUCCESS:
+		return b.extrasFailure("mig", "cannot read the MIG mode", ret)
+	case mode != nvml.DEVICE_MIG_ENABLE:
+		return true
+	}
+
+	groups, ok := b.enumerateMIG(dev, parentUUID, extras)
+	if !ok {
+		return false
+	}
+
+	if len(groups) == 0 {
+		return true
+	}
+
+	// the enumerated GPU instances are alive no matter what the GPM probe
+	// says below: mark them seen first, so a transient probe failure cannot
+	// get their retained samples mistaken for orphans
+	for _, group := range groups {
+		seenGIs[giKey(parentUUID, group.gi)] = true
+	}
+
+	support, ret := dev.GpmQueryDeviceSupport()
+
+	switch {
+	case isLifecycleError(ret):
+		return b.extrasFailure("mig", "cannot probe the GPU instance activity support", ret)
+	case ret != nvml.SUCCESS, support.IsSupportedDevice == 0:
+		// pre-Hopper MIG (e.g. A100), or a driver without the GPM
+		// interface: inventory and memory only
+		return true
+	}
+
+	utilByGI := map[string]*collect.MIGUtilization{}
+
+	for _, group := range groups {
+		util, ok := b.gpmUtilization(dev, giKey(parentUUID, group.gi), group)
+		if !ok {
+			return false
+		}
+
+		utilByGI[strconv.Itoa(group.gi)] = util
+	}
+
+	// stamp the GPU instance's utilization onto each of its instances,
+	// starting from this cycle's tail of extras.MIG (this parent's entries)
+	for i := range extras.MIG {
+		instance := &extras.MIG[i]
+		if instance.ParentUUID != parentUUID {
+			continue
+		}
+
+		instance.Utilization = utilByGI[instance.GPUInstanceID]
+	}
+
+	return true
+}
+
+// giKey is the GPM retention key of one GPU instance.
+func giKey(parentUUID string, gi int) string {
+	return parentUUID + "/" + strconv.Itoa(gi)
+}
+
+// enumerateMIG lists the parent's MIG devices into extras and groups them by
+// GPU instance. Reports the groups and whether extras collection may
+// continue.
+//
+//nolint:cyclop,funlen // one linear enumeration pass with per-getter fallbacks
+func (b *Backend) enumerateMIG(
+	dev nvml.Device,
+	parentUUID string,
+	extras *collect.Extras,
+) ([]migGroup, bool) {
+	maxMig, ret := dev.GetMaxMigDeviceCount()
+	if ret != nvml.SUCCESS {
+		return nil, b.extrasFailure("mig", "cannot count the MIG devices", ret)
+	}
+
+	byGI := map[int]*migGroup{}
+
+	for migIdx := range maxMig {
+		mig, ret := dev.GetMigDeviceHandleByIndex(migIdx)
+
+		switch {
+		case ret == nvml.ERROR_NOT_FOUND, ret == nvml.ERROR_INVALID_ARGUMENT:
+			// an empty slot: profiles occupy varying slot counts, so sparse
+			// indices are normal
+			continue
+		case ret != nvml.SUCCESS:
+			if !b.extrasFailure("mig", "cannot get a MIG device handle", ret) {
+				return nil, false
+			}
+
+			continue
+		}
+
+		uuid, ret := mig.GetUUID()
+		if ret != nvml.SUCCESS {
+			if !b.extrasFailure("mig", "cannot read a MIG device uuid", ret) {
+				return nil, false
+			}
+
+			continue
+		}
+
+		gi, giRet := mig.GetGpuInstanceId()
+		ci, ciRet := mig.GetComputeInstanceId()
+
+		if giRet != nvml.SUCCESS || ciRet != nvml.SUCCESS {
+			if !b.extrasFailure("mig", "cannot read a MIG device topology", firstError(giRet, ciRet)) {
+				return nil, false
+			}
+
+			continue
+		}
+
+		profile, ret := migProfile(mig)
+		if isLifecycleError(ret) {
+			return nil, b.extrasFailure("mig", "cannot read a MIG device name", ret)
+		}
+
+		instance := collect.MIGInstance{
+			ParentUUID:        parentUUID,
+			UUID:              normalizeMIGUUID(uuid),
+			GPUInstanceID:     strconv.Itoa(gi),
+			ComputeInstanceID: strconv.Itoa(ci),
+			Profile:           profile,
+		}
+
+		memory, ret := mig.GetMemoryInfo_v2()
+
+		switch {
+		case ret == nvml.SUCCESS:
+			instance.Memory = &collect.MIGMemory{
+				Total:    memory.Total,
+				Used:     memory.Used,
+				Free:     memory.Free,
+				Reserved: memory.Reserved,
+			}
+		case isLifecycleError(ret):
+			return nil, b.extrasFailure("mig", "cannot read a MIG device memory", ret)
+		}
+
+		extras.MIG = append(extras.MIG, instance)
+
+		group := byGI[gi]
+		if group == nil {
+			group = &migGroup{gi: gi}
+			byGI[gi] = group
+		}
+
+		group.members = append(group.members, instance.UUID+":"+instance.Profile+":"+instance.ComputeInstanceID)
+	}
+
+	groups := make([]migGroup, 0, len(byGI))
+
+	for _, group := range byGI {
+		sort.Strings(group.members)
+		groups = append(groups, *group)
+	}
+
+	sort.Slice(groups, func(i, j int) bool { return groups[i].gi < groups[j].gi })
+
+	return groups, true
+}
+
+// gpmUtilization computes one GPU instance's utilization from the retained
+// previous sample and a fresh one, rotating the retention. A first sight (or
+// an invalidated retention) seeds the state and reports nil values. Reports
+// whether extras collection may continue.
+//
+//nolint:cyclop // the retention guards are a linear rule set
+func (b *Backend) gpmUtilization(dev nvml.Device, key string, group migGroup) (*collect.MIGUtilization, bool) {
+	fingerprint := strings.Join(group.members, ",")
+	now := b.now()
+
+	state := b.gpm[key]
+
+	// a reused numeric GI id or an overgrown window invalidates the retained
+	// sample: diffing across generations or a boundless window would produce
+	// plausible-looking wrong values
+	if state != nil && (state.fingerprint != fingerprint || now.Sub(state.taken) > gpmMaxWindow) {
+		_ = b.api.gpmSampleFree(state.sample)
+		delete(b.gpm, key)
+
+		state = nil
+	}
+
+	// keep the window anchored under rapid scraping: serve the previous
+	// computed values instead of rotating the sample
+	if state != nil && now.Sub(state.taken) < gpmMinWindow {
+		return state.last, true
+	}
+
+	sample, ret := b.api.gpmSampleAlloc()
+	if ret != nvml.SUCCESS {
+		return nil, b.extrasFailure("mig-gpm", "cannot allocate a GPM sample", ret)
+	}
+
+	if ret := b.api.gpmMigSampleGet(dev, group.gi, sample); ret != nvml.SUCCESS {
+		_ = b.api.gpmSampleFree(sample)
+
+		return nil, b.extrasFailure("mig-gpm", "cannot sample the GPU instance activity", ret)
+	}
+
+	if state == nil {
+		if b.gpm == nil {
+			b.gpm = map[string]*gpmState{}
+		}
+
+		b.gpm[key] = &gpmState{sample: sample, taken: now, fingerprint: fingerprint}
+
+		return nil, true
+	}
+
+	util, ok := b.gpmMetrics(state.sample, sample)
+	if !ok {
+		// a lifecycle-class failure: markLost already released the retained
+		// samples and emptied the map, so only the fresh local sample is
+		// still ours to free
+		_ = b.api.gpmSampleFree(sample)
+
+		return nil, false
+	}
+
+	_ = b.api.gpmSampleFree(state.sample)
+	state.sample = sample
+	state.taken = now
+	state.last = util
+
+	return util, true
+}
+
+// gpmMetrics diffs two samples into utilization values. A metric whose
+// per-metric status is not success, or whose value is not finite, stays nil.
+// Reports whether extras collection may continue: a lifecycle-class failure,
+// outer or per-metric, marks the backend lost and aborts.
+//
+//nolint:cyclop // one linear decode pass with per-metric classification
+func (b *Backend) gpmMetrics(prev, cur nvml.GpmSample) (*collect.MIGUtilization, bool) {
+	ids := []uint32{
+		gpmMetricGraphicsUtil, gpmMetricSMUtil, gpmMetricSMOccupancy,
+		gpmMetricAnyTensorUtil, gpmMetricPcieTxPerSec, gpmMetricPcieRxPerSec,
+	}
+
+	var metricsGet nvml.GpmMetricsGetType
+
+	metricsGet.NumMetrics = uint32(len(ids)) //nolint:gosec // G115: len(ids) is a small constant
+	metricsGet.Sample1 = prev
+	metricsGet.Sample2 = cur
+
+	for i, id := range ids {
+		metricsGet.Metrics[i].MetricId = id
+	}
+
+	if ret := b.api.gpmMetricsGet(&metricsGet); ret != nvml.SUCCESS {
+		return nil, b.extrasFailure("mig-gpm", "cannot compute the GPU instance activity metrics", ret)
+	}
+
+	util := &collect.MIGUtilization{}
+
+	for i, id := range ids {
+		metric := metricsGet.Metrics[i]
+
+		metricRet := nvml.Return(metric.NvmlReturn) //nolint:gosec // G115: the field carries an nvmlReturn_t
+		if metricRet != nvml.SUCCESS {
+			if isLifecycleError(metricRet) {
+				return nil, b.extrasFailure("mig-gpm", "GPU instance activity metric hit a lifecycle error", metricRet)
+			}
+
+			continue
+		}
+
+		if math.IsNaN(metric.Value) || math.IsInf(metric.Value, 0) {
+			continue
+		}
+
+		switch id {
+		case gpmMetricGraphicsUtil:
+			util.GraphicsActivityRatio = new(metric.Value / 100)
+		case gpmMetricSMUtil:
+			util.SMActivityRatio = new(metric.Value / 100)
+		case gpmMetricSMOccupancy:
+			util.SMOccupancyRatio = new(metric.Value / 100)
+		case gpmMetricAnyTensorUtil:
+			util.TensorActivityRatio = new(metric.Value / 100)
+		case gpmMetricPcieTxPerSec:
+			util.PCIeTXBytesPerSecond = new(metric.Value * gpmMibMultiplier)
+		case gpmMetricPcieRxPerSec:
+			util.PCIeRXBytesPerSecond = new(metric.Value * gpmMibMultiplier)
+		}
+	}
+
+	return util, true
+}
+
+// freeGPMSamples releases every retained GPM sample. It must run before an
+// NVML shutdown: samples must never be freed after the library is torn down
+// nor reused across a re-initialization.
+func (b *Backend) freeGPMSamples() {
+	for key, state := range b.gpm {
+		_ = b.api.gpmSampleFree(state.sample)
+		delete(b.gpm, key)
+	}
+}
+
+// dropOrphanGPMStates frees the retained samples of GPU instances that
+// disappeared (a MIG reconfiguration between two cycles).
+func (b *Backend) dropOrphanGPMStates(seenGIs map[string]bool) {
+	for key, state := range b.gpm {
+		if seenGIs[key] {
+			continue
+		}
+
+		_ = b.api.gpmSampleFree(state.sample)
+		delete(b.gpm, key)
+	}
+}
+
+// migProfile extracts the MIG profile ("1g.10gb") from the MIG device name
+// ("NVIDIA H100 80GB HBM3 MIG 1g.10gb"), falling back to the full name when
+// the shape is unknown, or to the absent token when unreadable. The return
+// code is reported so the caller can classify lifecycle failures.
+func migProfile(mig nvml.Device) (string, nvml.Return) {
+	name, ret := mig.GetName()
+	if ret != nvml.SUCCESS {
+		return tokenNotAvailable, ret
+	}
+
+	if _, profile, found := strings.Cut(name, " MIG "); found && profile != "" {
+		return profile, nvml.SUCCESS
+	}
+
+	return name, nvml.SUCCESS
+}
+
+// normalizeMIGUUID normalizes a MIG device uuid the way GPU uuids are
+// normalized on every label: lowercase, without the type prefix.
+func normalizeMIGUUID(raw string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(raw)), "mig-")
+}
+
+// firstError picks the first non-success return of a pair, for error paths
+// that fold two getters.
+func firstError(a, other nvml.Return) nvml.Return {
+	if a != nvml.SUCCESS {
+		return a
+	}
+
+	return other
+}
+
+// migAppID renders a per-process MIG instance id label value: NVML reports
+// non-MIG processes with the invalid-id sentinel, which renders as an empty
+// label.
+func migAppID(id uint32) string {
+	if id == migInvalidID {
+		return ""
+	}
+
+	return strconv.FormatUint(uint64(id), 10)
+}

--- a/internal/nvmlnative/mig_nvml_internal_test.go
+++ b/internal/nvmlnative/mig_nvml_internal_test.go
@@ -1,0 +1,591 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gpmFake tracks the seam-level GPM calls: sample lifecycle accounting
+// (allocs must equal frees plus live retained samples) and canned metric
+// values keyed by metric id.
+type gpmFake struct {
+	allocs, frees int
+	migSampleRet  nvml.Return
+	metricsRet    nvml.Return
+	values        map[uint32]float64
+}
+
+func (g *gpmFake) install(api *nvmlAPI) {
+	api.gpmSampleAlloc = func() (nvml.GpmSample, nvml.Return) {
+		g.allocs++
+
+		return &mock.GpmSample{}, nvml.SUCCESS
+	}
+	api.gpmSampleFree = func(nvml.GpmSample) nvml.Return {
+		g.frees++
+
+		return nvml.SUCCESS
+	}
+	api.gpmMigSampleGet = func(nvml.Device, int, nvml.GpmSample) nvml.Return {
+		return g.migSampleRet
+	}
+	api.gpmMetricsGet = func(metricsGet *nvml.GpmMetricsGetType) nvml.Return {
+		if g.metricsRet != nvml.SUCCESS {
+			return g.metricsRet
+		}
+
+		for i := range metricsGet.NumMetrics {
+			metric := &metricsGet.Metrics[i]
+			metric.NvmlReturn = uint32(nvml.SUCCESS)
+			metric.Value = g.values[metric.MetricId]
+		}
+
+		return nvml.SUCCESS
+	}
+}
+
+func (g *gpmFake) live() int { return g.allocs - g.frees }
+
+// migDevice builds a mock MIG device handle (compute instance 0; the
+// multi-CI rendering semantics are covered by the exporter tests).
+func migDevice(uuid string, gi int) *mock.Device {
+	return &mock.Device{
+		GetUUIDFunc:              func() (string, nvml.Return) { return uuid, nvml.SUCCESS },
+		GetNameFunc:              func() (string, nvml.Return) { return "NVIDIA H100 80GB HBM3 MIG 1g.10gb", nvml.SUCCESS },
+		GetGpuInstanceIdFunc:     func() (int, nvml.Return) { return gi, nvml.SUCCESS },
+		GetComputeInstanceIdFunc: func() (int, nvml.Return) { return 0, nvml.SUCCESS },
+		GetMemoryInfo_v2Func: func() (nvml.Memory_v2, nvml.Return) {
+			return nvml.Memory_v2{Total: 10 * 1024 * 1024 * 1024, Used: 1024, Free: 999, Reserved: 512}, nvml.SUCCESS
+		},
+	}
+}
+
+// migParent builds a MIG-enabled parent device serving the given MIG
+// handles, with GPM support flagged as requested.
+func migParent(gpmSupported bool, migs ...nvml.Device) *mock.Device {
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetMigModeFunc = func() (int, int, nvml.Return) {
+		return nvml.DEVICE_MIG_ENABLE, nvml.DEVICE_MIG_ENABLE, nvml.SUCCESS
+	}
+	dev.GetMaxMigDeviceCountFunc = func() (int, nvml.Return) { return len(migs) + 2, nvml.SUCCESS }
+	dev.GetMigDeviceHandleByIndexFunc = func(idx int) (nvml.Device, nvml.Return) {
+		if idx >= len(migs) {
+			// sparse tail, as on real hardware
+			return nil, nvml.ERROR_NOT_FOUND
+		}
+
+		return migs[idx], nvml.SUCCESS
+	}
+	dev.GpmQueryDeviceSupportFunc = func() (nvml.GpmSupport, nvml.Return) {
+		supported := uint32(0)
+		if gpmSupported {
+			supported = 1
+		}
+
+		return nvml.GpmSupport{IsSupportedDevice: supported}, nvml.SUCCESS
+	}
+
+	return dev
+}
+
+func migOpts() CollectOptions { return CollectOptions{MIG: true} }
+
+func TestMIGInventoryAndMemory(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(false,
+		migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1),
+		migDevice("MIG-BBBBBBBB-1111-1111-1111-111111111111", 2),
+	)
+
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+	backend := newTestBackend(t, fake)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, reading.Extras.MIG, 2)
+
+	first := reading.Extras.MIG[0]
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", first.ParentUUID)
+	assert.Equal(t, "aaaaaaaa-1111-1111-1111-111111111111", first.UUID, "MIG- prefix must be normalized away")
+	assert.Equal(t, "1", first.GPUInstanceID)
+	assert.Equal(t, "0", first.ComputeInstanceID)
+	assert.Equal(t, "1g.10gb", first.Profile, "the profile must be parsed out of the device name")
+	require.NotNil(t, first.Memory)
+	assert.Equal(t, uint64(10*1024*1024*1024), first.Memory.Total)
+	assert.Equal(t, uint64(512), first.Memory.Reserved)
+	assert.Nil(t, first.Utilization, "no GPM support must mean inventory and memory only")
+}
+
+func TestMIGDisabledTouchesNoMIGGetter(t *testing.T) {
+	t.Parallel()
+
+	// MIG mode disabled: beyond the mode probe, no MIG getter has a stub,
+	// so touching any of them would panic
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetMigModeFunc = func() (int, int, nvml.Return) {
+		return nvml.DEVICE_MIG_DISABLE, nvml.DEVICE_MIG_DISABLE, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, reading.Extras.MIG)
+}
+
+func TestMIGNotSupportedIsSilent(t *testing.T) {
+	t.Parallel()
+
+	// a GPU that cannot do MIG at all reports NOT_SUPPORTED on the mode
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetMigModeFunc = func() (int, int, nvml.Return) { return 0, 0, nvml.ERROR_NOT_SUPPORTED }
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, reading.Extras.MIG)
+	assert.Equal(t, 0, fake.shutdowns)
+}
+
+func TestMIGGPMCrossCycle(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{
+		gpmMetricGraphicsUtil:  99.9992,
+		gpmMetricSMUtil:        90.668,
+		gpmMetricSMOccupancy:   50,
+		gpmMetricAnyTensorUtil: 22.7059,
+		gpmMetricPcieTxPerSec:  100,
+		gpmMetricPcieRxPerSec:  50,
+	}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	// first sight seeds the sample and emits nothing
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+	require.Len(t, reading.Extras.MIG, 1)
+	assert.Nil(t, reading.Extras.MIG[0].Utilization)
+	assert.Equal(t, 1, gpm.live(), "the seed sample must be retained")
+
+	// the second cycle diffs against the retained sample
+	current = current.Add(5 * time.Second)
+
+	reading, _, err = query(t.Context())
+	require.NoError(t, err)
+
+	util := reading.Extras.MIG[0].Utilization
+	require.NotNil(t, util)
+	require.NotNil(t, util.GraphicsActivityRatio)
+	assert.InDelta(t, 0.999992, *util.GraphicsActivityRatio, 1e-9, "GPM percentages must become ratios")
+	require.NotNil(t, util.SMActivityRatio)
+	assert.InDelta(t, 0.90668, *util.SMActivityRatio, 1e-9)
+	require.NotNil(t, util.TensorActivityRatio)
+	assert.InDelta(t, 0.227059, *util.TensorActivityRatio, 1e-9)
+	require.NotNil(t, util.PCIeTXBytesPerSecond)
+	assert.InDelta(t, 100*1048576, *util.PCIeTXBytesPerSecond, 1e-9, "GPM PCIe is MiB/s, not KB/s")
+	assert.Equal(t, 1, gpm.live(), "exactly one retained sample per GPU instance")
+
+	// a rapid follow-up scrape must not rotate the anchored sample and must
+	// serve the same values again
+	current = current.Add(100 * time.Millisecond)
+	allocsBefore := gpm.allocs
+
+	reading, _, err = query(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, reading.Extras.MIG[0].Utilization)
+	assert.InDelta(t, 0.999992, *reading.Extras.MIG[0].Utilization.GraphicsActivityRatio, 1e-9)
+	assert.Equal(t, allocsBefore, gpm.allocs, "the min-window guard must not take a new sample")
+}
+
+func TestMIGGPMFingerprintInvalidation(t *testing.T) {
+	t.Parallel()
+
+	// the same numeric GI id backed by a different MIG device between two
+	// cycles (destroy + recreate) must reseed instead of diffing across
+	// generations
+	uuid := "MIG-AAAAAAAA-1111-1111-1111-111111111111"
+	mig := migDevice("", 1)
+	mig.GetUUIDFunc = func() (string, nvml.Return) { return uuid, nvml.SUCCESS }
+
+	parent := migParent(true, mig)
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{gpmMetricSMUtil: 50}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+
+	// reconfigure: same GI id, new MIG device uuid
+	uuid = "MIG-CCCCCCCC-1111-1111-1111-111111111111"
+	current = current.Add(5 * time.Second)
+
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, reading.Extras.MIG[0].Utilization,
+		"a changed GPU instance generation must reseed, not diff across generations")
+	assert.Equal(t, 1, gpm.live(), "the stale sample must be freed, the new seed retained")
+	assert.Equal(t, 2, gpm.allocs)
+}
+
+func TestMIGGPMOrphanCleanupAndMarkLost(t *testing.T) {
+	t.Parallel()
+
+	migEnabled := true
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	parent.GetMigModeFunc = func() (int, int, nvml.Return) {
+		if migEnabled {
+			return nvml.DEVICE_MIG_ENABLE, nvml.DEVICE_MIG_ENABLE, nvml.SUCCESS
+		}
+
+		return nvml.DEVICE_MIG_DISABLE, nvml.DEVICE_MIG_DISABLE, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, gpm.live())
+
+	// the GPU instance disappears (MIG disabled): the orphaned sample must
+	// be freed
+	migEnabled = false
+	current = current.Add(5 * time.Second)
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, gpm.live(), "orphaned GPU instance samples must be freed")
+
+	// re-enable and seed again, then a lifecycle teardown must free the rest
+	migEnabled = true
+	current = current.Add(5 * time.Second)
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, gpm.live())
+
+	backend.mu.Lock()
+	backend.markLost()
+	backend.mu.Unlock()
+
+	assert.Equal(t, 0, gpm.live(), "markLost must free every retained sample before shutdown")
+}
+
+func TestComputeAppsMIGAttribution(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+	dev.GetComputeRunningProcessesFunc = func() ([]nvml.ProcessInfo, nvml.Return) {
+		return []nvml.ProcessInfo{
+			{Pid: 42, UsedGpuMemory: 1024 * 1024, GpuInstanceId: 3, ComputeInstanceId: 0},
+			{Pid: 43, UsedGpuMemory: 1024 * 1024, GpuInstanceId: migInvalidID, ComputeInstanceId: migInvalidID},
+		}, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	opts := CollectOptions{ComputeApps: true}
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), opts)(t.Context())
+	require.NoError(t, err)
+	require.Len(t, reading.Apps, 2)
+
+	assert.Equal(t, "3", reading.Apps[0].GPUInstanceID)
+	assert.Equal(t, "0", reading.Apps[0].ComputeInstanceID)
+	assert.Empty(t, reading.Apps[1].GPUInstanceID, "the invalid-id sentinel must render as an empty label")
+	assert.Empty(t, reading.Apps[1].ComputeInstanceID)
+}
+
+func TestMIGGPMMaxWindowReseeds(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{gpmMetricSMUtil: 50}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+
+	// a gap beyond the maximum window must reseed instead of reporting an
+	// average over a boundless window
+	current = current.Add(11 * time.Minute)
+
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, reading.Extras.MIG[0].Utilization, "an overgrown window must reseed, not diff")
+	assert.Equal(t, 1, gpm.live(), "the stale sample must be freed and the fresh seed retained")
+	assert.Equal(t, 2, gpm.allocs)
+
+	// and the reseeded state works again afterwards
+	current = current.Add(5 * time.Second)
+
+	reading, _, err = query(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, reading.Extras.MIG[0].Utilization)
+}
+
+func TestMIGGPMPerMetricFailureAndNonFiniteSkip(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{}
+
+	api := fake.api()
+	gpm.install(&api)
+	// override the metrics decoder: one metric fails per-metric, one is
+	// non-finite, the rest carry values
+	api.gpmMetricsGet = func(metricsGet *nvml.GpmMetricsGetType) nvml.Return {
+		for i := range metricsGet.NumMetrics {
+			metric := &metricsGet.Metrics[i]
+
+			switch metric.MetricId {
+			case gpmMetricSMUtil:
+				metric.NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
+			case gpmMetricSMOccupancy:
+				metric.NvmlReturn = uint32(nvml.SUCCESS)
+				metric.Value = math.NaN()
+			default:
+				metric.NvmlReturn = uint32(nvml.SUCCESS)
+				metric.Value = 42
+			}
+		}
+
+		return nvml.SUCCESS
+	}
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+
+	current = current.Add(5 * time.Second)
+
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+
+	util := reading.Extras.MIG[0].Utilization
+	require.NotNil(t, util)
+	assert.Nil(t, util.SMActivityRatio, "a failed per-metric status must render nothing")
+	assert.Nil(t, util.SMOccupancyRatio, "a non-finite value must render nothing")
+	require.NotNil(t, util.GraphicsActivityRatio, "healthy sibling metrics must survive")
+	assert.InDelta(t, 0.42, *util.GraphicsActivityRatio, 1e-9)
+}
+
+func TestMIGGPMMetricsFailureRotatesAndRecovers(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{gpmMetricSMUtil: 50}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+
+	// a transient non-lifecycle metrics failure: no values this cycle, the
+	// rotation continues, nothing leaks and the cycle stays green
+	gpm.metricsRet = nvml.ERROR_UNKNOWN
+	current = current.Add(5 * time.Second)
+
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, reading.Extras.MIG[0].Utilization)
+	assert.Equal(t, 1, gpm.live())
+	assert.Equal(t, 0, fake.shutdowns)
+
+	// and it heals on the next cycle
+	gpm.metricsRet = nvml.SUCCESS
+	current = current.Add(5 * time.Second)
+
+	reading, _, err = query(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, reading.Extras.MIG[0].Utilization)
+}
+
+func TestMIGGPMSampleGetLifecycleAborts(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{migSampleRet: nvml.ERROR_GPU_IS_LOST}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
+	require.NoError(t, err, "extras must never fail the collection")
+	assert.Nil(t, reading.Extras.MIG[0].Utilization)
+	assert.Equal(t, 1, fake.shutdowns, "the lifecycle error must mark the backend for re-init")
+	assert.Equal(t, 0, gpm.live(), "no sample may leak through the abort")
+}
+
+func TestMIGLifecycleOnHandleLookupAborts(t *testing.T) {
+	t.Parallel()
+
+	// the handle lookup hitting a lost GPU must mark the backend for
+	// re-initialization, not read as a sparse slot
+	parent := migParent(true)
+	parent.GetMigDeviceHandleByIndexFunc = func(int) (nvml.Device, nvml.Return) {
+		return nil, nvml.ERROR_GPU_IS_LOST
+	}
+	parent.GetMaxMigDeviceCountFunc = func() (int, nvml.Return) { return 2, nvml.SUCCESS }
+
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+	backend := newTestBackend(t, fake)
+
+	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, reading.Extras.MIG)
+	assert.Equal(t, 1, fake.shutdowns, "a lost GPU during MIG enumeration must mark for re-init")
+}
+
+func TestCloseFreesGPMSamples(t *testing.T) {
+	t.Parallel()
+
+	parent := migParent(true, migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1))
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	_, _, err = backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, gpm.live())
+
+	backend.Close()
+
+	assert.Equal(t, 0, gpm.live(), "Close must free every retained sample before shutdown")
+	assert.Equal(t, 1, fake.shutdowns)
+}
+
+func TestMIGGPMFingerprintProfileChange(t *testing.T) {
+	t.Parallel()
+
+	// the same GI id and MIG uuid, but a different profile (destroy and
+	// recreate with another shape) must also invalidate the retention
+	name := "NVIDIA H100 80GB HBM3 MIG 1g.10gb"
+	mig := migDevice("MIG-AAAAAAAA-1111-1111-1111-111111111111", 1)
+	mig.GetNameFunc = func() (string, nvml.Return) { return name, nvml.SUCCESS }
+
+	parent := migParent(true, mig)
+	fake := &fakeAPI{devices: []nvml.Device{parent}}
+
+	gpm := &gpmFake{values: map[uint32]float64{gpmMetricSMUtil: 50}}
+
+	api := fake.api()
+	gpm.install(&api)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	current := time.Now()
+	backend.now = func() time.Time { return current }
+
+	query := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())
+
+	_, _, err = query(t.Context())
+	require.NoError(t, err)
+
+	name = "NVIDIA H100 80GB HBM3 MIG 2g.20gb"
+	current = current.Add(5 * time.Second)
+
+	reading, _, err := query(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, reading.Extras.MIG[0].Utilization, "a changed profile must reseed the retention")
+	assert.Equal(t, 1, gpm.live())
+}

--- a/internal/nvmlnative/options.go
+++ b/internal/nvmlnative/options.go
@@ -13,4 +13,7 @@ type CollectOptions struct {
 	PCIeThroughput bool
 	// Energy enables the per-GPU cumulative energy counter.
 	Energy bool
+	// MIG enables the per-MIG-instance readings. GPUs without MIG mode
+	// enabled contribute nothing beyond one mode probe.
+	MIG bool
 }

--- a/internal/nvmlnative/symbols.go
+++ b/internal/nvmlnative/symbols.go
@@ -39,6 +39,51 @@ var nvmlSymbolRequirements = []symbolRequirement{
 		serves: "energy_joules_total",
 	},
 	{
+		goCall: "GetMaxMigDeviceCount",
+		anyOf:  []string{"nvmlDeviceGetMaxMigDeviceCount"},
+		serves: "mig_* metrics",
+	},
+	{
+		goCall: "GetMigDeviceHandleByIndex",
+		anyOf:  []string{"nvmlDeviceGetMigDeviceHandleByIndex"},
+		serves: "mig_* metrics",
+	},
+	{
+		goCall: "GetGpuInstanceId",
+		anyOf:  []string{"nvmlDeviceGetGpuInstanceId"},
+		serves: "mig_* metrics, per-process MIG attribution",
+	},
+	{
+		goCall: "GetComputeInstanceId",
+		anyOf:  []string{"nvmlDeviceGetComputeInstanceId"},
+		serves: "mig_* metrics, per-process MIG attribution",
+	},
+	{
+		goCall: "GpmQueryDeviceSupport",
+		anyOf:  []string{"nvmlGpmQueryDeviceSupport"},
+		serves: "mig_*_ratio, mig_pcie_throughput_*",
+	},
+	{
+		goCall: "gpmSampleAlloc",
+		anyOf:  []string{"nvmlGpmSampleAlloc"},
+		serves: "mig_*_ratio, mig_pcie_throughput_*",
+	},
+	{
+		goCall: "gpmSampleFree",
+		anyOf:  []string{"nvmlGpmSampleFree"},
+		serves: "mig_*_ratio, mig_pcie_throughput_*",
+	},
+	{
+		goCall: "gpmMigSampleGet",
+		anyOf:  []string{"nvmlGpmMigSampleGet"},
+		serves: "mig_*_ratio, mig_pcie_throughput_*",
+	},
+	{
+		goCall: "gpmMetricsGet",
+		anyOf:  []string{"nvmlGpmMetricsGet"},
+		serves: "mig_*_ratio, mig_pcie_throughput_*",
+	},
+	{
 		goCall: "GetPcieThroughput",
 		anyOf:  []string{"nvmlDeviceGetPcieThroughput"},
 		serves: "pcie_throughput_*_bytes_per_second",

--- a/internal/nvmlnative/symbols_internal_test.go
+++ b/internal/nvmlnative/symbols_internal_test.go
@@ -196,7 +196,7 @@ func collectCallSites(file *ast.File, seen map[string]bool) {
 		}
 
 		method := selector.Sel.Name
-		if strings.HasPrefix(method, "Get") || method == "ValidateInforom" {
+		if strings.HasPrefix(method, "Get") || strings.HasPrefix(method, "Gpm") || method == "ValidateInforom" {
 			// skip go-nvml package-level helpers reached through the seam
 			if ident, isIdent := selector.X.(*ast.Ident); isIdent && ident.Name == "nvml" {
 				return true


### PR DESCRIPTION
GPUs with MIG mode enabled now export one info series per MIG device carrying the parent GPU uuid, the MIG device uuid, the GPU instance and compute instance ids and the profile name, plus the MIG device's memory in bytes. Nothing needs configuring, the series appear when MIG instances exist and other GPUs contribute nothing.

On hardware that supports the GPM interface (the Hopper generation and later), each GPU instance also reports graphics, SM, occupancy and tensor activity ratios and PCIe throughput, computed over the window between the two most recent collections. The first collection that sees a GPU instance seeds the sampling and emits nothing. The window is guarded on both ends: rapid scrapes keep serving the previous values instead of shrinking the window, and an overgrown window reseeds instead of reporting a stale average. A GPU instance recreated under the same numeric id between two collections is detected and reseeded rather than diffed across generations, and retained samples are released when instances disappear, on driver loss and on shutdown. Older MIG hardware such as A100 gets inventory and memory only.

A new opt-in flag adds GPU instance and compute instance labels to the per-process metrics in nvml mode, attributing processes to their MIG instance. It is opt-in because it changes the label set of an established metric family.

Closes #203.

Stacked on #465.