### PR TITLE
feat(nvml): count XID errors and serve the inactive remapped rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ It can also skip `nvidia-smi` and read the metrics straight from the NVIDIA
 Management Library (NVML), the C library `nvidia-smi` itself is built on. This
 mode is experimental and exports a superset of the default mode's metrics: the
 same core set plus NVML-only extras like the GPU energy counter, per-MIG-instance
-metrics and opt-in PCIe throughput; see [CONFIGURE.md](docs/CONFIGURE.md).
+metrics, XID error counters and opt-in PCIe throughput; see
+[CONFIGURE.md](docs/CONFIGURE.md).
 
 This project is based on [a0s/nvidia-smi-exporter](https://github.com/a0s/nvidia-smi-exporter).
 However, this one is written in Go to produce a single, static binary.

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -13,8 +13,8 @@ To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
 variant (for example `1.7.0-nvml`). It exports a superset of the default
 backend's metrics: the same core set plus NVML-only extras like the GPU
-energy counter, per-MIG-instance metrics and opt-in PCIe throughput. The
-`-nvml` images are built for
+energy counter, per-MIG-instance metrics, XID error counters and opt-in
+PCIe throughput. The `-nvml` images are built for
 linux/amd64 only, so on mixed-architecture clusters add
 `kubernetes.io/arch: amd64` to `nodeSelector`.
 

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -13,8 +13,8 @@ To try the experimental NVML backend, which reads the driver library
 directly instead of running `nvidia-smi`, set the image tag to a `-nvml`
 variant (for example `1.7.0-nvml`). It exports a superset of the default
 backend's metrics: the same core set plus NVML-only extras like the GPU
-energy counter, per-MIG-instance metrics and opt-in PCIe throughput. The
-`-nvml` images are built for
+energy counter, per-MIG-instance metrics, XID error counters and opt-in
+PCIe throughput. The `-nvml` images are built for
 linux/amd64 only, so on mixed-architecture clusters add
 `kubernetes.io/arch: amd64` to `nodeSelector`.
 

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -343,6 +343,7 @@ What each backend can do:
 | PCIe throughput (`--collect.pcie-throughput`) | no | yes |
 | Per-MIG-instance metrics (`mig_info`, `mig_memory_*`, `mig_*_ratio`) | no | yes |
 | Per-process MIG attribution (`--collect.compute-apps-mig`) | no | yes |
+| XID error counters (`xid_errors_total`) | no | yes |
 
 The NVML-only families are documented in [METRICS.md](METRICS.md). The PCIe
 throughput family is opt-in via `--collect.pcie-throughput` because of its

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -72,6 +72,29 @@ generous privileges (the exporter container may need to run privileged with
 `NVIDIA_MIG_MONITOR_DEVICES=all` and share the host PID namespace); MIG
 inventory and memory worked unprivileged in testing.
 
+The NVML backend also watches for XID errors, the driver's numbered error
+events (a stuck kernel, an ECC failure, a fallen-off-the-bus GPU). These are
+invisible to `nvidia-smi` and to the query-field metrics, they only surface
+through driver events or the kernel log:
+
+- `nvidia_smi_xid_errors_total{uuid, xid}` (counter): XID error events
+  observed since the exporter started. A series appears when its first
+  event arrives; history from before the exporter started cannot be
+  replayed. The counters live outside the collection pipeline, so they stay
+  visible while collections fail, which is exactly when XIDs happen.
+- `nvidia_smi_xid_last_timestamp_seconds{uuid, xid}` (gauge): when the most
+  recent event was received by the exporter (the driver events carry no
+  timestamp of their own).
+
+For alerting, prefer the timestamp:
+`time() - nvidia_smi_xid_last_timestamp_seconds < 300` fires for any XID in
+the last five minutes, including a series' very first event. A rate-based
+expression like `increase(nvidia_smi_xid_errors_total[5m]) > 0` misses that
+first event, because Prometheus never observed the zero before it.
+
+Nothing needs configuring; on setups where the driver does not support
+event registration the families simply stay empty.
+
 Both backends also stamp the CUDA version the installed driver supports onto
 `nvidia_smi_gpu_info` as the `cuda_version` label. This is the version of
 the CUDA API the driver carries, not an installed CUDA toolkit. The default

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -47,6 +47,10 @@ const scrapeTimeoutHeader = "X-Prometheus-Scrape-Timeout-Seconds"
 // conversion), so they are treated like a missing header.
 const maxScrapeTimeoutSeconds = 24 * 60 * 60
 
+// xidWatcherExitGrace is how long shutdown waits for the XID watcher's
+// bounded driver call to return before abandoning the goroutine.
+const xidWatcherExitGrace = 3 * time.Second
+
 // Options carries what the callers inject into a run beyond the command-line
 // arguments.
 type Options struct {
@@ -469,7 +473,7 @@ func setupExporter(
 	registry *prometheus.Registry,
 	logger *slog.Logger,
 ) (*exporter.GPUExporter, error) {
-	resolved, query, exitCodeMetric, err := setupBackend(ctx, eg, cfg, logger)
+	resolved, query, xids, exitCodeMetric, err := setupBackend(ctx, eg, cfg, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -494,9 +498,10 @@ func setupExporter(
 		PCIeThroughput: cfg.pcieThroughput,
 		Energy:         cfg.backend == backendNVML,
 		MIG:            cfg.backend == backendNVML,
+		XIDEvents:      cfg.backend == backendNVML,
 	}
 
-	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, features, exitCodeMetric, logger)
+	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, features, xids, exitCodeMetric, logger)
 
 	// the go and process collectors keep the exposed families identical to
 	// what the default registry used to serve
@@ -518,16 +523,18 @@ func setupExporter(
 // nvidia-smi; the nvml backend resolves against its compiled catalog and
 // reports collection status as an NVML return code under its own metric
 // name.
+//
+//nolint:ireturn // the exec backend has no XID source, a nil interface is the point
 func setupBackend(
 	ctx context.Context,
 	eg *errgroup.Group,
 	cfg collectConfig,
 	logger *slog.Logger,
-) (nvidiasmi.ResolvedFields, collect.QueryFunc, exporter.ExitCodeMetric, error) {
+) (nvidiasmi.ResolvedFields, collect.QueryFunc, exporter.XIDSource, exporter.ExitCodeMetric, error) {
 	if cfg.backend == backendNVML {
 		backend, err := nvmlnative.New(logger)
 		if err != nil {
-			return nvidiasmi.ResolvedFields{}, nil, exporter.ExitCodeMetric{},
+			return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
 				fmt.Errorf("failed to set up the nvml backend: %w", err)
 		}
 
@@ -536,7 +543,7 @@ func setupBackend(
 		if err != nil {
 			backend.Close()
 
-			return nvidiasmi.ResolvedFields{}, nil, exporter.ExitCodeMetric{},
+			return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
 				fmt.Errorf("failed to resolve query fields: %w", err)
 		}
 
@@ -551,6 +558,8 @@ func setupBackend(
 			return nil
 		})
 
+		superviseXIDWatcher(ctx, eg, backend, logger)
+
 		opts := nvmlnative.CollectOptions{
 			ComputeApps:    cfg.computeApps,
 			PCIeThroughput: cfg.pcieThroughput,
@@ -558,7 +567,7 @@ func setupBackend(
 			MIG:            true,
 		}
 
-		return resolved, backend.QueryFunc(resolved, opts), exporter.NVMLReturnCodeMetric, nil
+		return resolved, backend.QueryFunc(resolved, opts), backend, exporter.NVMLReturnCodeMetric, nil
 	}
 
 	resolved, err := nvidiasmi.ResolveFields(
@@ -571,7 +580,7 @@ func setupBackend(
 		logger,
 	)
 	if err != nil {
-		return nvidiasmi.ResolvedFields{}, nil, exporter.ExitCodeMetric{},
+		return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
 			fmt.Errorf("failed to resolve query fields: %w", err)
 	}
 
@@ -581,7 +590,43 @@ func setupBackend(
 	cudaVersion := nvidiasmi.QueryCudaVersion(
 		ctx, cfg.nvidiaSmiCommand, cfg.timeout, nvidiasmi.DefaultRunFunc, logger)
 
-	return resolved, buildQueryFunc(cfg, resolved, cudaVersion, logger), exporter.ExecExitCodeMetric, nil
+	return resolved, buildQueryFunc(cfg, resolved, cudaVersion, logger), nil, exporter.ExecExitCodeMetric, nil
+}
+
+// superviseXIDWatcher runs the XID watcher beside the collection cycles for
+// the whole application lifetime; it returns nil on shutdown and never fails
+// the group. The watcher is supervised rather than joined directly: a driver
+// call that ignores its own bound must not hang process exit, which is the
+// ultimate cleanup (same rule as the shutdown handling).
+func superviseXIDWatcher(
+	ctx context.Context,
+	eg *errgroup.Group,
+	backend *nvmlnative.Backend,
+	logger *slog.Logger,
+) {
+	eg.Go(func() error {
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			_ = backend.RunXIDWatcher(ctx)
+		}()
+
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+		}
+
+		select {
+		case <-done:
+		case <-time.After(xidWatcherExitGrace):
+			logger.Warn("abandoning the XID watcher: stuck inside the driver")
+		}
+
+		return nil
+	})
 }
 
 // buildQueryFunc builds the collection cycle: the GPU query, plus the

--- a/internal/collect/extras.go
+++ b/internal/collect/extras.go
@@ -1,5 +1,7 @@
 package collect
 
+import "time"
+
 // Extras carries backend-specific readings that are outside the nvidia-smi
 // query-field schema. Every family follows the Apps contract: it fails
 // softly, so a family the backend cannot serve is nil/empty and never fails
@@ -39,6 +41,23 @@ type EnergyCounter struct {
 	// Joules counts since the driver was last loaded. It resets when the
 	// driver reloads or the GPU is reset, both outside this process.
 	Joules float64
+}
+
+// XIDCounter is one (GPU, XID code) pair's cumulative error-event count.
+// XID state deliberately does NOT ride Extras: it is owned by a long-lived
+// watcher and read at scrape time, so the counters stay visible during the
+// exact driver incidents that make collections fail.
+type XIDCounter struct {
+	// UUID is the GPU uuid, normalized like every uuid label, cached at
+	// event registration time (the GPU may be unreadable once it errors).
+	UUID string
+	// XID is the numeric XID error code.
+	XID uint64
+	// Count is the number of events observed since the exporter started.
+	Count uint64
+	// LastSeen is when the most recent event was received by the exporter
+	// (NVML events carry no timestamp of their own).
+	LastSeen time.Time
 }
 
 // MIGInstance is one MIG device: a compute instance inside a GPU instance of

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -64,6 +65,17 @@ type Features struct {
 	Energy bool
 	// MIG enables the per-MIG-instance metric families (nvml backend).
 	MIG bool
+	// XIDEvents enables the XID error counter families (nvml backend). The
+	// values come from the XIDSource passed to New, not from the snapshot.
+	XIDEvents bool
+}
+
+// XIDSource serves the cumulative XID error counts. It is read at scrape
+// time, independently of the collection pipeline, so the counters stay
+// visible while collections fail (which is exactly when XIDs happen). The
+// implementation must be safe for concurrent use.
+type XIDSource interface {
+	XIDCounts() []collect.XIDCounter
 }
 
 // GPUExporter renders the latest collection as Prometheus metrics. It is
@@ -89,6 +101,9 @@ type GPUExporter struct {
 	energyDesc            *prometheus.Desc
 	migDescs              *migDescs
 	appMIGLabels          bool
+	xids                  XIDSource
+	xidCountDesc          *prometheus.Desc
+	xidTimestampDesc      *prometheus.Desc
 	logger                *slog.Logger
 	ctx                   context.Context //nolint:containedctx
 }
@@ -126,6 +141,7 @@ func New(
 	fields nvidiasmi.ResolvedFields,
 	source collect.Source,
 	features Features,
+	xids XIDSource,
 	exitCodeMetric ExitCodeMetric,
 	logger *slog.Logger,
 ) *GPUExporter {
@@ -160,6 +176,7 @@ func New(
 		energyDesc:            newEnergyDesc(prefix, features.Energy),
 		migDescs:              newMIGDescs(prefix, features.MIG),
 		appMIGLabels:          features.ComputeAppMIGLabels,
+		xids:                  xids,
 		logger:                logger,
 		gpuInfoDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, "", "gpu_info"),
@@ -170,8 +187,30 @@ func New(
 	}
 
 	addHealthDescs(exp, prefix, exitCodeMetric)
+	addXIDDescs(exp, prefix, features.XIDEvents)
 
 	return exp
+}
+
+// addXIDDescs builds the XID error counter descriptors, left nil when the
+// feature is disabled.
+func addXIDDescs(exp *GPUExporter, prefix string, enabled bool) {
+	if !enabled {
+		return
+	}
+
+	exp.xidCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "xid_errors_total"),
+		"Number of XID errors observed on the GPU since the exporter started. "+
+			"A series appears when its first event arrives; earlier history cannot be replayed.",
+		[]string{uuidLabel, "xid"},
+		nil)
+	exp.xidTimestampDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, "", "xid_last_timestamp_seconds"),
+		"Unix timestamp of the most recently observed XID error, as received by the exporter "+
+			"(the driver events carry no timestamp of their own).",
+		[]string{uuidLabel, "xid"},
+		nil)
 }
 
 // addHealthDescs builds the collection health descriptors.
@@ -382,6 +421,11 @@ func (e *GPUExporter) Describe(descCh chan<- *prometheus.Desc) {
 			e.sendDesc(descCh, desc)
 		}
 	}
+
+	if e.xidCountDesc != nil {
+		e.sendDesc(descCh, e.xidCountDesc)
+		e.sendDesc(descCh, e.xidTimestampDesc)
+	}
 }
 
 // Collect fetches the latest reading from the source and delivers it as
@@ -390,6 +434,11 @@ func (e *GPUExporter) Collect(metricCh chan<- prometheus.Metric) {
 	snapshot := e.source.Latest(e.ctx)
 
 	e.renderHealth(metricCh, snapshot)
+
+	// the XID counters render before the no-data return below: a GPU
+	// throwing XIDs typically also fails collections, and that is exactly
+	// when these series must stay visible
+	e.renderXIDs(metricCh)
 
 	if snapshot.Table == nil {
 		return
@@ -401,6 +450,41 @@ func (e *GPUExporter) Collect(metricCh chan<- prometheus.Metric) {
 
 	e.renderApps(metricCh, snapshot)
 	e.renderExtras(metricCh, snapshot)
+}
+
+// renderXIDs emits the XID error counters from the dedicated source. Unlike
+// every other family they do not come from the snapshot: the counts are
+// event-driven, cumulative in-process state served fresh on every scrape.
+func (e *GPUExporter) renderXIDs(metricCh chan<- prometheus.Metric) {
+	if e.xidCountDesc == nil || e.xids == nil {
+		return
+	}
+
+	for _, counter := range e.xids.XIDCounts() {
+		xid := strconv.FormatUint(counter.XID, 10)
+
+		e.sendLabeledCounter(metricCh, e.xidCountDesc, float64(counter.Count), counter.UUID, xid)
+		e.sendLabeledGauge(metricCh, e.xidTimestampDesc,
+			float64(counter.LastSeen.UnixNano())/1e9, counter.UUID, xid)
+	}
+}
+
+// sendLabeledCounter emits one constant counter with the given label values,
+// logging instead of failing if it cannot be built.
+func (e *GPUExporter) sendLabeledCounter(
+	metricCh chan<- prometheus.Metric,
+	desc *prometheus.Desc,
+	value float64,
+	labelValues ...string,
+) {
+	metric, err := prometheus.NewConstMetric(desc, prometheus.CounterValue, value, labelValues...)
+	if err != nil {
+		e.logger.Error("failed to create metric", "err", err, "desc", desc.String())
+
+		return
+	}
+
+	e.sendMetric(metricCh, metric)
 }
 
 // renderExtras emits the backend-specific families carried outside the

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -208,7 +208,7 @@ func newTestExporter(
 
 	source := collect.NewLive(query, 0, nil, logger)
 
-	return exporter.New(ctx, prefix, resolved, source, exporter.Features{}, exporter.ExecExitCodeMetric, logger)
+	return exporter.New(ctx, prefix, resolved, source, exporter.Features{}, nil, exporter.ExecExitCodeMetric, logger)
 }
 
 // staticSource serves a fixed snapshot, for driving the render paths directly.
@@ -237,6 +237,7 @@ func newAppsExporter(t *testing.T, snapshot collect.Snapshot) *exporter.GPUExpor
 		resolved,
 		&staticSource{snapshot: snapshot},
 		exporter.Features{ComputeApps: true},
+		nil,
 		exporter.ExecExitCodeMetric,
 		logger,
 	)
@@ -259,6 +260,7 @@ func newExtrasExporter(t *testing.T, features exporter.Features, snapshot collec
 		resolved,
 		&staticSource{snapshot: snapshot},
 		features,
+		nil,
 		exporter.ExecExitCodeMetric,
 		logger,
 	)
@@ -473,7 +475,7 @@ func TestCollectDeliversMetricsOnFatalError(t *testing.T) {
 	}
 
 	source := collect.NewLive(query, 0, func(fatalErr error) { cancel(fatalErr) }, logger)
-	exp := exporter.New(ctx, "aaa", resolved, source, exporter.Features{}, exporter.ExecExitCodeMetric, logger)
+	exp := exporter.New(ctx, "aaa", resolved, source, exporter.Features{}, nil, exporter.ExecExitCodeMetric, logger)
 
 	families := gatherFamilies(t, exp)
 
@@ -574,7 +576,16 @@ func TestCollectComputeAppsDisabled(t *testing.T) {
 	// the feature is off
 	apps := []nvidiasmi.ComputeApp{{GPUUUID: "abc", PID: "42", ProcessName: "x", UsedMemory: "1 MiB"}}
 	source := &staticSource{snapshot: appsSnapshot(gpuTable("GPU-ABC"), apps, true)}
-	exp := exporter.New(t.Context(), "aaa", resolved, source, exporter.Features{}, exporter.ExecExitCodeMetric, logger)
+	exp := exporter.New(
+		t.Context(),
+		"aaa",
+		resolved,
+		source,
+		exporter.Features{},
+		nil,
+		exporter.ExecExitCodeMetric,
+		logger,
+	)
 
 	families := gatherFamilies(t, exp)
 
@@ -801,4 +812,83 @@ func TestComputeAppMIGLabels(t *testing.T) {
 	info, ok = families["aaa_compute_app_info"]
 	require.True(t, ok)
 	require.Len(t, info.GetMetric()[0].GetLabel(), 3)
+}
+
+// staticXIDs is a canned XIDSource.
+type staticXIDs struct {
+	counters []collect.XIDCounter
+}
+
+func (s *staticXIDs) XIDCounts() []collect.XIDCounter { return s.counters }
+
+func TestXIDsRenderEvenWhenCollectionFails(t *testing.T) {
+	t.Parallel()
+
+	logger := slogt.New(t)
+
+	resolved, err := nvidiasmi.ResolveFields(
+		t.Context(), "bbb", "fan.speed", "", 0, nvidiasmi.DefaultRunFunc, logger)
+	require.NoError(t, err)
+
+	xids := &staticXIDs{counters: []collect.XIDCounter{
+		{UUID: "abc", XID: 79, Count: 3, LastSeen: time.Unix(1700000000, 0)},
+	}}
+
+	// a failed collection: no table at all, which is exactly when the XID
+	// counters must stay visible
+	failed := collect.Snapshot{Attempted: true, Success: false, Failures: 1}
+
+	exp := exporter.New(
+		t.Context(),
+		"aaa",
+		resolved,
+		&staticSource{snapshot: failed},
+		exporter.Features{XIDEvents: true},
+		xids,
+		exporter.ExecExitCodeMetric,
+		logger,
+	)
+
+	families := gatherFamilies(t, exp)
+
+	counts, ok := families["aaa_xid_errors_total"]
+	require.True(t, ok, "xid counters must render without a table")
+	assert.Equal(t, dto.MetricType_COUNTER, counts.GetType())
+	assertFloat(t, 3, counts.GetMetric()[0].GetCounter().GetValue())
+	assert.Equal(t, "abc", labelValue(t, counts.GetMetric()[0], "uuid"))
+	assert.Equal(t, "79", labelValue(t, counts.GetMetric()[0], "xid"))
+
+	stamps, ok := families["aaa_xid_last_timestamp_seconds"]
+	require.True(t, ok)
+	assertFloat(t, 1700000000, stamps.GetMetric()[0].GetGauge().GetValue())
+}
+
+func TestXIDsSuppressedWhenOff(t *testing.T) {
+	t.Parallel()
+
+	logger := slogt.New(t)
+
+	resolved, err := nvidiasmi.ResolveFields(
+		t.Context(), "bbb", "fan.speed", "", 0, nvidiasmi.DefaultRunFunc, logger)
+	require.NoError(t, err)
+
+	// a live, populated source: the feature gate alone must suppress the
+	// families
+	xids := &staticXIDs{counters: []collect.XIDCounter{{UUID: "abc", XID: 79, Count: 3}}}
+
+	exp := exporter.New(
+		t.Context(),
+		"aaa",
+		resolved,
+		&staticSource{snapshot: extrasSnapshot(gpuTable("GPU-ABC"), collect.Extras{})},
+		exporter.Features{},
+		xids,
+		exporter.ExecExitCodeMetric,
+		logger,
+	)
+
+	families := gatherFamilies(t, exp)
+
+	assert.NotContains(t, families, "aaa_xid_errors_total")
+	assert.NotContains(t, families, "aaa_xid_last_timestamp_seconds")
 }

--- a/internal/integration/gpuparity_test.go
+++ b/internal/integration/gpuparity_test.go
@@ -450,6 +450,10 @@ var nvmlOnlyFamilyPrefixes = []string{
 	"nvidia_smi_mig_sm_occupancy_ratio",
 	"nvidia_smi_mig_tensor_activity_ratio",
 	"nvidia_smi_mig_pcie_throughput_",
+	// xid series appear only after an event is observed, so their presence
+	// is asserted by the GPU-box runbook (which triggers a real XID), not
+	// here
+	"nvidia_smi_xid_",
 }
 
 func isNVMLOnlyFamily(family string) bool {

--- a/internal/nvmlnative/backend_nvml.go
+++ b/internal/nvmlnative/backend_nvml.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -41,6 +42,15 @@ type nvmlAPI struct {
 	gpmSampleFree   func(nvml.GpmSample) nvml.Return
 	gpmMigSampleGet func(nvml.Device, int, nvml.GpmSample) nvml.Return
 	gpmMetricsGet   func(*nvml.GpmMetricsGetType) nvml.Return
+	// eventSetCreate is package-level in go-nvml, hence on the seam; the
+	// set's Wait/Free are interface methods and mock naturally
+	eventSetCreate func() (nvml.EventSet, nvml.Return)
+	// lookupSymbol probes whether the driver library exports a symbol. A
+	// getter whose export is missing entirely does NOT answer with a polite
+	// FUNCTION_NOT_FOUND return: the lazily bound call crashes the process
+	// (observed live on driver 590 with the v2 remapped-rows entry point),
+	// so maybe-absent direct getters must be probed before the first call.
+	lookupSymbol func(string) error
 }
 
 func realNVML() nvmlAPI {
@@ -61,6 +71,8 @@ func realNVML() nvmlAPI {
 		gpmSampleFree:     nvml.GpmSampleFree,
 		gpmMigSampleGet:   nvml.GpmMigSampleGet,
 		gpmMetricsGet:     nvml.GpmMetricsGet,
+		eventSetCreate:    nvml.EventSetCreate,
+		lookupSymbol:      func(name string) error { return nvml.Extensions().LookupSymbol(name) },
 	}
 }
 
@@ -81,13 +93,34 @@ type Backend struct {
 	// extrasWarned makes a persistent extras failure visible exactly once
 	// per family, mirroring permLogged/fnfLogged.
 	extrasWarned map[string]bool
+	// symbolsPresent caches driver-library symbol probes (constant for the
+	// process lifetime). Guarded by mu like the rest of the cycle state.
+	symbolsPresent map[string]bool
 	// gpm retains one activity sample per GPU instance across cycles, so
 	// utilization can be computed over the inter-collection window. Guarded
 	// by mu like the rest of the cycle state; every sample is freed before
 	// any NVML shutdown.
 	gpm map[string]*gpmState
 	// now is the clock, injectable so the GPM window guards are testable.
-	now    func() time.Time
+	// Set once at construction, immutable afterwards (the XID watcher reads
+	// it without the cycle lock).
+	now func() time.Time
+	// lifecycleMu is the barrier between NVML shutdown and the XID
+	// watcher's in-flight driver calls: the watcher holds it shared around
+	// every NVML operation, shutdown takes it exclusively (bounded, so a
+	// wedged watcher call cannot hang a collection forever). Lock ordering:
+	// mu before lifecycleMu, never the reverse.
+	lifecycleMu sync.RWMutex
+	// generation counts successful NVML initializations and genLive tells
+	// whether the current generation is usable. Atomics: the watcher reads
+	// them without the cycle lock, and shutdown must be able to flip
+	// genLive even when the exclusive lifecycle lock cannot be acquired.
+	generation atomic.Uint64
+	genLive    atomic.Bool
+	// xids accumulates the XID error events observed by the watcher. It
+	// has its own lock and is read at scrape time, outside the snapshot
+	// pipeline.
+	xids   xidAccumulator
 	logger *slog.Logger
 }
 
@@ -104,6 +137,8 @@ func newWithAPI(api nvmlAPI, logger *slog.Logger) (*Backend, error) {
 	}
 
 	backend.initialized = true
+	backend.generation.Store(1)
+	backend.genLive.Store(true)
 
 	return backend, nil
 }
@@ -131,12 +166,23 @@ func (b *Backend) Close() {
 	}
 	defer b.mu.Unlock()
 
-	if b.initialized {
-		b.freeGPMSamples()
-
-		_ = b.api.shutdown()
-		b.initialized = false
+	if !b.initialized {
+		return
 	}
+
+	b.freeGPMSamples()
+
+	b.initialized = false
+	b.genLive.Store(false)
+
+	if !b.tryLifecycleLock() {
+		b.logger.Warn("skipping NVML shutdown: the XID watcher is stuck inside the driver")
+
+		return
+	}
+	defer b.lifecycleMu.Unlock()
+
+	_ = b.api.shutdown()
 }
 
 // lifecycleErrors are NVML returns that mean the driver/GPU state is gone,
@@ -272,6 +318,8 @@ func (b *Backend) collectTable(
 		b.logger.Info("re-initialized NVML after a lifecycle error")
 
 		b.initialized = true
+		b.generation.Add(1)
+		b.genLive.Store(true)
 	}
 
 	count, ret := b.api.deviceCount()
@@ -366,15 +414,91 @@ func (b *Backend) lifecycle(ret nvml.Return, err error) error {
 
 // markLost flags the backend for re-initialization on the next cycle. The
 // retained GPM samples die with the NVML generation, so they are freed
-// (best-effort) before the shutdown.
+// (best-effort) before the shutdown, and the generation is declared dead
+// first so the XID watcher stops touching it even when the shutdown itself
+// has to be skipped behind a wedged watcher call.
 func (b *Backend) markLost() {
-	if b.initialized {
-		b.freeGPMSamples()
-
-		b.initialized = false
-
-		_ = b.api.shutdown()
+	if !b.initialized {
+		return
 	}
+
+	b.freeGPMSamples()
+
+	b.initialized = false
+	b.genLive.Store(false)
+
+	if !b.tryLifecycleLock() {
+		b.logger.Warn("skipping NVML shutdown: the XID watcher is stuck inside the driver")
+
+		return
+	}
+	defer b.lifecycleMu.Unlock()
+
+	_ = b.api.shutdown()
+}
+
+// lifecycleLockDeadline bounds how long a shutdown waits for the XID watcher
+// to leave the driver. The watcher's wait calls are themselves bounded to a
+// second, so the deadline only fires when a driver call is genuinely wedged.
+const lifecycleLockDeadline = 2 * time.Second
+
+// tryLifecycleLock acquires the exclusive lifecycle lock, bounded: process
+// health must never hang forever behind an unkillable driver call. The
+// acquisition must BLOCK (in a goroutine raced against the deadline) rather
+// than poll TryLock: only a pending blocking acquisition gets writer
+// priority over the watcher, which holds the shared lock for the full
+// duration of each bounded driver wait and releases it only momentarily
+// (verified empirically: a TryLock poll virtually never lands in that gap).
+func (b *Backend) tryLifecycleLock() bool {
+	acquired := make(chan struct{})
+
+	go func() {
+		b.lifecycleMu.Lock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		return true
+	case <-time.After(lifecycleLockDeadline):
+		// the pending acquisition will land eventually (when the wedged
+		// call returns); it must release immediately then, or the watcher
+		// would starve forever afterwards
+		go func() {
+			<-acquired
+			b.lifecycleMu.Unlock()
+		}()
+
+		return false
+	}
+}
+
+// tryRecover is the watcher's scrape-independent recovery path: when event
+// registration fails because the driver generation died, waiting for a
+// scrape to re-initialize NVML would leave event collection deaf on an idle
+// exporter. It funnels through the same state transitions as a collection
+// cycle, best-effort: when a cycle holds the lock, that cycle handles the
+// recovery anyway.
+func (b *Backend) tryRecover() {
+	if !b.mu.TryLock() {
+		return
+	}
+	defer b.mu.Unlock()
+
+	if b.initialized {
+		// the generation died without the cycle path noticing yet
+		b.markLost()
+	}
+
+	if ret := b.api.init(); ret != nvml.SUCCESS {
+		return
+	}
+
+	b.logger.Info("re-initialized NVML after a lifecycle error (event watcher recovery)")
+
+	b.initialized = true
+	b.generation.Add(1)
+	b.genLive.Store(true)
 }
 
 // lifecycleRetError carries a lifecycle-class return code out of a device
@@ -787,6 +911,26 @@ func (b *Backend) collectDevice(
 	if reqs.want("retired_pages.pending") {
 		retiredPending, ret := dev.GetRetiredPagesPendingStatus()
 		coll.set("retired_pages.pending", ret, func() string { return yesNo(retiredPending == nvml.FEATURE_ENABLED) })
+	}
+
+	if reqs.want("remapped_rows.correctable_inactive", "remapped_rows.uncorrectable_inactive") {
+		// only the inactive counts come from the v2 call: the four classic
+		// fields stay on the unversioned call, so drivers without the v2
+		// entry point keep serving them (the inactive series just stay
+		// absent there). The export must be probed first: driver 590 ships
+		// no v2 symbol at all, and calling a missing export crashes the
+		// process instead of returning FUNCTION_NOT_FOUND (verified live).
+		var info nvml.RemappedRowsInfo_v2
+
+		ret := nvml.ERROR_FUNCTION_NOT_FOUND
+		if b.symbolPresent("nvmlDeviceGetRemappedRows_v2") {
+			info, ret = dev.GetRemappedRows_v2()
+		}
+
+		coll.set("remapped_rows.correctable_inactive", ret,
+			func() string { return strconv.FormatUint(uint64(info.CorrInactiveRemaps), 10) })
+		coll.set("remapped_rows.uncorrectable_inactive", ret,
+			func() string { return strconv.FormatUint(uint64(info.UncInactiveRemaps), 10) })
 	}
 
 	if reqs.want("remapped_rows.correctable", "remapped_rows.uncorrectable",
@@ -1465,6 +1609,29 @@ func (b *Backend) extrasFailure(family, msg string, ret nvml.Return) bool {
 	}
 
 	return true
+}
+
+// symbolPresent reports whether the driver library exports the symbol,
+// cached for the process lifetime. The caller holds the backend lock.
+func (b *Backend) symbolPresent(name string) bool {
+	present, ok := b.symbolsPresent[name]
+	if ok {
+		return present
+	}
+
+	if b.symbolsPresent == nil {
+		b.symbolsPresent = map[string]bool{}
+	}
+
+	present = b.api.lookupSymbol(name) == nil
+	b.symbolsPresent[name] = present
+
+	if !present {
+		b.logger.Info("driver library lacks an optional entry point, "+
+			"the fields it serves stay absent", "symbol", name)
+	}
+
+	return present
 }
 
 // warnOnce logs a warning the first time a family fails, so a persistent

--- a/internal/nvmlnative/backend_nvml_internal_test.go
+++ b/internal/nvmlnative/backend_nvml_internal_test.go
@@ -4,7 +4,9 @@ package nvmlnative
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,7 +25,8 @@ import (
 // devices panic on any method without a stub, so these tests double as proof
 // that unrequested getters are never called (the collection plan).
 type fakeAPI struct {
-	inits, shutdowns int
+	// atomics: the XID watcher drives init/shutdown from its own goroutine
+	inits, shutdowns atomic.Int64
 	devices          []nvml.Device
 	initRet          nvml.Return
 }
@@ -31,12 +34,12 @@ type fakeAPI struct {
 func (f *fakeAPI) api() nvmlAPI {
 	return nvmlAPI{
 		init: func() nvml.Return {
-			f.inits++
+			f.inits.Add(1)
 
 			return f.initRet
 		},
 		shutdown: func() nvml.Return {
-			f.shutdowns++
+			f.shutdowns.Add(1)
 
 			return nvml.SUCCESS
 		},
@@ -51,6 +54,7 @@ func (f *fakeAPI) api() nvmlAPI {
 		driverVersion:     func() (string, nvml.Return) { return "590.48.01", nvml.SUCCESS },
 		cudaDriverVersion: func() (int, nvml.Return) { return 13010, nvml.SUCCESS },
 		processName:       func(int) (string, nvml.Return) { return "/usr/bin/burn", nvml.SUCCESS },
+		lookupSymbol:      func(string) error { return nil },
 		validateInforom:   func(nvml.Device) nvml.Return { return nvml.SUCCESS },
 	}
 }
@@ -163,7 +167,7 @@ func TestLifecycleErrorFailsCollectionAndReinitializes(t *testing.T) {
 	var fatal *collect.FatalError
 
 	require.ErrorAs(t, err, &fatal, "lifecycle errors must drive shutdown-on-error")
-	assert.Equal(t, 1, fake.shutdowns, "backend must tear NVML down after a lifecycle error")
+	assert.Equal(t, int64(1), fake.shutdowns.Load(), "backend must tear NVML down after a lifecycle error")
 
 	// recovery: the next cycle re-initializes and succeeds
 	lost = false
@@ -171,7 +175,7 @@ func TestLifecycleErrorFailsCollectionAndReinitializes(t *testing.T) {
 	_, code, err = query(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 0, code)
-	assert.Equal(t, 2, fake.inits, "the recovery cycle must re-initialize NVML")
+	assert.Equal(t, int64(2), fake.inits.Load(), "the recovery cycle must re-initialize NVML")
 }
 
 func TestZeroDevicesIsAFailedCollection(t *testing.T) {
@@ -232,7 +236,12 @@ func TestComputeAppsFailSoftlyButMarkLifecycle(t *testing.T) {
 	assert.True(t, reading.AppsAttempted)
 	assert.False(t, reading.AppsSuccess)
 	require.Error(t, reading.AppsErr)
-	assert.Equal(t, 1, fake.shutdowns, "a lost GPU during per-process collection must still mark for re-init")
+	assert.Equal(
+		t,
+		int64(1),
+		fake.shutdowns.Load(),
+		"a lost GPU during per-process collection must still mark for re-init",
+	)
 }
 
 func TestComputeAppsHappyPath(t *testing.T) {
@@ -301,7 +310,7 @@ func TestCloseShutsDownOnce(t *testing.T) {
 	backend.Close()
 	backend.Close() // idempotent
 
-	assert.Equal(t, 1, fake.shutdowns)
+	assert.Equal(t, int64(1), fake.shutdowns.Load())
 }
 
 func TestCloseSkipsWhenCollectionHoldsTheDriver(t *testing.T) {
@@ -338,7 +347,7 @@ func TestCloseSkipsWhenCollectionHoldsTheDriver(t *testing.T) {
 		t.Fatal("Close hung behind a wedged driver call")
 	}
 
-	assert.Equal(t, 0, fake.shutdowns, "Close must skip shutdown while the driver is held")
+	assert.Equal(t, int64(0), fake.shutdowns.Load(), "Close must skip shutdown while the driver is held")
 	close(release)
 }
 
@@ -519,7 +528,7 @@ func TestExtrasLifecycleErrorStaysSoftAndMarksLost(t *testing.T) {
 
 	reading, _, err = query(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, 2, fake.inits, "the next cycle must re-initialize NVML")
+	assert.Equal(t, int64(2), fake.inits.Load(), "the next cycle must re-initialize NVML")
 	require.Len(t, reading.Extras.Energy, 1)
 }
 
@@ -557,7 +566,7 @@ func TestExtrasNonLifecycleFailureSkipsOnlyThatDevice(t *testing.T) {
 
 	require.Len(t, reading.Extras.Energy, 1, "device 1 must survive device 0's non-lifecycle failure")
 	assert.Equal(t, "99999999-2222-3333-4444-555555555555", reading.Extras.Energy[0].UUID)
-	assert.Equal(t, 0, fake.shutdowns, "a non-lifecycle failure must not tear NVML down")
+	assert.Equal(t, int64(0), fake.shutdowns.Load(), "a non-lifecycle failure must not tear NVML down")
 }
 
 func TestExtrasLifecycleAbortsRemainingDevices(t *testing.T) {
@@ -589,7 +598,7 @@ func TestExtrasLifecycleAbortsRemainingDevices(t *testing.T) {
 	assert.Equal(t, 0, code)
 	assert.Empty(t, reading.Extras.Energy)
 	assert.Empty(t, reading.Extras.PCIe)
-	assert.Equal(t, 1, fake.shutdowns, "the lifecycle error must mark the backend for re-init")
+	assert.Equal(t, int64(1), fake.shutdowns.Load(), "the lifecycle error must mark the backend for re-init")
 }
 
 func TestExtrasPcieNotSupportedSkipsDevice(t *testing.T) {
@@ -609,5 +618,83 @@ func TestExtrasPcieNotSupportedSkipsDevice(t *testing.T) {
 	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), opts)(t.Context())
 	require.NoError(t, err, "an unsupported PCIe counter must not fail the collection")
 	assert.Empty(t, reading.Extras.PCIe)
-	assert.Equal(t, 0, fake.shutdowns, "NOT_SUPPORTED is not a lifecycle error")
+	assert.Equal(t, int64(0), fake.shutdowns.Load(), "NOT_SUPPORTED is not a lifecycle error")
+}
+
+func TestRemappedRowsInactiveFields(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	dev.GetRemappedRows_v2Func = func() (nvml.RemappedRowsInfo_v2, nvml.Return) {
+		return nvml.RemappedRowsInfo_v2{CorrInactiveRemaps: 3, UncInactiveRemaps: 7}, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	fields := resolveFields(t, "remapped_rows.correctable_inactive,remapped_rows.uncorrectable_inactive")
+
+	reading, _, err := backend.QueryFunc(fields, CollectOptions{})(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "3", cellValue(t, reading.Table, "remapped_rows.correctable_inactive"))
+	assert.Equal(t, "7", cellValue(t, reading.Table, "remapped_rows.uncorrectable_inactive"))
+}
+
+func TestRemappedRowsInactiveAbsentOnOldDrivers(t *testing.T) {
+	t.Parallel()
+
+	// a driver without the newer entry point: the classic four fields keep
+	// coming from the unversioned call, only the inactive pair reads absent
+	dev := identityDevice()
+	dev.GetRemappedRows_v2Func = func() (nvml.RemappedRowsInfo_v2, nvml.Return) {
+		return nvml.RemappedRowsInfo_v2{}, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+	dev.GetRemappedRowsFunc = func() (int, int, bool, bool, nvml.Return) {
+		return 5, 1, false, false, nvml.SUCCESS
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	backend := newTestBackend(t, fake)
+
+	fields := resolveFields(t,
+		"remapped_rows.correctable,remapped_rows.correctable_inactive,"+
+			"remapped_rows.uncorrectable,remapped_rows.uncorrectable_inactive")
+
+	reading, _, err := backend.QueryFunc(fields, CollectOptions{})(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "5", cellValue(t, reading.Table, "remapped_rows.correctable"))
+	assert.Equal(t, "1", cellValue(t, reading.Table, "remapped_rows.uncorrectable"))
+	assert.Equal(t, "[Function Not Found]", cellValue(t, reading.Table, "remapped_rows.correctable_inactive"))
+	assert.Equal(t, "[Function Not Found]", cellValue(t, reading.Table, "remapped_rows.uncorrectable_inactive"))
+}
+
+func TestRemappedRowsInactiveAbsentWhenSymbolMissing(t *testing.T) {
+	t.Parallel()
+
+	// a driver library that ships no v2 export at all: the getter must not
+	// even be called (a missing export crashes at call time, it does not
+	// return an error), so the device has no stub for it
+	dev := identityDevice()
+	dev.GetPowerUsageFunc = func() (uint32, nvml.Return) { return 12340, nvml.SUCCESS }
+
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+
+	api := fake.api()
+	api.lookupSymbol = func(name string) error {
+		if name == "nvmlDeviceGetRemappedRows_v2" {
+			return errors.New("symbol not found")
+		}
+
+		return nil
+	}
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	fields := resolveFields(t, "power.draw,remapped_rows.correctable_inactive")
+
+	reading, _, err := backend.QueryFunc(fields, CollectOptions{})(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "[Function Not Found]", cellValue(t, reading.Table, "remapped_rows.correctable_inactive"))
+	assert.Equal(t, "12.34 W", cellValue(t, reading.Table, "power.draw"))
 }

--- a/internal/nvmlnative/backend_unavailable.go
+++ b/internal/nvmlnative/backend_unavailable.go
@@ -3,6 +3,7 @@
 package nvmlnative
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 
@@ -36,5 +37,15 @@ func (b *Backend) DriverVersion() string { return "" }
 
 // QueryFunc is never reachable: New always fails first.
 func (b *Backend) QueryFunc(_ nvidiasmi.ResolvedFields, _ CollectOptions) collect.QueryFunc {
+	panic("nvml backend is not available in this build")
+}
+
+// RunXIDWatcher is never reachable: New always fails first.
+func (b *Backend) RunXIDWatcher(_ context.Context) error {
+	panic("nvml backend is not available in this build")
+}
+
+// XIDCounts is never reachable: New always fails first.
+func (b *Backend) XIDCounts() []collect.XIDCounter {
 	panic("nvml backend is not available in this build")
 }

--- a/internal/nvmlnative/catalog.go
+++ b/internal/nvmlnative/catalog.go
@@ -153,7 +153,9 @@ var fieldOrder = []nvidiasmi.QField{
 	"retired_pages.double_bit.count",
 	"retired_pages.pending",
 	"remapped_rows.correctable",
+	"remapped_rows.correctable_inactive",
 	"remapped_rows.uncorrectable",
+	"remapped_rows.uncorrectable_inactive",
 	"remapped_rows.pending",
 	"remapped_rows.failure",
 	"remapped_rows.histogram.max",
@@ -336,7 +338,9 @@ var catalogRFields = map[nvidiasmi.QField]nvidiasmi.RField{
 	"retired_pages.double_bit.count":                          "retired_pages.double_bit.count",
 	"retired_pages.pending":                                   "retired_pages.pending",
 	"remapped_rows.correctable":                               "remapped_rows.correctable",
+	"remapped_rows.correctable_inactive":                      "remapped_rows.correctable_inactive",
 	"remapped_rows.uncorrectable":                             "remapped_rows.uncorrectable",
+	"remapped_rows.uncorrectable_inactive":                    "remapped_rows.uncorrectable_inactive",
 	"remapped_rows.pending":                                   "remapped_rows.pending",
 	"remapped_rows.failure":                                   "remapped_rows.failure",
 	"remapped_rows.histogram.max":                             "remapped_rows.histogram.max",
@@ -513,10 +517,8 @@ const deprecatedFieldsMinDriverMajor = 590
 // newest capture and it is not listed here; adding a field here is the
 // explicit "defer" decision, adding it to the catalog is the fix.
 var deferredFields = map[nvidiasmi.QField]bool{
-	"kmd_version":                          true,
-	"pcie.link.gen.hostmax":                true,
-	"remapped_rows.correctable_inactive":   true,
-	"remapped_rows.uncorrectable_inactive": true,
+	"kmd_version":           true,
+	"pcie.link.gen.hostmax": true,
 }
 
 // deferredFieldPrefixes covers whole deferred families (vGPU capabilities,

--- a/internal/nvmlnative/mig_nvml_internal_test.go
+++ b/internal/nvmlnative/mig_nvml_internal_test.go
@@ -161,7 +161,7 @@ func TestMIGNotSupportedIsSilent(t *testing.T) {
 	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, reading.Extras.MIG)
-	assert.Equal(t, 0, fake.shutdowns)
+	assert.Equal(t, int64(0), fake.shutdowns.Load())
 }
 
 func TestMIGGPMCrossCycle(t *testing.T) {
@@ -477,7 +477,7 @@ func TestMIGGPMMetricsFailureRotatesAndRecovers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, reading.Extras.MIG[0].Utilization)
 	assert.Equal(t, 1, gpm.live())
-	assert.Equal(t, 0, fake.shutdowns)
+	assert.Equal(t, int64(0), fake.shutdowns.Load())
 
 	// and it heals on the next cycle
 	gpm.metricsRet = nvml.SUCCESS
@@ -505,7 +505,7 @@ func TestMIGGPMSampleGetLifecycleAborts(t *testing.T) {
 	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
 	require.NoError(t, err, "extras must never fail the collection")
 	assert.Nil(t, reading.Extras.MIG[0].Utilization)
-	assert.Equal(t, 1, fake.shutdowns, "the lifecycle error must mark the backend for re-init")
+	assert.Equal(t, int64(1), fake.shutdowns.Load(), "the lifecycle error must mark the backend for re-init")
 	assert.Equal(t, 0, gpm.live(), "no sample may leak through the abort")
 }
 
@@ -526,7 +526,7 @@ func TestMIGLifecycleOnHandleLookupAborts(t *testing.T) {
 	reading, _, err := backend.QueryFunc(resolveFields(t, "power.draw"), migOpts())(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, reading.Extras.MIG)
-	assert.Equal(t, 1, fake.shutdowns, "a lost GPU during MIG enumeration must mark for re-init")
+	assert.Equal(t, int64(1), fake.shutdowns.Load(), "a lost GPU during MIG enumeration must mark for re-init")
 }
 
 func TestCloseFreesGPMSamples(t *testing.T) {
@@ -550,7 +550,7 @@ func TestCloseFreesGPMSamples(t *testing.T) {
 	backend.Close()
 
 	assert.Equal(t, 0, gpm.live(), "Close must free every retained sample before shutdown")
-	assert.Equal(t, 1, fake.shutdowns)
+	assert.Equal(t, int64(1), fake.shutdowns.Load())
 }
 
 func TestMIGGPMFingerprintProfileChange(t *testing.T) {

--- a/internal/nvmlnative/symbols.go
+++ b/internal/nvmlnative/symbols.go
@@ -84,6 +84,40 @@ var nvmlSymbolRequirements = []symbolRequirement{
 		serves: "mig_*_ratio, mig_pcie_throughput_*",
 	},
 	{
+		goCall: "eventSetCreate",
+		anyOf:  []string{"nvmlEventSetCreate"},
+		serves: "xid_errors_total",
+	},
+	{
+		goCall: "RegisterEvents",
+		anyOf:  []string{"nvmlDeviceRegisterEvents"},
+		serves: "xid_errors_total",
+	},
+	{
+		// reached as interface methods on the event set (not scannable call
+		// shapes); listed so the inventory check still proves the driver
+		// carries them
+		goCall: "eventSetWait",
+		anyOf:  []string{"nvmlEventSetWait_v2", "nvmlEventSetWait"},
+		serves: "xid_errors_total",
+	},
+	{
+		goCall: "eventSetFree",
+		anyOf:  []string{"nvmlEventSetFree"},
+		serves: "xid_errors_total",
+	},
+	{
+		// the unversioned symbol is accepted as an alternative because the
+		// 590 driver library genuinely ships no v2 export (verified live on
+		// an H200: the recorded capture inventory of 405 symbols matches
+		// the library exactly). The call site probes the export first and
+		// leaves the inactive fields absent when it is missing, so the
+		// requirement the inventory must prove is only the classic call.
+		goCall: "GetRemappedRows_v2",
+		anyOf:  []string{"nvmlDeviceGetRemappedRows_v2", "nvmlDeviceGetRemappedRows"},
+		serves: "remapped_rows.*_inactive",
+	},
+	{
 		goCall: "GetPcieThroughput",
 		anyOf:  []string{"nvmlDeviceGetPcieThroughput"},
 		serves: "pcie_throughput_*_bytes_per_second",

--- a/internal/nvmlnative/symbols_internal_test.go
+++ b/internal/nvmlnative/symbols_internal_test.go
@@ -167,19 +167,30 @@ func TestSymbolManifestCoversCollectorCallSites(t *testing.T) {
 	}
 }
 
+// collectSeamFields records the nvmlAPI seam field names: every field is a
+// core requirement, except the symbol prober, which is not a symbol itself.
+func collectSeamFields(structType *ast.StructType, seen map[string]bool) {
+	for _, field := range structType.Fields.List {
+		for _, fieldName := range field.Names {
+			// lookupSymbol probes exports, it is not one itself
+			if fieldName.Name == "lookupSymbol" {
+				continue
+			}
+
+			seen[fieldName.Name] = true
+		}
+	}
+}
+
 // collectCallSites records device getter calls and nvmlAPI seam field names.
 //
 //nolint:cyclop // one linear AST walk over the two call-site shapes
 func collectCallSites(file *ast.File, seen map[string]bool) {
 	ast.Inspect(file, func(node ast.Node) bool {
-		// the seam struct type: every field is a core requirement
+		// the seam struct type
 		if typeSpec, ok := node.(*ast.TypeSpec); ok && typeSpec.Name.Name == "nvmlAPI" {
 			if structType, isStruct := typeSpec.Type.(*ast.StructType); isStruct {
-				for _, field := range structType.Fields.List {
-					for _, fieldName := range field.Names {
-						seen[fieldName.Name] = true
-					}
-				}
+				collectSeamFields(structType, seen)
 			}
 
 			return true
@@ -196,7 +207,8 @@ func collectCallSites(file *ast.File, seen map[string]bool) {
 		}
 
 		method := selector.Sel.Name
-		if strings.HasPrefix(method, "Get") || strings.HasPrefix(method, "Gpm") || method == "ValidateInforom" {
+		if strings.HasPrefix(method, "Get") || strings.HasPrefix(method, "Gpm") ||
+			method == "ValidateInforom" || method == "RegisterEvents" {
 			// skip go-nvml package-level helpers reached through the seam
 			if ident, isIdent := selector.X.(*ast.Ident); isIdent && ident.Name == "nvml" {
 				return true

--- a/internal/nvmlnative/xid_nvml.go
+++ b/internal/nvmlnative/xid_nvml.go
@@ -1,0 +1,349 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+// xidWaitTimeoutMs bounds each event wait, so the watcher regularly
+// re-checks its generation and the context without busy-looping.
+const xidWaitTimeoutMs = 1000
+
+// xidBackoffStart and xidBackoffMax pace the registration retries when NVML
+// is down or events are unavailable. The backoff resets after a successful
+// registration and is context-aware, so shutdown never waits it out.
+const (
+	xidBackoffStart = time.Second
+	xidBackoffMax   = 30 * time.Second
+)
+
+// xidAccumulator is the cross-cycle XID state: written by the watcher
+// goroutine, read at scrape time. It has its own lock because it is the only
+// state shared between the watcher and the scrape path.
+type xidAccumulator struct {
+	mu    sync.Mutex
+	stats map[string]map[uint64]*xidStat
+	// waitWarned makes a persistent event-wait failure visible exactly
+	// once, alongside the accumulator because it shares the same lock.
+	waitWarned bool
+}
+
+// xidStat is one (GPU, XID code) pair's running state.
+type xidStat struct {
+	count uint64
+	last  time.Time
+}
+
+// bump records one observed event.
+func (a *xidAccumulator) bump(uuid string, xid uint64, at time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.stats == nil {
+		a.stats = map[string]map[uint64]*xidStat{}
+	}
+
+	perGPU := a.stats[uuid]
+	if perGPU == nil {
+		perGPU = map[uint64]*xidStat{}
+		a.stats[uuid] = perGPU
+	}
+
+	stat := perGPU[xid]
+	if stat == nil {
+		stat = &xidStat{}
+		perGPU[xid] = stat
+	}
+
+	stat.count++
+	stat.last = at
+}
+
+// counts snapshots the accumulated state, sorted for deterministic output.
+func (a *xidAccumulator) counts() []collect.XIDCounter {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var counters []collect.XIDCounter
+
+	for uuid, perGPU := range a.stats {
+		for xid, stat := range perGPU {
+			counters = append(counters, collect.XIDCounter{
+				UUID:     uuid,
+				XID:      xid,
+				Count:    stat.count,
+				LastSeen: stat.last,
+			})
+		}
+	}
+
+	sort.Slice(counters, func(i, j int) bool {
+		if counters[i].UUID != counters[j].UUID {
+			return counters[i].UUID < counters[j].UUID
+		}
+
+		return counters[i].XID < counters[j].XID
+	})
+
+	return counters
+}
+
+// XIDCounts serves the accumulated XID error counts to the exporter. Safe
+// for concurrent use; independent of the collection pipeline by design, so
+// the counters stay visible while collections fail.
+func (b *Backend) XIDCounts() []collect.XIDCounter {
+	return b.xids.counts()
+}
+
+// xidWatcherLog makes each watcher failure mode visible exactly once, so a
+// setup without event support does not flood the log every backoff round.
+type xidWatcherLog struct {
+	createWarned   bool
+	registerWarned bool
+	noneWarned     bool
+}
+
+// RunXIDWatcher registers for XID error events on every device and
+// accumulates them until ctx ends. It runs beside the collection cycles, not
+// inside them: XIDs must be caught as they happen, not when a scrape
+// arrives. It never returns an error: on a machine without event support the
+// watcher idles (retrying periodically, in case a driver reload changes the
+// answer) and the XID families simply stay empty. When the driver generation
+// dies underneath it, the watcher drives the re-initialization itself, so
+// event collection recovers even when nothing is scraping.
+func (b *Backend) RunXIDWatcher(ctx context.Context) error {
+	warnings := &xidWatcherLog{}
+	backoff := xidBackoffStart
+
+	for ctx.Err() == nil {
+		set, uuids, generation, ok := b.xidRegister(warnings)
+		if !ok {
+			// registration failing usually means the driver generation is
+			// dead: recover it here rather than waiting for a scrape
+			b.tryRecover()
+
+			if !sleepContext(ctx, backoff) {
+				return nil
+			}
+
+			backoff = min(backoff*2, xidBackoffMax)
+
+			continue
+		}
+
+		// a fresh registration round may fail for fresh reasons: make them
+		// visible again instead of staying silenced forever
+		*warnings = xidWatcherLog{}
+
+		healthy := b.xidWait(ctx, set, uuids, generation)
+		if healthy {
+			backoff = xidBackoffStart
+
+			continue
+		}
+
+		// the wait path itself failed: pace the rebuild, or a persistently
+		// failing driver call would spin register/wait/free at full speed
+		if !sleepContext(ctx, backoff) {
+			return nil
+		}
+
+		backoff = min(backoff*2, xidBackoffMax)
+	}
+
+	return nil
+}
+
+// xidRegister builds an event set and registers every device for XID
+// events, under the shared lifecycle barrier. It reports the set, the
+// registration-time uuid cache (a GPU may be unreadable by the time it
+// errors), the NVML generation the set belongs to, and whether anything was
+// registered at all.
+//
+//nolint:cyclop,funlen,ireturn // one linear pass; the event set is go-nvml.s own interface type
+func (b *Backend) xidRegister(warnings *xidWatcherLog) (nvml.EventSet, map[nvml.Device]string, uint64, bool) {
+	b.lifecycleMu.RLock()
+	defer b.lifecycleMu.RUnlock()
+
+	if !b.genLive.Load() {
+		return nil, nil, 0, false
+	}
+
+	generation := b.generation.Load()
+
+	set, ret := b.api.eventSetCreate()
+	if ret != nvml.SUCCESS {
+		if !warnings.createWarned {
+			warnings.createWarned = true
+
+			b.logger.Warn("cannot create an NVML event set, XID errors will not be counted",
+				"nvml_return", ret.String())
+		}
+
+		return nil, nil, 0, false
+	}
+
+	count, ret := b.api.deviceCount()
+	if ret != nvml.SUCCESS {
+		_ = set.Free()
+
+		return nil, nil, 0, false
+	}
+
+	uuids := map[nvml.Device]string{}
+
+	for deviceIdx := range count {
+		dev, ret := b.api.deviceByIndex(deviceIdx)
+		if ret != nvml.SUCCESS {
+			continue
+		}
+
+		uuid, ret := dev.GetUUID()
+		if ret != nvml.SUCCESS {
+			continue
+		}
+
+		if ret := dev.RegisterEvents(nvml.EventTypeXidCriticalError, set); ret != nvml.SUCCESS {
+			if !warnings.registerWarned {
+				warnings.registerWarned = true
+
+				b.logger.Warn("cannot register for XID error events on a GPU",
+					"uuid", nvidiasmi.NormalizeUUID(uuid), "nvml_return", ret.String())
+			}
+
+			continue
+		}
+
+		uuids[dev] = nvidiasmi.NormalizeUUID(uuid)
+	}
+
+	if len(uuids) == 0 {
+		_ = set.Free()
+
+		if !warnings.noneWarned {
+			warnings.noneWarned = true
+
+			b.logger.Warn("registered no GPU for XID error events, the XID counters stay empty")
+		}
+
+		return nil, nil, 0, false
+	}
+
+	// the readiness signal: anything waiting to inject a test XID (the
+	// GPU-box runbook) must wait for this line, since earlier events cannot
+	// be replayed
+	b.logger.Info("watching for GPU XID error events", "gpus", len(uuids))
+
+	return set, uuids, generation, true
+}
+
+// xidWait drains the event set until the context ends, the NVML generation
+// dies, or the set fails. Every driver call happens under the shared
+// lifecycle barrier. The set is freed under that same barrier, and ONLY
+// while its generation is still alive: once the generation died, the
+// shutdown that killed it also reclaimed the set, and freeing it would
+// touch a torn-down library (when a wedged shutdown was skipped instead,
+// the unfreeable set is the lesser evil, and the next real shutdown
+// reclaims it). Reports whether the wait path stayed healthy: false means
+// the driver failed the wait itself and the rebuild must be paced.
+func (b *Backend) xidWait(
+	ctx context.Context,
+	set nvml.EventSet,
+	uuids map[nvml.Device]string,
+	generation uint64,
+) bool {
+	generationAlive := func() bool {
+		return b.genLive.Load() && b.generation.Load() == generation
+	}
+
+	for {
+		b.lifecycleMu.RLock()
+
+		if ctx.Err() != nil || !generationAlive() {
+			if generationAlive() {
+				_ = set.Free()
+			}
+
+			b.lifecycleMu.RUnlock()
+
+			return true
+		}
+
+		data, ret := set.Wait(xidWaitTimeoutMs)
+
+		//nolint:exhaustive // every other return is a failed wait
+		switch ret {
+		case nvml.SUCCESS:
+			b.lifecycleMu.RUnlock()
+			b.recordXID(uuids, data)
+		case nvml.ERROR_TIMEOUT:
+			b.lifecycleMu.RUnlock()
+		default:
+			// the wait itself failed: this event set is done. Free it while
+			// still holding the barrier (unless its generation died) and let
+			// the outer loop rebuild.
+			if generationAlive() {
+				_ = set.Free()
+			}
+
+			b.lifecycleMu.RUnlock()
+
+			b.warnOnceXID("GPU XID event wait failed, rebuilding the event registration", ret)
+
+			return false
+		}
+	}
+}
+
+// warnOnceXID logs a wait failure without flooding: the accumulator mutex
+// guards the flag because the watcher is the only writer but tests may run
+// concurrent watchers.
+func (b *Backend) warnOnceXID(msg string, ret nvml.Return) {
+	b.xids.mu.Lock()
+	defer b.xids.mu.Unlock()
+
+	if b.xids.waitWarned {
+		return
+	}
+
+	b.xids.waitWarned = true
+
+	b.logger.Warn(msg, "nvml_return", ret.String())
+}
+
+// recordXID folds one received event into the accumulator.
+func (b *Backend) recordXID(uuids map[nvml.Device]string, data nvml.EventData) {
+	uuid := uuids[data.Device]
+	if uuid == "" {
+		// an event from a device that was not in the registration cache:
+		// label it explicitly rather than dropping the count
+		uuid = "unknown"
+	}
+
+	b.xids.bump(uuid, data.EventData, b.now())
+
+	b.logger.Warn("observed a GPU XID error", "uuid", uuid, "xid", data.EventData)
+}
+
+// sleepContext sleeps for the given duration, reporting false when the
+// context ended first.
+func sleepContext(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/internal/nvmlnative/xid_nvml_internal_test.go
+++ b/internal/nvmlnative/xid_nvml_internal_test.go
@@ -1,0 +1,361 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// xidFake drives the watcher: a queue of events served by Wait, plus
+// lifecycle accounting for the event sets.
+type xidFake struct {
+	mu      sync.Mutex
+	pending []nvml.EventData
+	creates atomic.Int64
+	frees   atomic.Int64
+	regs    atomic.Int64
+	waiting atomic.Int64
+	// holdWait simulates how long the driver's bounded wait blocks (as
+	// nanoseconds); wedge, when non-nil, blocks the wait until closed.
+	holdWait atomic.Int64
+	wedge    chan struct{}
+	regRet   nvml.Return
+	waitRet  nvml.Return
+}
+
+func (x *xidFake) push(data nvml.EventData) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+
+	x.pending = append(x.pending, data)
+}
+
+func (x *xidFake) wait(uint32) (nvml.EventData, nvml.Return) {
+	x.waiting.Add(1)
+
+	if x.wedge != nil {
+		<-x.wedge
+	}
+
+	if x.waitRet != nvml.SUCCESS {
+		return nvml.EventData{}, x.waitRet
+	}
+
+	x.mu.Lock()
+
+	if len(x.pending) > 0 {
+		data := x.pending[0]
+		x.pending = x.pending[1:]
+		x.mu.Unlock()
+
+		return data, nvml.SUCCESS
+	}
+
+	x.mu.Unlock()
+
+	// simulate the driver's bounded wait without burning a test's real
+	// second per iteration (tests raise holdWait for realistic contention)
+	hold := time.Duration(x.holdWait.Load())
+	if hold == 0 {
+		hold = time.Millisecond
+	}
+
+	time.Sleep(hold)
+
+	return nvml.EventData{}, nvml.ERROR_TIMEOUT
+}
+
+// install wires the fake into the seam and the device.
+func (x *xidFake) install(api *nvmlAPI, dev *mock.Device) {
+	api.eventSetCreate = func() (nvml.EventSet, nvml.Return) {
+		x.creates.Add(1)
+
+		return &mock.EventSet{
+			WaitFunc: x.wait,
+			FreeFunc: func() nvml.Return {
+				x.frees.Add(1)
+
+				return nvml.SUCCESS
+			},
+		}, nvml.SUCCESS
+	}
+
+	dev.RegisterEventsFunc = func(uint64, nvml.EventSet) nvml.Return {
+		if x.regRet != nvml.SUCCESS {
+			return x.regRet
+		}
+
+		x.regs.Add(1)
+
+		return nvml.SUCCESS
+	}
+}
+
+// startWatcher runs the watcher until the test ends, reporting a wait group
+// so teardown can assert the goroutine exited.
+func startWatcher(t *testing.T, backend *Backend) (context.CancelFunc, *sync.WaitGroup) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		assert.NoError(t, backend.RunXIDWatcher(ctx))
+	})
+
+	return cancel, &wg
+}
+
+func TestXIDWatcherCountsEvents(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	xid := &xidFake{}
+
+	api := fake.api()
+	xid.install(&api, dev)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	xid.push(nvml.EventData{Device: dev, EventType: nvml.EventTypeXidCriticalError, EventData: 79})
+	xid.push(nvml.EventData{Device: dev, EventType: nvml.EventTypeXidCriticalError, EventData: 79})
+	xid.push(nvml.EventData{Device: dev, EventType: nvml.EventTypeXidCriticalError, EventData: 31})
+
+	cancel, wg := startWatcher(t, backend)
+
+	require.Eventually(t, func() bool {
+		return len(backend.XIDCounts()) == 2
+	}, 5*time.Second, 5*time.Millisecond, "both xid series must appear")
+
+	counts := backend.XIDCounts()
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", counts[0].UUID,
+		"the uuid must come from the registration-time cache, normalized")
+	assert.Equal(t, uint64(31), counts[0].XID, "output must be sorted")
+	assert.Equal(t, uint64(1), counts[0].Count)
+	assert.Equal(t, uint64(79), counts[1].XID)
+	assert.Equal(t, uint64(2), counts[1].Count)
+	assert.False(t, counts[0].LastSeen.IsZero())
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, xid.creates.Load(), xid.frees.Load(), "every event set must be freed")
+}
+
+func TestXIDWatcherUnsupportedIdles(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	xid := &xidFake{regRet: nvml.ERROR_NOT_SUPPORTED}
+
+	api := fake.api()
+	xid.install(&api, dev)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	cancel, wg := startWatcher(t, backend)
+
+	require.Eventually(t, func() bool {
+		return xid.creates.Load() >= 1
+	}, 5*time.Second, 5*time.Millisecond)
+
+	assert.Empty(t, backend.XIDCounts())
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, xid.creates.Load(), xid.frees.Load(),
+		"a set with no registrations must still be freed")
+}
+
+func TestXIDWatcherRebuildsAcrossGenerationsAndKeepsCounts(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	xid := &xidFake{}
+
+	api := fake.api()
+	xid.install(&api, dev)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	xid.push(nvml.EventData{Device: dev, EventType: nvml.EventTypeXidCriticalError, EventData: 79})
+
+	cancel, wg := startWatcher(t, backend)
+
+	require.Eventually(t, func() bool {
+		return len(backend.XIDCounts()) == 1
+	}, 5*time.Second, 5*time.Millisecond)
+
+	// a driver loss: the watcher must notice the dead generation, drive the
+	// re-initialization itself (no scrape runs here), re-register, and keep
+	// the counts
+	regsBefore := xid.regs.Load()
+
+	backend.mu.Lock()
+	backend.markLost()
+	backend.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		return xid.regs.Load() > regsBefore
+	}, 10*time.Second, 5*time.Millisecond, "the watcher must recover and re-register without a scrape")
+
+	assert.Equal(t, int64(2), fake.inits.Load(), "the watcher must have re-initialized NVML itself")
+
+	xid.push(nvml.EventData{Device: dev, EventType: nvml.EventTypeXidCriticalError, EventData: 79})
+
+	require.Eventually(t, func() bool {
+		counts := backend.XIDCounts()
+
+		return len(counts) == 1 && counts[0].Count == 2
+	}, 5*time.Second, 5*time.Millisecond, "counts must survive the generation change")
+
+	cancel()
+	wg.Wait()
+
+	// the first generation's set died with the shutdown that killed it (the
+	// watcher must NOT free it afterwards); only the second one is freed
+	assert.Equal(t, xid.creates.Load()-1, xid.frees.Load(),
+		"exactly the dead generation's set must stay unfreed")
+}
+
+func TestXIDWatcherWaitFailureRebuildsWithBackoff(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	xid := &xidFake{waitRet: nvml.ERROR_UNKNOWN}
+
+	api := fake.api()
+	xid.install(&api, dev)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	cancel, wg := startWatcher(t, backend)
+
+	// the failing set is freed and rebuilt (with backoff, so give it time
+	// for at least one full rebuild round)
+	require.Eventually(t, func() bool {
+		return xid.creates.Load() >= 2 && xid.frees.Load() >= 1
+	}, 10*time.Second, 5*time.Millisecond)
+
+	// and the rebuilds are paced: a persistent wait failure must never spin
+	// the register/wait/free loop at full speed
+	time.Sleep(2 * time.Second)
+	assert.Less(t, xid.creates.Load(), int64(8),
+		"wait failures must back off between rebuilds, not hot-loop")
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, xid.creates.Load(), xid.frees.Load(),
+		"the generation stayed alive, so every set must be freed")
+}
+
+func TestMarkLostShutsDownWhileWatcherIsHealthy(t *testing.T) {
+	t.Parallel()
+
+	// the empirically pinned barrier property: a healthy watcher holds the
+	// shared lock for the full duration of each bounded wait, and shutdown
+	// must still acquire the exclusive lock within roughly one wait bound
+	// (a polling acquisition provably cannot; see tryLifecycleLock)
+	dev := identityDevice()
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	xid := &xidFake{}
+
+	api := fake.api()
+	xid.install(&api, dev)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	// make each wait hold the shared lock for a realistic while
+	xid.holdWait.Store(int64(200 * time.Millisecond))
+
+	cancel, wg := startWatcher(t, backend)
+
+	require.Eventually(t, func() bool {
+		return xid.regs.Load() >= 1
+	}, 5*time.Second, 5*time.Millisecond)
+
+	start := time.Now()
+
+	backend.mu.Lock()
+	backend.markLost()
+	backend.mu.Unlock()
+
+	elapsed := time.Since(start)
+
+	assert.Equal(t, int64(1), fake.shutdowns.Load(),
+		"a healthy watcher must not make shutdown miss its window")
+	assert.Less(t, elapsed, lifecycleLockDeadline,
+		"the exclusive acquisition must land within the wait bound, not hit the deadline")
+
+	cancel()
+	wg.Wait()
+}
+
+func TestMarkLostSkipsShutdownBehindWedgedWait(t *testing.T) {
+	t.Parallel()
+
+	dev := identityDevice()
+	fake := &fakeAPI{devices: []nvml.Device{dev}}
+	xid := &xidFake{}
+
+	api := fake.api()
+	xid.install(&api, dev)
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	// wedge the driver call: Wait blocks until released, far beyond the
+	// shutdown deadline
+	xid.wedge = make(chan struct{})
+
+	cancel, wg := startWatcher(t, backend)
+
+	require.Eventually(t, func() bool {
+		return xid.waiting.Load() >= 1
+	}, 5*time.Second, 5*time.Millisecond, "the watcher must be inside the wedged wait")
+
+	start := time.Now()
+
+	backend.mu.Lock()
+	backend.markLost()
+	backend.mu.Unlock()
+
+	assert.Equal(t, int64(0), fake.shutdowns.Load(),
+		"shutdown must be skipped, never executed under a wedged driver call")
+	assert.GreaterOrEqual(t, time.Since(start), lifecycleLockDeadline,
+		"the skip must come from the bounded deadline")
+
+	// releasing the wedge lets the watcher notice the dead generation and
+	// park; the late-acquire cleanup must unlock the barrier so recovery
+	// (which flips markLost again) does not deadlock
+	close(xid.wedge)
+
+	require.Eventually(t, func() bool {
+		return fake.inits.Load() >= 2
+	}, 10*time.Second, 5*time.Millisecond, "the watcher must recover once the wedge clears")
+
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
The nvml backend now watches for XID errors, the driver's numbered error events that nvidia-smi never reports, and exports them as a counter labeled by GPU and XID code, plus a timestamp of the most recent event. The watcher runs beside the collection cycles for the whole application lifetime and re-registers itself after a driver loss, backing off while NVML is down. Setups without event support simply keep the families empty.

The counters live outside the collection pipeline and render even when a collection fails or has never succeeded, because a GPU throwing XID errors is exactly the one whose collections break. They count events observed since the exporter started, and earlier history cannot be replayed.

Driver shutdowns now coordinate with the watcher through a shared barrier: a shutdown waits out the watcher's bounded driver call, and when a call is genuinely wedged the shutdown is skipped rather than hanging the process, mirroring the existing close behavior. The watcher independently notices the dead generation and rebuilds.

The two inactive remapped-rows counts move from the recorded deferrals into the served catalog. They come from a newer driver interface that older drivers answer with a missing-function error, so the classic remapped-rows fields keep working there and only the new series stay absent, matching what nvidia-smi itself reports per driver generation.

Closes #406.

Stacked on #465 and #466.