### PR TITLE
feat: add a demo backend serving synthetic data without a GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,21 @@ probably the better fit; this exporter aims at the cases above.
 - Auto-discovery of the metric fields `nvidia-smi` can expose (future-compatible)
 - Optional per-process GPU metrics: see which process uses how much GPU memory
 - Experimental NVML mode: reads the driver library directly instead of running `nvidia-smi`, and unlocks metrics `nvidia-smi` cannot provide (Linux)
+- Demo mode: realistic synthetic metrics on any machine, no GPU needed - try the exporter or build dashboards anywhere
 - Comes with its own [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
+
+## Try it without a GPU
+
+Demo mode serves realistic synthetic metrics, including the NVML-only
+families, with no GPU, driver or even Linux required:
+
+```bash
+nvidia_gpu_exporter --collect.backend demo
+```
+
+By default it simulates two H200 GPUs with fluctuating values, a MIG topology
+and an XID error history. The simulated setup is configurable; see
+[CONFIGURE.md](docs/CONFIGURE.md).
 
 ## Visualization
 

--- a/cmd/fake-nvidia-smi/main.go
+++ b/cmd/fake-nvidia-smi/main.go
@@ -25,9 +25,12 @@ package main
 import (
 	"os"
 
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/captures"
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/fakesmi"
 )
 
 func main() {
-	os.Exit(fakesmi.Run(os.Args[1:], os.Stdout, os.Stderr))
+	source := fakesmi.CaptureSource{FS: captures.FS, Default: captures.Default}
+
+	os.Exit(fakesmi.Run(source, os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -13,7 +13,7 @@ usage: nvidia_gpu_exporter [<flags>]
 Flags:
   -h, --[no-]help               Show context-sensitive help (also try
                                 --help-long and --help-man).
-      --web.listen-address=:9835 ...
+      --web.listen-address=:9835 ...  
                                 Addresses on which to expose metrics and web
                                 interface. Repeatable for multiple addresses.
                                 Examples: `:9100` or `[::1]:9100` for http,
@@ -25,21 +25,21 @@ Flags:
                                 (for listening on both stacks).
       --web.read-timeout=10s    Maximum duration before timing out read of the
                                 request.
-      --web.read-header-timeout=10s
+      --web.read-header-timeout=10s  
                                 Maximum duration before timing out read of the
                                 request headers.
       --web.write-timeout=15s   Maximum duration before timing out write of the
                                 response.
       --web.idle-timeout=60s    Maximum amount of time to wait for the next
                                 request when keep-alive is enabled.
-      --web.telemetry-path="/metrics"
+      --web.telemetry-path="/metrics"  
                                 Path under which to expose metrics.
       --web.max-requests=40     Maximum number of concurrent scrapes of the
                                 metrics endpoint. Requests beyond the limit
                                 are answered with a 503 immediately instead of
                                 queueing up behind a slow collection. 0 disables
                                 the limit.
-      --web.timeout-offset=500ms
+      --web.timeout-offset=500ms  
                                 Offset subtracted from the scrape
                                 timeout Prometheus advertises in the
                                 X-Prometheus-Scrape-Timeout-Seconds header,
@@ -47,7 +47,7 @@ Flags:
                                 Prometheus. The advertised timeout minus this
                                 offset bounds each scrape's collection, on top
                                 of --collect.timeout.
-      --nvidia-smi-command="nvidia-smi"
+      --nvidia-smi-command="nvidia-smi"  
                                 Path or command to be used for the nvidia-smi
                                 executable. Multiple words run the first as the
                                 executable with the rest as its arguments (e.g.
@@ -57,12 +57,12 @@ Flags:
                                 itself, not consumed by the shell you set the
                                 flag from: --nvidia-smi-command '"C:\Program
                                 Files\...\nvidia-smi.exe"'.
-      --query-field-names="AUTO"
+      --query-field-names="AUTO"  
                                 Comma-separated list of the query fields.
                                 You can find out possible fields by running
                                 `nvidia-smi --help-query-gpu`. The value `AUTO`
                                 will automatically detect the fields to query.
-      --query-field-names-exclude=""
+      --query-field-names-exclude=""  
                                 Comma-separated list of query fields to exclude
                                 from being queried. Names match literally, with
                                 `*` as a wildcard for any sequence of characters
@@ -76,7 +76,9 @@ Flags:
                                 requires Linux and a build with the backend
                                 compiled in. It exposes every metric the exec
                                 backend exposes, plus NVML-only extras (see the
-                                docs).
+                                docs). `demo` serves synthetic data mimicking
+                                the nvml surface, with no GPU or driver needed,
+                                on any platform.
       --collect.interval=0      Interval at which the collection runs in the
                                 background, with scrapes serving the most
                                 recent result. When 0, the collection runs
@@ -85,7 +87,7 @@ Flags:
                                 take, including all the work within it (e.g.
                                 the nvidia-smi runs) and the runs at startup.
                                 0 disables the bound.
-      --[no-]collect.compute-apps
+      --[no-]collect.compute-apps  
                                 Also export per-process GPU metrics
                                 (from `nvidia-smi --query-compute-apps`,
                                 or the equivalent NVML calls in nvml mode).
@@ -93,20 +95,25 @@ Flags:
                                 other workloads' processes requires sharing
                                 the host PID namespace (hostPID in Kubernetes,
                                 --pid=host in Docker).
-      --[no-]collect.compute-apps-mig
+      --demo-config=""          Path to the demo backend's config file (the
+                                fake-nvidia-smi YAML plus an extras block;
+                                see the docs). Only with --collect.backend=demo;
+                                the built-in demo setup is used when unset.
+      --[no-]collect.compute-apps-mig  
                                 Add MIG attribution labels (gpu_instance_id,
-                                compute_instance_id) to the per-process
-                                metrics (requires --collect.compute-apps and
-                                --collect.backend=nvml). Opt-in because it
-                                changes the label set of the per-process series.
-      --[no-]collect.pcie-throughput
+                                compute_instance_id) to the per-process metrics
+                                (requires --collect.compute-apps and the nvml
+                                or demo backend). Opt-in because it changes the
+                                label set of the per-process series.
+      --[no-]collect.pcie-throughput  
                                 Also export the PCIe TX/RX throughput per
-                                GPU (requires --collect.backend=nvml). Each
-                                direction is sampled over a separate 20ms driver
-                                counter window, adding roughly 40ms per GPU
-                                to every collection cycle (~320ms on an 8-GPU
-                                node); pairing it with --collect.interval keeps
-                                scrapes unaffected.
+                                GPU (requires --collect.backend=nvml;
+                                the demo backend serves the family regardless).
+                                Each direction is sampled over a separate 20ms
+                                driver counter window, adding roughly 40ms per
+                                GPU to every collection cycle (~320ms on an
+                                8-GPU node); pairing it with --collect.interval
+                                keeps scrapes unaffected.
       --[no-]shutdown-on-error  Shut down the exporter if there is a fatal
                                 collection error (a failing nvidia-smi run,
                                 or a lost GPU/driver in nvml mode). When false,
@@ -328,22 +335,23 @@ a superset of the default backend's: every metric derived from the
 field-by-field against live hardware), and on top of that shared core the
 nvml backend serves metric families only the driver library can provide.
 
-What each backend can do:
+What each backend can do (`demo` serves synthetic data, see
+[Demo mode](#demo-mode)):
 
-| Capability | exec | nvml |
-| --- | --- | --- |
-| Query-field metrics (identical names, labels, values) | yes | yes |
-| `gpu_info` with the `cuda_version` label | yes | yes |
-| Per-process metrics (`--collect.compute-apps`) | yes | yes |
-| Collection status metric | `command_exit_code` | `nvml_return_code` |
-| Custom command, remote scraping (`--nvidia-smi-command`, ssh, sudo) | yes | no |
-| Strongest isolation against a wedged driver (killable subprocess) | yes | no |
-| Brand-new driver fields before the catalog catches up (`AUTO`) | yes | no |
-| Total energy counter (`energy_joules_total`) | no | yes |
-| PCIe throughput (`--collect.pcie-throughput`) | no | yes |
-| Per-MIG-instance metrics (`mig_info`, `mig_memory_*`, `mig_*_ratio`) | no | yes |
-| Per-process MIG attribution (`--collect.compute-apps-mig`) | no | yes |
-| XID error counters (`xid_errors_total`) | no | yes |
+| Capability | exec | nvml | demo |
+| --- | --- | --- | --- |
+| Query-field metrics (identical names, labels, values) | yes | yes | synthetic |
+| `gpu_info` with the `cuda_version` label | yes | yes | yes |
+| Per-process metrics (`--collect.compute-apps`) | yes | yes | yes |
+| Collection status metric | `command_exit_code` | `nvml_return_code` | `nvml_return_code` |
+| Custom command, remote scraping (`--nvidia-smi-command`, ssh, sudo) | yes | no | no |
+| Strongest isolation against a wedged driver (killable subprocess) | yes | no | n/a |
+| Brand-new driver fields before the catalog catches up (`AUTO`) | yes | no | no |
+| Total energy counter (`energy_joules_total`) | no | yes | yes |
+| PCIe throughput (`--collect.pcie-throughput`) | no | yes | always on |
+| Per-MIG-instance metrics (`mig_info`, `mig_memory_*`, `mig_*_ratio`) | no | yes | yes |
+| Per-process MIG attribution (`--collect.compute-apps-mig`) | no | yes | yes |
+| XID error counters (`xid_errors_total`) | no | yes | yes |
 
 The NVML-only families are documented in [METRICS.md](METRICS.md). The PCIe
 throughput family is opt-in via `--collect.pcie-throughput` because of its
@@ -399,3 +407,82 @@ Current limits, while the backend is experimental:
 
 The `nvidia_smi_*` metric prefix stays as is in both backends: it names the
 data schema, not the collection mechanism.
+
+## Demo mode
+
+`--collect.backend=demo` serves synthetic data mimicking the nvml backend's
+full metric surface, with no GPU, no driver and no Linux required. It exists
+for trying the exporter out and for developing dashboards and alerts against
+realistic data. The exporter logs a warning at startup so a demo instance
+cannot be mistaken for a real one.
+
+```bash
+nvidia_gpu_exporter --collect.backend demo
+```
+
+The GPU metrics replay a real captured `nvidia-smi`, with values fluctuating
+between scrapes, and the NVML-only families are synthesized coherently on
+top: the energy counter integrates the power draw the table itself reports,
+MIG instances form a consistent topology where a busy instance runs hot and
+the rest idle, PCIe throughput jitters within configurable bounds, and XID
+error counters accumulate over time. Per-process metrics work too, including
+the MIG attribution labels (`--collect.compute-apps`,
+`--collect.compute-apps-mig`).
+
+The built-in setup simulates two H200 GPUs, a MIG topology on the first one
+and a pre-seeded XID history. `--demo-config` replaces it with your own
+scenario:
+
+```yaml
+# One of the two embedded captures:
+# linux-x86_64__nvidia-h200__590.48.01.txt
+# linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05.txt
+capture: linux-x86_64__nvidia-h200__590.48.01.txt
+state: load      # which captured state to serve: idle or load
+gpus: 4          # replicate the captured GPU into this many
+fluctuate: true  # jitter the naturally-moving values between scrapes
+extras:          # the demo-only part; every key is optional
+  seed: 42       # fix the randomness for reproducible values
+  energy-fallback-power-watts: 120  # used when the power field is excluded
+  pcie:
+    tx-bytes-per-second: {min: 0.2e9, max: 3e9}
+    rx-bytes-per-second: {min: 0.5e9, max: 8e9}
+  mig:
+    - gpu: 0     # index into the simulated GPU list
+      instances:
+        - {gi: 2, profile: 3g.71gb, cis: 2, busy: true}
+        - {gi: 7, profile: 1g.18gb}
+  xids:
+    initial: [{gpu: 1, xid: 79, count: 2}]  # pre-seeded error history
+    interval: 10m       # mean spacing of ongoing random events; omit to disable
+    codes: [13, 31, 79] # the pool ongoing events draw from
+```
+
+Everything above `extras` is the same configuration file the repository's
+fake `nvidia-smi` uses for development, so the full key reference lives with
+it in the repository. The fake's failure-injection keys (`exit`, `delay`,
+`stderr-msg`, `fail-arg`) are ignored in demo mode: they exist to test the
+subprocess handling the in-process demo path does not have. The file is
+re-read on every collection cycle: edits apply live without a restart, and a
+broken edit fails the collection (visible as
+`nvidia_smi_last_collect_success 0`) until fixed. An edit also resets the
+synthesized state (the energy and XID counters, the random sequence), like a
+driver reload would. One exception: the `cuda_version` label is read once at
+startup, so switching captures live keeps the old label until a restart.
+
+Details worth knowing when developing dashboards against demo data:
+
+- The mode is faithful to the real backend's quirks: GPUs carrying a MIG
+  topology report MIG mode enabled, `mig_*_ratio` utilization series are
+  absent on the first collection that sees a GPU instance (the real sampling
+  needs a pair of collections), and the energy counter starts at zero.
+- The PCIe throughput family is always on in demo mode but opt-in
+  (`--collect.pcie-throughput`) on the real nvml backend: a dashboard
+  validated against demo data shows empty PCIe panels on a default nvml
+  deployment unless the flag is set there.
+- The collection status metric is `nvml_return_code` for name parity with
+  the nvml backend; no driver library is involved.
+- For fully reproducible values, set `extras.seed` and leave `fluctuate`
+  off. The top-level `seed` key freezes the fake's jitter to one draw per
+  process instead (it mirrors the CLI fake's per-invocation behavior), so it
+  is not useful here.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -9,7 +9,9 @@ The experimental NVML backend exports a superset of these metrics: every
 metric below is identical in both backends, except that the NVML backend
 reports `nvidia_smi_nvml_return_code` in place of
 `nvidia_smi_command_exit_code`. On top of that shared core it serves the
-NVML-only families described in the next section.
+NVML-only families described in the next section. The demo backend serves
+the same surface as the NVML backend, with synthetic data (see the demo
+mode section in [CONFIGURE.md](CONFIGURE.md)).
 
 ## NVML-only metrics
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,7 +31,10 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/demo"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/demodata"
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/exporter"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/fakesmi"
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvmlnative"
 )
@@ -135,8 +138,9 @@ func Run(ctx context.Context, args []string, opts Options) error {
 				"experimental and reads the driver library (libnvidia-ml) directly, without "+
 				"nvidia-smi. The nvml backend requires Linux and a build with the backend "+
 				"compiled in. It exposes every metric the exec backend exposes, plus "+
-				"NVML-only extras (see the docs).").
-			Default(DefaultBackend).Enum("exec", "nvml")
+				"NVML-only extras (see the docs). `demo` serves synthetic data mimicking "+
+				"the nvml surface, with no GPU or driver needed, on any platform.").
+			Default(DefaultBackend).Enum("exec", "nvml", "demo")
 		collectInterval = app.Flag("collect.interval",
 			"Interval at which the collection runs in the background, with scrapes serving "+
 				"the most recent result. When 0, the collection runs synchronously on each "+
@@ -153,14 +157,20 @@ func Run(ctx context.Context, args []string, opts Options) error {
 				"container, seeing other workloads' processes requires sharing the host PID "+
 				"namespace (hostPID in Kubernetes, --pid=host in Docker).").
 			Default("false").Bool()
+		demoConfig = app.Flag("demo-config",
+			"Path to the demo backend's config file (the fake-nvidia-smi YAML plus an "+
+				"extras block; see the docs). Only with --collect.backend=demo; the "+
+				"built-in demo setup is used when unset.").
+			Default("").String()
 		collectComputeAppsMIG = app.Flag("collect.compute-apps-mig",
 			"Add MIG attribution labels (gpu_instance_id, compute_instance_id) to the "+
-				"per-process metrics (requires --collect.compute-apps and "+
-				"--collect.backend=nvml). Opt-in because it changes the label set of the "+
+				"per-process metrics (requires --collect.compute-apps and the nvml or demo "+
+				"backend). Opt-in because it changes the label set of the "+
 				"per-process series.").
 			Default("false").Bool()
 		collectPcieThroughput = app.Flag("collect.pcie-throughput",
-			"Also export the PCIe TX/RX throughput per GPU (requires --collect.backend=nvml). "+
+			"Also export the PCIe TX/RX throughput per GPU (requires --collect.backend=nvml; "+
+				"the demo backend serves the family regardless). "+
 				"Each direction is sampled over a separate 20ms driver counter window, adding "+
 				"roughly 40ms per GPU to every collection cycle (~320ms on an 8-GPU node); "+
 				"pairing it with --collect.interval keeps scrapes unaffected.").
@@ -206,6 +216,7 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		pcieThroughput:   *collectPcieThroughput,
 		computeApps:      *collectComputeApps,
 		computeAppsMIG:   *collectComputeAppsMIG,
+		demoConfig:       *demoConfig,
 	}
 
 	if err := validateBackendFlags(backendFlags); err != nil {
@@ -232,6 +243,7 @@ func Run(ctx context.Context, args []string, opts Options) error {
 		computeApps:      *collectComputeApps,
 		computeAppsMIG:   *collectComputeAppsMIG,
 		pcieThroughput:   *collectPcieThroughput,
+		demoConfig:       *demoConfig,
 		onFatal:          onFatal,
 	}
 
@@ -326,29 +338,38 @@ type backendFlagSet struct {
 	pcieThroughput   bool
 	computeApps      bool
 	computeAppsMIG   bool
+	demoConfig       string
 }
 
 // validateBackendFlags rejects flag combinations the chosen backend cannot
 // honor, as errors rather than silent ignores.
+//
+//nolint:cyclop // a flat rule list, one branch per combination
 func validateBackendFlags(flags backendFlagSet) error {
-	if flags.backend == backendNVML && flags.nvidiaSmiCommand != nvidiasmi.DefaultCommand {
-		// a custom command signals intent (ssh wrappers, sudo) the nvml
-		// backend cannot honor
-		return errors.New("--nvidia-smi-command cannot be combined with --collect.backend=nvml")
+	if flags.backend != backendExec && flags.nvidiaSmiCommand != nvidiasmi.DefaultCommand {
+		// a custom command signals intent (ssh wrappers, sudo) only the
+		// exec backend can honor
+		return fmt.Errorf("--nvidia-smi-command cannot be combined with --collect.backend=%s", flags.backend)
 	}
 
-	if flags.backend != backendNVML && flags.pcieThroughput {
-		// the throughput counters only exist in the driver library
+	if flags.backend == backendExec && flags.pcieThroughput {
+		// the throughput counters only exist in the driver library (the
+		// demo backend serves the family regardless and accepts the flag
+		// as a no-op)
 		return errors.New("--collect.pcie-throughput requires --collect.backend=nvml")
 	}
 
-	if flags.computeAppsMIG && flags.backend != backendNVML {
+	if flags.computeAppsMIG && flags.backend == backendExec {
 		// the per-process query output has no MIG attribution to parse
-		return errors.New("--collect.compute-apps-mig requires --collect.backend=nvml")
+		return errors.New("--collect.compute-apps-mig requires --collect.backend=nvml or demo")
 	}
 
 	if flags.computeAppsMIG && !flags.computeApps {
 		return errors.New("--collect.compute-apps-mig requires --collect.compute-apps")
+	}
+
+	if flags.demoConfig != "" && flags.backend != backendDemo {
+		return errors.New("--demo-config requires --collect.backend=demo")
 	}
 
 	return nil
@@ -433,10 +454,16 @@ func validateMetricsPathShape(metricsPath string) error {
 	}
 }
 
+// demoCommand is the placeholder executable name the demo backend's
+// in-process runner receives; it is never looked up on PATH (the runner
+// answers the prepared command without starting it).
+const demoCommand = "demo-nvidia-smi"
+
 // Collection backend names, the values of --collect.backend.
 const (
 	backendExec = "exec"
 	backendNVML = "nvml"
+	backendDemo = "demo"
 )
 
 // DefaultBackend is the default value of --collect.backend. The regular
@@ -457,6 +484,7 @@ type collectConfig struct {
 	computeApps      bool
 	computeAppsMIG   bool
 	pcieThroughput   bool
+	demoConfig       string
 	onFatal          func(error)
 }
 
@@ -491,14 +519,17 @@ func setupExporter(
 		src = collect.NewLive(query, cfg.timeout, cfg.onFatal, logger)
 	}
 
+	extrasCapable := cfg.backend == backendNVML || cfg.backend == backendDemo
+
 	features := exporter.Features{
 		ComputeApps:         cfg.computeApps,
 		ComputeAppMIGLabels: cfg.computeAppsMIG,
-		// the extras families exist only in the nvml backend
-		PCIeThroughput: cfg.pcieThroughput,
-		Energy:         cfg.backend == backendNVML,
-		MIG:            cfg.backend == backendNVML,
-		XIDEvents:      cfg.backend == backendNVML,
+		// the extras families exist in the nvml backend and its demo twin;
+		// the demo serves the PCIe family unconditionally
+		PCIeThroughput: cfg.pcieThroughput || cfg.backend == backendDemo,
+		Energy:         extrasCapable,
+		MIG:            extrasCapable,
+		XIDEvents:      extrasCapable,
 	}
 
 	exp := exporter.New(ctx, exporter.DefaultPrefix, resolved, src, features, xids, exitCodeMetric, logger)
@@ -532,42 +563,11 @@ func setupBackend(
 	logger *slog.Logger,
 ) (nvidiasmi.ResolvedFields, collect.QueryFunc, exporter.XIDSource, exporter.ExitCodeMetric, error) {
 	if cfg.backend == backendNVML {
-		backend, err := nvmlnative.New(logger)
-		if err != nil {
-			return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
-				fmt.Errorf("failed to set up the nvml backend: %w", err)
-		}
+		return setupNVMLBackend(ctx, eg, cfg, logger)
+	}
 
-		resolved, err := nvmlnative.Resolve(
-			cfg.qFieldsRaw, cfg.qFieldsExclude, backend.DriverVersion(), logger)
-		if err != nil {
-			backend.Close()
-
-			return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
-				fmt.Errorf("failed to resolve query fields: %w", err)
-		}
-
-		// tie NVML shutdown to the application lifetime, best-effort: a
-		// collection stuck inside the driver makes Close skip the shutdown
-		// call rather than delay process exit
-		eg.Go(func() error {
-			<-ctx.Done()
-
-			backend.Close()
-
-			return nil
-		})
-
-		superviseXIDWatcher(ctx, eg, backend, logger)
-
-		opts := nvmlnative.CollectOptions{
-			ComputeApps:    cfg.computeApps,
-			PCIeThroughput: cfg.pcieThroughput,
-			Energy:         true,
-			MIG:            true,
-		}
-
-		return resolved, backend.QueryFunc(resolved, opts), backend, exporter.NVMLReturnCodeMetric, nil
+	if cfg.backend == backendDemo {
+		return setupDemoBackend(ctx, cfg, logger)
 	}
 
 	resolved, err := nvidiasmi.ResolveFields(
@@ -590,7 +590,98 @@ func setupBackend(
 	cudaVersion := nvidiasmi.QueryCudaVersion(
 		ctx, cfg.nvidiaSmiCommand, cfg.timeout, nvidiasmi.DefaultRunFunc, logger)
 
-	return resolved, buildQueryFunc(cfg, resolved, cudaVersion, logger), nil, exporter.ExecExitCodeMetric, nil
+	query := buildQueryFunc(cfg, resolved, cudaVersion, nvidiasmi.DefaultRunFunc, logger)
+
+	return resolved, query, nil, exporter.ExecExitCodeMetric, nil
+}
+
+// setupNVMLBackend wires the nvml flavor: field resolution against the
+// compiled catalog, driver shutdown tied to the application lifetime, and the
+// XID watcher running beside the collection cycles.
+//
+//nolint:ireturn // the backend implements the XID source interface
+func setupNVMLBackend(
+	ctx context.Context,
+	eg *errgroup.Group,
+	cfg collectConfig,
+	logger *slog.Logger,
+) (nvidiasmi.ResolvedFields, collect.QueryFunc, exporter.XIDSource, exporter.ExitCodeMetric, error) {
+	backend, err := nvmlnative.New(logger)
+	if err != nil {
+		return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
+			fmt.Errorf("failed to set up the nvml backend: %w", err)
+	}
+
+	resolved, err := nvmlnative.Resolve(
+		cfg.qFieldsRaw, cfg.qFieldsExclude, backend.DriverVersion(), logger)
+	if err != nil {
+		backend.Close()
+
+		return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
+			fmt.Errorf("failed to resolve query fields: %w", err)
+	}
+
+	// tie NVML shutdown to the application lifetime, best-effort: a
+	// collection stuck inside the driver makes Close skip the shutdown
+	// call rather than delay process exit
+	eg.Go(func() error {
+		<-ctx.Done()
+
+		backend.Close()
+
+		return nil
+	})
+
+	superviseXIDWatcher(ctx, eg, backend, logger)
+
+	opts := nvmlnative.CollectOptions{
+		ComputeApps:    cfg.computeApps,
+		PCIeThroughput: cfg.pcieThroughput,
+		Energy:         true,
+		MIG:            true,
+	}
+
+	return resolved, backend.QueryFunc(resolved, opts), backend, exporter.NVMLReturnCodeMetric, nil
+}
+
+// setupDemoBackend wires the demo flavor: the exec pipeline running against
+// the in-process fake, wrapped so every cycle works from one immutable
+// configuration snapshot and carries the synthesized extras families. The
+// served surface mimics the nvml flavor.
+//
+//nolint:ireturn // the exec backend has no XID source, a nil interface is the point
+func setupDemoBackend(
+	ctx context.Context,
+	cfg collectConfig,
+	logger *slog.Logger,
+) (nvidiasmi.ResolvedFields, collect.QueryFunc, exporter.XIDSource, exporter.ExitCodeMetric, error) {
+	logger.Warn("demo mode: serving synthetic data, not a real GPU")
+
+	source := fakesmi.CaptureSource{FS: demodata.FS, Default: demodata.Default}
+
+	backend, err := demo.New(source, cfg.demoConfig, logger)
+	if err != nil {
+		return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
+			fmt.Errorf("failed to set up the demo backend: %w", err)
+	}
+
+	runFunc := backend.RunFunc()
+
+	resolved, err := nvidiasmi.ResolveFields(
+		ctx, demoCommand, cfg.qFieldsRaw, cfg.qFieldsExclude, cfg.timeout, runFunc, logger)
+	if err != nil {
+		return nvidiasmi.ResolvedFields{}, nil, nil, exporter.ExitCodeMetric{},
+			fmt.Errorf("failed to resolve query fields: %w", err)
+	}
+
+	cudaVersion := nvidiasmi.QueryCudaVersion(ctx, demoCommand, cfg.timeout, runFunc, logger)
+
+	demoCfg := cfg
+	demoCfg.nvidiaSmiCommand = demoCommand
+
+	query := backend.WrapQueryFunc(buildQueryFunc(demoCfg, resolved, cudaVersion, runFunc, logger))
+
+	return resolved, query, backend, exporter.NVMLReturnCodeMetric, nil
 }
 
 // superviseXIDWatcher runs the XID watcher beside the collection cycles for
@@ -637,11 +728,12 @@ func buildQueryFunc(
 	cfg collectConfig,
 	resolved nvidiasmi.ResolvedFields,
 	cudaVersion string,
+	runFunc nvidiasmi.RunFunc,
 	logger *slog.Logger,
 ) collect.QueryFunc {
 	return func(queryCtx context.Context) (collect.Reading, int, error) {
 		table, exitCode, err := nvidiasmi.Query(
-			queryCtx, cfg.nvidiaSmiCommand, resolved.Query, nvidiasmi.DefaultRunFunc)
+			queryCtx, cfg.nvidiaSmiCommand, resolved.Query, runFunc)
 		if err != nil {
 			return collect.Reading{}, exitCode, fmt.Errorf("failed to query gpus: %w", err)
 		}
@@ -653,7 +745,7 @@ func buildQueryFunc(
 			reading.AppsAttempted = true
 
 			apps, appsErr := nvidiasmi.QueryComputeApps(
-				queryCtx, cfg.nvidiaSmiCommand, nvidiasmi.DefaultRunFunc, logger)
+				queryCtx, cfg.nvidiaSmiCommand, runFunc, logger)
 			if appsErr != nil {
 				reading.AppsErr = appsErr
 			} else {

--- a/internal/collect/extras.go
+++ b/internal/collect/extras.go
@@ -13,14 +13,15 @@ type Extras struct {
 	// example "13.1"), empty when unknown. Both backends fill it; the
 	// exporter renders it as the cuda_version label on gpu_info.
 	CUDAVersion string
-	// PCIe holds per-GPU PCIe throughput samples. Only the nvml backend
-	// fills it, and only under --collect.pcie-throughput.
+	// PCIe holds per-GPU PCIe throughput samples. The nvml backend fills it
+	// under --collect.pcie-throughput; the demo backend always fills it.
 	PCIe []PCIeThroughput
-	// Energy holds per-GPU cumulative energy counters. Only the nvml
-	// backend fills it; devices that cannot report it are absent.
+	// Energy holds per-GPU cumulative energy counters. The nvml and demo
+	// backends fill it; devices that cannot report it are absent.
 	Energy []EnergyCounter
-	// MIG holds per-MIG-instance readings. Only the nvml backend fills it,
-	// and only for GPUs with MIG mode enabled.
+	// MIG holds per-MIG-instance readings. The nvml backend fills it for
+	// GPUs with MIG mode enabled; the demo backend synthesizes its
+	// configured topology.
 	MIG []MIGInstance
 }
 

--- a/internal/demo/config.go
+++ b/internal/demo/config.go
@@ -1,0 +1,309 @@
+// Package demo implements the demo backend: the exec pipeline running
+// against the in-process fake nvidia-smi, plus synthesizers for the metric
+// families only the nvml backend can serve on real hardware (energy, PCIe
+// throughput, per-MIG-instance readings, XID error counters). It is pure Go:
+// no driver, no cgo, any platform.
+package demo
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// extrasConfig is the demo-specific `extras:` block of the shared fake-smi
+// config file. Every part is optional; built-in defaults keep all families
+// alive.
+type extrasConfig struct {
+	// Seed drives every synthesized draw; nil derives one from the clock.
+	Seed *int64 `yaml:"seed"`
+	// PCIe sets the throughput jitter ranges, in bytes per second.
+	PCIe *pcieConfig `yaml:"pcie"`
+	// XIDs configures the error-event emitter.
+	XIDs *xidConfig `yaml:"xids"`
+	// MIG lists per-GPU MIG topologies, keyed by the simulated GPU's list
+	// index (the same keying as the fake's per-GPU overrides).
+	MIG []migGPUConfig `yaml:"mig"`
+	// EnergyFallbackPowerWatts integrates the energy counter when the GPU
+	// query does not include the power field (an explicit field selection
+	// may exclude it; the counter must not depend on the public schema).
+	EnergyFallbackPowerWatts float64 `yaml:"energy-fallback-power-watts"` //nolint:tagliatelle // kebab-case config keys
+}
+
+// pcieConfig is the PCIe throughput jitter, bytes per second.
+type pcieConfig struct {
+	TXBytesPerSecond rangeCfg `yaml:"tx-bytes-per-second"` //nolint:tagliatelle // kebab-case config keys
+	RXBytesPerSecond rangeCfg `yaml:"rx-bytes-per-second"` //nolint:tagliatelle // kebab-case config keys
+}
+
+// rangeCfg is an inclusive numeric range.
+type rangeCfg struct {
+	Min float64 `yaml:"min"`
+	Max float64 `yaml:"max"`
+}
+
+// xidConfig drives the XID emitter: a static set applied at startup (so the
+// families are populated immediately; real series only appear after a first
+// event) and an optional cadence for motion.
+type xidConfig struct {
+	Initial []xidEventConfig `yaml:"initial"`
+	// Interval is the mean spacing of ongoing random events; empty or zero
+	// disables them (deterministic, golden-test friendly).
+	Interval string `yaml:"interval"`
+	// Codes is the pool ongoing events draw from.
+	Codes []uint64 `yaml:"codes"`
+}
+
+// xidEventConfig is one pre-seeded event batch.
+type xidEventConfig struct {
+	GPU   int    `yaml:"gpu"`
+	XID   uint64 `yaml:"xid"`
+	Count uint64 `yaml:"count"`
+}
+
+// migGPUConfig is one simulated GPU's MIG topology.
+type migGPUConfig struct {
+	GPU       int                 `yaml:"gpu"`
+	Instances []migInstanceConfig `yaml:"instances"`
+}
+
+// migInstanceConfig is one GPU instance.
+type migInstanceConfig struct {
+	GI      int    `yaml:"gi"`
+	Profile string `yaml:"profile"`
+	// CIs is the number of compute instances sharing the GPU instance;
+	// defaults to one.
+	CIs int `yaml:"cis"`
+	// MemoryTotalBytes overrides the framebuffer size; the default is
+	// parsed from the profile name's size token.
+	MemoryTotalBytes uint64 `yaml:"memory-total-bytes"` //nolint:tagliatelle // kebab-case config keys
+	// Busy marks the instance that reports high activity; the others idle.
+	Busy bool `yaml:"busy"`
+}
+
+// defaultXIDCodes is the pool ongoing events draw from: the codes commonly
+// seen in the wild (application faults, ECC, thermal, bus errors).
+//
+//nolint:gochecknoglobals // static default table
+var defaultXIDCodes = []uint64{13, 31, 43, 48, 63, 79, 119}
+
+// defaultEnergyFallbackPowerWatts integrates energy when no power reading is
+// available anywhere.
+const defaultEnergyFallbackPowerWatts = 120
+
+// profileSizeRe extracts the size token of a MIG profile name ("3g.71gb").
+var profileSizeRe = regexp.MustCompile(`\.(\d+)gb$`)
+
+// parseExtras decodes and validates the extras block; a nil node yields the
+// defaults.
+func parseExtras(node *yaml.Node) (*extrasConfig, error) {
+	cfg := &extrasConfig{}
+
+	if node != nil {
+		var buf bytes.Buffer
+		if err := yaml.NewEncoder(&buf).Encode(node); err != nil {
+			return nil, fmt.Errorf("failed to re-encode the extras block: %w", err)
+		}
+
+		dec := yaml.NewDecoder(&buf)
+		dec.KnownFields(true)
+
+		if err := dec.Decode(cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse the extras block: %w", err)
+		}
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	cfg.applyDefaults()
+
+	return cfg, nil
+}
+
+// validate rejects inconsistent extras before they can produce misleading
+// series.
+//
+//nolint:cyclop // one linear rule list
+func (c *extrasConfig) validate() error {
+	if c.PCIe != nil {
+		for name, rng := range map[string]rangeCfg{
+			"tx-bytes-per-second": c.PCIe.TXBytesPerSecond,
+			"rx-bytes-per-second": c.PCIe.RXBytesPerSecond,
+		} {
+			if !isFinite(rng.Min) || !isFinite(rng.Max) || rng.Min < 0 || rng.Max < rng.Min {
+				return fmt.Errorf("pcie %s must be finite and satisfy 0 <= min <= max", name)
+			}
+		}
+	}
+
+	if !isFinite(c.EnergyFallbackPowerWatts) || c.EnergyFallbackPowerWatts < 0 {
+		return errors.New("energy-fallback-power-watts must be a finite non-negative number")
+	}
+
+	if err := c.validateXIDs(); err != nil {
+		return err
+	}
+
+	seenGPU := map[int]bool{}
+
+	for _, gpu := range c.MIG {
+		if seenGPU[gpu.GPU] {
+			return fmt.Errorf("duplicate mig entry for gpu %d", gpu.GPU)
+		}
+
+		seenGPU[gpu.GPU] = true
+
+		if err := validateInstances(gpu); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateXIDs checks the XID emitter settings.
+func (c *extrasConfig) validateXIDs() error {
+	if c.XIDs == nil {
+		return nil
+	}
+
+	if c.XIDs.Interval != "" {
+		interval, err := time.ParseDuration(c.XIDs.Interval)
+		if err != nil {
+			return fmt.Errorf("invalid xids interval: %w", err)
+		}
+
+		if interval <= 0 {
+			return errors.New("xids interval must be positive, omit it to disable ongoing events")
+		}
+	}
+
+	for _, event := range c.XIDs.Initial {
+		if event.GPU < 0 {
+			return fmt.Errorf("initial xid event has a negative gpu index %d", event.GPU)
+		}
+	}
+
+	return nil
+}
+
+// isFinite reports whether the value is a usable number.
+func isFinite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
+// validateInstances checks one GPU's topology.
+func validateInstances(gpu migGPUConfig) error {
+	if gpu.GPU < 0 {
+		return fmt.Errorf("mig entry has a negative gpu index %d", gpu.GPU)
+	}
+
+	if len(gpu.Instances) == 0 {
+		return fmt.Errorf("mig entry for gpu %d has no instances", gpu.GPU)
+	}
+
+	seenGI := map[int]bool{}
+
+	for _, instance := range gpu.Instances {
+		if instance.GI < 0 {
+			return fmt.Errorf("negative gi %d on gpu %d", instance.GI, gpu.GPU)
+		}
+
+		if seenGI[instance.GI] {
+			return fmt.Errorf("duplicate gi %d on gpu %d", instance.GI, gpu.GPU)
+		}
+
+		seenGI[instance.GI] = true
+
+		if instance.Profile == "" {
+			return fmt.Errorf("gi %d on gpu %d needs a profile", instance.GI, gpu.GPU)
+		}
+
+		if instance.CIs < 0 {
+			return fmt.Errorf("gi %d on gpu %d has a negative cis count", instance.GI, gpu.GPU)
+		}
+
+		if instance.MemoryTotalBytes == 0 && !profileSizeRe.MatchString(instance.Profile) {
+			return fmt.Errorf("gi %d on gpu %d: profile %q carries no size token, set memory-total-bytes",
+				instance.GI, gpu.GPU, instance.Profile)
+		}
+	}
+
+	return nil
+}
+
+// applyDefaults fills the optional parts.
+func (c *extrasConfig) applyDefaults() {
+	if c.PCIe == nil {
+		c.PCIe = &pcieConfig{
+			TXBytesPerSecond: rangeCfg{Min: 0.2e9, Max: 3e9},
+			RXBytesPerSecond: rangeCfg{Min: 0.5e9, Max: 8e9},
+		}
+	}
+
+	if c.XIDs == nil {
+		c.XIDs = &xidConfig{}
+	}
+
+	if len(c.XIDs.Codes) == 0 {
+		c.XIDs.Codes = defaultXIDCodes
+	}
+
+	if c.EnergyFallbackPowerWatts <= 0 {
+		c.EnergyFallbackPowerWatts = defaultEnergyFallbackPowerWatts
+	}
+
+	for gpuIdx := range c.MIG {
+		for i := range c.MIG[gpuIdx].Instances {
+			instance := &c.MIG[gpuIdx].Instances[i]
+			if instance.CIs == 0 {
+				instance.CIs = 1
+			}
+
+			if instance.MemoryTotalBytes == 0 {
+				instance.MemoryTotalBytes = profileMemoryBytes(instance.Profile)
+			}
+		}
+	}
+}
+
+// xidInterval reports the parsed cadence, zero when disabled.
+func (c *extrasConfig) xidInterval() time.Duration {
+	if c.XIDs == nil || c.XIDs.Interval == "" {
+		return 0
+	}
+
+	interval, err := time.ParseDuration(c.XIDs.Interval)
+	if err != nil {
+		// validated at parse time; unreachable
+		return 0
+	}
+
+	return interval
+}
+
+// profileMemoryBytes derives a framebuffer size from the profile name's size
+// token ("3g.71gb" -> 71 GiB). The marketing number is only an
+// approximation of what real hardware reports, which is why an explicit
+// memory-total-bytes override exists.
+func profileMemoryBytes(profile string) uint64 {
+	match := profileSizeRe.FindStringSubmatch(profile)
+	if match == nil {
+		return 0
+	}
+
+	gigabytes, err := strconv.ParseUint(match[1], 10, 32)
+	if err != nil {
+		return 0
+	}
+
+	return gigabytes << 30
+}

--- a/internal/demo/default-config.yaml
+++ b/internal/demo/default-config.yaml
@@ -1,0 +1,18 @@
+# The demo backend's built-in configuration: a fluctuating two-GPU H200 box
+# with a MIG topology on the first card (mirroring a live-verified layout),
+# pre-seeded XID history and slow ongoing events, so every metric family
+# shows something out of the box. Pass --demo-config to replace it.
+capture: linux-x86_64__nvidia-h200__590.48.01
+state: load
+fluctuate: true
+gpus: 2
+extras:
+  mig:
+    - gpu: 0
+      instances:
+        - {gi: 2, profile: 3g.71gb, cis: 2, busy: true}
+        - {gi: 7, profile: 1g.18gb}
+  xids:
+    initial:
+      - {gpu: 1, xid: 79, count: 2}
+    interval: 10m

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -1,0 +1,399 @@
+package demo
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/fakesmi"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+// defaultConfigYAML is the built-in configuration served when no
+// --demo-config is given: a fluctuating two-GPU H200 box with a MIG topology
+// on the first card (mirroring a live-verified layout), pre-seeded XID
+// history and slow ongoing events, so every metric family shows something
+// out of the box.
+//
+//go:embed default-config.yaml
+var defaultConfigYAML []byte
+
+// snapshot is one collection cycle's immutable configuration: the fake's
+// document and the decoded extras, always swapped together so an atomic
+// config edit can never produce mismatched table and extras within a cycle.
+type snapshot struct {
+	cfg    *fakesmi.Config
+	extras *extrasConfig
+	// hash fingerprints the raw config document. A changed document resets
+	// the synthesized state (rng, counters, seeded events), like a driver
+	// reload would: the retained state's meaning is tied to the scenario
+	// that produced it.
+	hash [sha256.Size]byte
+}
+
+// Backend synthesizes the nvml-superset metric surface without hardware. It
+// wraps the exec pipeline: the table and per-process data come from the
+// in-process fake nvidia-smi, and the extras families are synthesized on
+// top, coherent with the served table.
+type Backend struct {
+	source     fakesmi.CaptureSource
+	configPath string
+	logger     *slog.Logger
+
+	// cycleMu serializes whole collection cycles: one configuration
+	// snapshot rules a cycle from its reload through the queries to the
+	// extras overlay, so an overlapping abandoned collection can never mix
+	// one config's table with another config's extras. Cycles are pure
+	// in-memory work (failure injection is stripped), so holding the lock
+	// across a cycle costs microseconds.
+	cycleMu sync.Mutex
+
+	mu      sync.Mutex
+	current snapshot
+	// now is the clock, injectable so the energy integration is testable.
+	now func() time.Time
+	rng *demoRand
+
+	energy map[string]*energyState
+	xids   map[string]map[uint64]*xidStat
+	// xidsSeeded records that the initial events were applied (they resolve
+	// GPU indexes against the first served table).
+	xidsSeeded bool
+	nextXIDAt  time.Time
+	// seenGIs tracks the GPU instances previous cycles served: like the
+	// real backend's GPM sampling, utilization needs a sample pair, so the
+	// first cycle that sees a GPU instance serves no utilization for it.
+	seenGIs map[string]bool
+}
+
+// energyState is one GPU's energy integration state.
+type energyState struct {
+	joules    float64
+	lastPower float64
+	lastAt    time.Time
+}
+
+// xidStat is one (GPU, XID code) pair's running state.
+type xidStat struct {
+	count uint64
+	last  time.Time
+}
+
+// New loads and validates the initial configuration (the built-in default
+// when path is empty) and builds the backend. Configuration problems are
+// startup errors; a later edit breaking the file fails that collection
+// instead.
+func New(source fakesmi.CaptureSource, path string, logger *slog.Logger) (*Backend, error) {
+	backend := &Backend{
+		source:     source,
+		configPath: path,
+		logger:     logger,
+		now:        time.Now,
+	}
+
+	snap, err := backend.loadSnapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := backend.preflight(snap); err != nil {
+		return nil, err
+	}
+
+	backend.current = snap
+	backend.resetState(snap)
+
+	return backend, nil
+}
+
+// RunFunc adapts the in-process fake to the exec pipeline's runner seam: the
+// prepared command's arguments are answered from the current cycle's
+// snapshot, with no subprocess. Failure-injection exit codes and delay
+// cancellation are exec-flavor features the in-process path deliberately
+// does not reproduce.
+func (b *Backend) RunFunc() nvidiasmi.RunFunc {
+	return func(cmd *exec.Cmd) error {
+		b.mu.Lock()
+		snap := b.current
+		b.mu.Unlock()
+
+		code := fakesmi.RunWith(b.source, snap.cfg, cmd.Args[1:], cmd.Stdout, cmd.Stderr)
+		if code != 0 {
+			return fmt.Errorf("demo invocation failed with code %d", code)
+		}
+
+		return nil
+	}
+}
+
+// WrapQueryFunc turns the exec-built collection into a demo cycle: one
+// configuration snapshot is loaded up front and every part of the cycle (the
+// GPU query, the per-process query, the extras synthesis) works from it.
+// Whole cycles are serialized: an abandoned collection overlapping its
+// replacement (the documented live-collection behavior) must not interleave
+// two configurations within one cycle. Cycles are pure in-memory work
+// (failure injection is stripped), so the serialization costs microseconds.
+func (b *Backend) WrapQueryFunc(inner collect.QueryFunc) collect.QueryFunc {
+	return func(ctx context.Context) (collect.Reading, int, error) {
+		b.cycleMu.Lock()
+		defer b.cycleMu.Unlock()
+
+		if err := b.beginCycle(); err != nil {
+			return collect.Reading{}, -1, err
+		}
+
+		reading, code, err := inner(ctx)
+		if err != nil {
+			return reading, code, err
+		}
+
+		b.overlay(&reading)
+
+		return reading, code, nil
+	}
+}
+
+// XIDCounts serves the accumulated synthetic XID events to the exporter,
+// mirroring the real source's semantics: cumulative, sorted, visible at
+// scrape time independent of collection success.
+func (b *Backend) XIDCounts() []collect.XIDCounter {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var counters []collect.XIDCounter
+
+	for uuid, perGPU := range b.xids {
+		for xid, stat := range perGPU {
+			counters = append(counters, collect.XIDCounter{
+				UUID:     uuid,
+				XID:      xid,
+				Count:    stat.count,
+				LastSeen: stat.last,
+			})
+		}
+	}
+
+	sortXIDCounters(counters)
+
+	return counters
+}
+
+// preflight proves the configuration actually serves a GPU table: the capture
+// must exist, hold the requested state, and the identity/override resolution
+// must go through. Without it, a bad capture name would pass the YAML
+// parsing, start an apparently healthy exporter, and then fail every
+// collection.
+func (b *Backend) preflight(snap snapshot) error {
+	var stderr bytes.Buffer
+
+	args := []string{"--query-gpu=uuid", "--format=csv"}
+	if code := fakesmi.RunWith(b.source, snap.cfg, args, io.Discard, &stderr); code != 0 {
+		return fmt.Errorf("the demo config cannot serve a GPU table: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+// resetState reinitializes everything derived from the configuration
+// scenario. Called at startup and when a live edit changes the document.
+func (b *Backend) resetState(snap snapshot) {
+	b.rng = newDemoRand(snap.extras.Seed)
+	b.energy = map[string]*energyState{}
+	b.xids = map[string]map[uint64]*xidStat{}
+	b.xidsSeeded = false
+	b.nextXIDAt = time.Time{}
+	b.seenGIs = map[string]bool{}
+}
+
+// loadSnapshot reads and validates one immutable configuration, reconciling
+// the fake's document with the extras so the served table cannot contradict
+// the synthesized families.
+func (b *Backend) loadSnapshot() (snapshot, error) {
+	data := defaultConfigYAML
+
+	if b.configPath != "" {
+		var err error
+
+		data, err = os.ReadFile(b.configPath)
+		if err != nil {
+			return snapshot{}, fmt.Errorf("failed to load the demo config: %w", err)
+		}
+	}
+
+	cfg, err := fakesmi.ParseConfig(data)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("failed to load the demo config: %w", err)
+	}
+
+	extras, err := parseExtras(cfg.Extras())
+	if err != nil {
+		return snapshot{}, fmt.Errorf("invalid demo config: %w", err)
+	}
+
+	if err := reconcile(cfg, extras); err != nil {
+		return snapshot{}, fmt.Errorf("invalid demo config: %w", err)
+	}
+
+	return snapshot{cfg: cfg, extras: extras, hash: sha256.Sum256(data)}, nil
+}
+
+// reconcile aligns the fake's table with the extras. GPU indexes the table
+// cannot serve are configuration errors, not silent no-ops. GPUs carrying a
+// MIG topology report MIG mode enabled (unless the config explicitly
+// overrides the field), because a real GPU can never serve MIG instances
+// while reporting the mode off. The failure-injection settings are stripped:
+// they exist to test the exec pipeline's subprocess handling, which the
+// in-process path does not reproduce.
+func reconcile(cfg *fakesmi.Config, extras *extrasConfig) error {
+	cfg.StripFailureInjection()
+
+	for _, gpu := range extras.MIG {
+		for _, field := range []string{"mig.mode.current", "mig.mode.pending"} {
+			if err := cfg.EnsureFieldOverride(gpu.GPU, field, "Enabled"); err != nil {
+				return fmt.Errorf("mig entry: %w", err)
+			}
+		}
+	}
+
+	for _, event := range extras.XIDs.Initial {
+		if event.GPU >= cfg.GPUCount() {
+			return fmt.Errorf("initial xid event: gpu index %d is out of range: the config simulates %d GPU(s)",
+				event.GPU, cfg.GPUCount())
+		}
+	}
+
+	return nil
+}
+
+// beginCycle refreshes the configuration snapshot from disk, preserving the
+// edit-without-restart loop. A changed document also resets the synthesized
+// state, so seed and pre-seeded event edits take effect like everything
+// else. The built-in default never changes.
+func (b *Backend) beginCycle() error {
+	if b.configPath == "" {
+		return nil
+	}
+
+	snap, err := b.loadSnapshot()
+	if err != nil {
+		return err
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if snap.hash != b.current.hash {
+		b.logger.Info("demo config changed, resetting the synthesized state")
+		b.resetState(snap)
+	}
+
+	b.current = snap
+
+	return nil
+}
+
+// overlay synthesizes the extras families onto one cycle's reading, coherent
+// with the served table (the energy counter integrates the table's own power
+// draw). All retained state is mutex-guarded: abandoned live collections can
+// overlap their replacements.
+func (b *Backend) overlay(reading *collect.Reading) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	snap := b.current
+	uuids, power := tableIdentity(reading.Table)
+	b.privatePower(snap, uuids, power)
+
+	now := b.now()
+
+	b.synthEnergy(uuids, power, snap.extras, now, reading)
+	b.synthPCIe(uuids, snap.extras, reading)
+	b.synthMIG(uuids, snap.extras, reading)
+	attributeApps(uuids, snap.extras, reading)
+	b.tickXIDs(uuids, snap.extras, now)
+}
+
+// privatePower fills the power draws the public query left out, from the
+// same configuration snapshot, the way the real backend reads the driver
+// independently of the query plan: excluding the power field from the
+// metrics must not change what the energy counter integrates. Rows whose
+// power is not a number keep no entry and fall back to the configured watts.
+func (b *Backend) privatePower(snap snapshot, uuids []string, power map[string]float64) {
+	missing := false
+
+	for _, uuid := range uuids {
+		if _, exists := power[uuid]; !exists {
+			missing = true
+
+			break
+		}
+	}
+
+	if !missing {
+		return
+	}
+
+	var out bytes.Buffer
+
+	args := []string{"--query-gpu=uuid,power.draw", "--format=csv"}
+	if code := fakesmi.RunWith(b.source, snap.cfg, args, &out, io.Discard); code != 0 {
+		return
+	}
+
+	lines := strings.SplitN(out.String(), "\n", 2)
+	if len(lines) < 2 {
+		return
+	}
+
+	// the first line is the CSV header
+	for line := range strings.Lines(lines[1]) {
+		uuid, raw, found := strings.Cut(strings.TrimSpace(line), ", ")
+		if !found {
+			continue
+		}
+
+		normalized := nvidiasmi.NormalizeUUID(uuid)
+		if _, exists := power[normalized]; exists {
+			continue
+		}
+
+		if watts, err := nvidiasmi.TransformFieldValue("power.draw", raw, 1); err == nil {
+			power[normalized] = watts
+		}
+	}
+}
+
+// tableIdentity extracts the served GPUs' identity in row order: the uuid
+// list (index-aligned with the config's GPU keying) and each GPU's power
+// draw when the field was part of the query.
+func tableIdentity(table *nvidiasmi.Table) ([]string, map[string]float64) {
+	if table == nil {
+		return nil, nil
+	}
+
+	uuids := make([]string, 0, len(table.Rows))
+	power := make(map[string]float64, len(table.Rows))
+
+	for _, row := range table.Rows {
+		uuid := nvidiasmi.NormalizeUUID(row.QFieldToCells[nvidiasmi.UUIDQField].RawValue)
+		uuids = append(uuids, uuid)
+
+		if cell, ok := row.QFieldToCells["power.draw"]; ok {
+			if watts, err := nvidiasmi.TransformFieldValue("power.draw", cell.RawValue, 1); err == nil {
+				power[uuid] = watts
+			}
+		}
+	}
+
+	return uuids, power
+}

--- a/internal/demo/demo_internal_test.go
+++ b/internal/demo/demo_internal_test.go
@@ -1,0 +1,593 @@
+package demo
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/demodata"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/fakesmi"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+func testSource() fakesmi.CaptureSource {
+	return fakesmi.CaptureSource{FS: demodata.FS, Default: demodata.Default}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// extrasFrom parses a full demo config document and decodes its extras block.
+func extrasFrom(t *testing.T, doc string) (*extrasConfig, error) {
+	t.Helper()
+
+	cfg, err := fakesmi.ParseConfig([]byte(doc))
+	require.NoError(t, err)
+
+	return parseExtras(cfg.Extras())
+}
+
+//nolint:funlen // a table of config validation cases, long but flat
+func TestParseExtrasValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{
+			name: "valid full config",
+			doc: `extras:
+  seed: 42
+  pcie:
+    tx-bytes-per-second: {min: 1e9, max: 2e9}
+    rx-bytes-per-second: {min: 1e9, max: 2e9}
+  xids:
+    initial: [{gpu: 0, xid: 79, count: 2}]
+    interval: 10m
+    codes: [13, 31]
+  mig:
+    - gpu: 0
+      instances:
+        - {gi: 2, profile: 3g.71gb, cis: 2, busy: true}
+        - {gi: 7, profile: 1g.18gb}
+`,
+		},
+		{name: "no extras block", doc: "state: idle\n"},
+		{
+			name:    "unknown key rejected by the strict decoder",
+			doc:     "extras:\n  bogus: 1\n",
+			wantErr: "bogus",
+		},
+		{
+			name: "duplicate gpu",
+			doc: "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: 1g.18gb}]}\n" +
+				"    - {gpu: 0, instances: [{gi: 2, profile: 1g.18gb}]}\n",
+			wantErr: "duplicate mig entry for gpu 0",
+		},
+		{
+			name:    "duplicate gi",
+			doc:     "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: 1g.18gb}, {gi: 1, profile: 2g.35gb}]}\n",
+			wantErr: "duplicate gi 1 on gpu 0",
+		},
+		{
+			name:    "gpu without instances",
+			doc:     "extras:\n  mig:\n    - {gpu: 0}\n",
+			wantErr: "has no instances",
+		},
+		{
+			name:    "instance without profile",
+			doc:     "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1}]}\n",
+			wantErr: "needs a profile",
+		},
+		{
+			name:    "profile without size token and no explicit bytes",
+			doc:     "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: weird}]}\n",
+			wantErr: "carries no size token",
+		},
+		{
+			name: "profile without size token but explicit bytes",
+			doc:  "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: weird, memory-total-bytes: 1024}]}\n",
+		},
+		{
+			name:    "negative cis",
+			doc:     "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: 1g.18gb, cis: -1}]}\n",
+			wantErr: "negative cis",
+		},
+		{
+			name:    "pcie min above max",
+			doc:     "extras:\n  pcie:\n    tx-bytes-per-second: {min: 5, max: 1}\n",
+			wantErr: "must be finite and satisfy",
+		},
+		{
+			name:    "pcie negative min",
+			doc:     "extras:\n  pcie:\n    rx-bytes-per-second: {min: -1, max: 1}\n",
+			wantErr: "must be finite and satisfy",
+		},
+		{
+			name:    "bad xid interval",
+			doc:     "extras:\n  xids:\n    interval: often\n",
+			wantErr: "invalid xids interval",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := extrasFrom(t, testCase.doc)
+
+			if testCase.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtrasDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := extrasFrom(t, "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: 3g.71gb}]}\n")
+	require.NoError(t, err)
+
+	assert.Positive(t, cfg.PCIe.TXBytesPerSecond.Max)
+	assert.Positive(t, cfg.PCIe.RXBytesPerSecond.Max)
+	assert.NotEmpty(t, cfg.XIDs.Codes)
+	assert.InDelta(t, float64(defaultEnergyFallbackPowerWatts), cfg.EnergyFallbackPowerWatts, 0)
+	assert.Equal(t, 1, cfg.MIG[0].Instances[0].CIs, "cis must default to one")
+	assert.Equal(t, uint64(71)<<30, cfg.MIG[0].Instances[0].MemoryTotalBytes,
+		"memory must default to the profile's size token")
+	assert.Equal(t, time.Duration(0), cfg.xidInterval(), "no interval means no ongoing events")
+}
+
+func TestProfileMemoryBytes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, uint64(71)<<30, profileMemoryBytes("3g.71gb"))
+	assert.Equal(t, uint64(18)<<30, profileMemoryBytes("1g.18gb"))
+	assert.Zero(t, profileMemoryBytes("weird"))
+}
+
+func TestMigUUIDStableAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	first := migUUID("parent", 2, 0, "3g.71gb")
+
+	assert.Equal(t, first, migUUID("parent", 2, 0, "3g.71gb"), "same tuple must reuse the uuid")
+	assert.NotEqual(t, first, migUUID("parent", 2, 1, "3g.71gb"))
+	assert.NotEqual(t, first, migUUID("parent", 7, 0, "3g.71gb"))
+	assert.NotEqual(t, first, migUUID("other", 2, 0, "3g.71gb"))
+	assert.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`, first)
+}
+
+func TestSynthEnergyTrapezoid(t *testing.T) {
+	t.Parallel()
+
+	backend := &Backend{energy: map[string]*energyState{}}
+	extras := &extrasConfig{EnergyFallbackPowerWatts: 120}
+	start := time.Unix(1000, 0)
+
+	var first collect.Reading
+
+	backend.synthEnergy([]string{"u0"}, map[string]float64{"u0": 100}, extras, start, &first)
+	require.Len(t, first.Extras.Energy, 1)
+	assert.Zero(t, first.Extras.Energy[0].Joules, "the first sample must emit zero")
+
+	var second collect.Reading
+
+	backend.synthEnergy([]string{"u0"}, map[string]float64{"u0": 200}, extras, start.Add(10*time.Second), &second)
+	assert.InDelta(t, 1500.0, second.Extras.Energy[0].Joules, 1e-9,
+		"trapezoid of 100W to 200W over 10s")
+
+	// no table power: the configured fallback keeps integrating
+	var third collect.Reading
+
+	backend.synthEnergy([]string{"u0"}, nil, extras, start.Add(20*time.Second), &third)
+	assert.InDelta(t, 1500.0+(200+120)/2.0*10, third.Extras.Energy[0].Joules, 1e-9)
+
+	// a GPU that left the config is forgotten; a new one starts at zero
+	var fourth collect.Reading
+
+	backend.synthEnergy([]string{"u1"}, nil, extras, start.Add(30*time.Second), &fourth)
+	require.Len(t, fourth.Extras.Energy, 1)
+	assert.Zero(t, fourth.Extras.Energy[0].Joules)
+	assert.NotContains(t, backend.energy, "u0")
+}
+
+func TestSynthMIGShape(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1)
+	backend := &Backend{rng: newDemoRand(&seed), seenGIs: map[string]bool{}}
+	extras, err := extrasFrom(t, `extras:
+  mig:
+    - gpu: 0
+      instances:
+        - {gi: 2, profile: 3g.71gb, cis: 2, busy: true}
+        - {gi: 7, profile: 1g.18gb}
+    - gpu: 5
+      instances:
+        - {gi: 1, profile: 1g.18gb}
+`)
+	require.NoError(t, err)
+
+	var reading collect.Reading
+
+	backend.synthMIG([]string{"u0", "u1"}, extras, &reading)
+
+	// gpu 5 is out of range and skipped; gpu 0 yields 2 CIs + 1 CI
+	require.Len(t, reading.Extras.MIG, 3)
+
+	first, second, third := reading.Extras.MIG[0], reading.Extras.MIG[1], reading.Extras.MIG[2]
+
+	assert.Equal(t, "u0", first.ParentUUID)
+	assert.Equal(t, "2", first.GPUInstanceID)
+	assert.Equal(t, "0", first.ComputeInstanceID)
+	assert.Equal(t, "1", second.ComputeInstanceID)
+	assert.Equal(t, "1c.3g.71gb", first.Profile, "sliced instances carry the ci-qualified profile")
+	assert.Equal(t, "1g.18gb", third.Profile)
+	assert.NotEqual(t, first.UUID, second.UUID)
+
+	// sibling CIs share the GPU-instance-scoped readings
+	assert.Same(t, first.Memory, second.Memory)
+	assert.NotSame(t, first.Memory, third.Memory)
+
+	// like the real backend's GPM sampling, the first cycle that sees a GPU
+	// instance serves no utilization
+	assert.Nil(t, first.Utilization)
+	assert.Nil(t, third.Utilization)
+
+	// the memory invariant holds
+	assert.Equal(t, first.Memory.Total, first.Memory.Used+first.Memory.Free+first.Memory.Reserved)
+
+	// the second cycle serves utilization: the busy instance runs hot,
+	// sibling CIs share it
+	var next collect.Reading
+
+	backend.synthMIG([]string{"u0", "u1"}, extras, &next)
+	require.Len(t, next.Extras.MIG, 3)
+	first, second, third = next.Extras.MIG[0], next.Extras.MIG[1], next.Extras.MIG[2]
+
+	require.NotNil(t, first.Utilization)
+	require.NotNil(t, third.Utilization)
+	assert.Same(t, first.Utilization, second.Utilization)
+	assert.Greater(t, *first.Utilization.SMActivityRatio, 0.5)
+	assert.Less(t, *third.Utilization.SMActivityRatio, 0.1)
+}
+
+func TestSynthMIGDepartedInstanceStartsOver(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1)
+	backend := &Backend{rng: newDemoRand(&seed), seenGIs: map[string]bool{}}
+	extras, err := extrasFrom(t, "extras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: 1g.18gb}]}\n")
+	require.NoError(t, err)
+
+	var first collect.Reading
+
+	backend.synthMIG([]string{"u0"}, extras, &first)
+	require.Nil(t, first.Extras.MIG[0].Utilization)
+
+	// the instance leaves the topology for one cycle
+	empty, err := extrasFrom(t, "state: idle\n")
+	require.NoError(t, err)
+	backend.synthMIG([]string{"u0"}, empty, &collect.Reading{})
+
+	// back again: first-cycle semantics apply anew
+	var back collect.Reading
+
+	backend.synthMIG([]string{"u0"}, extras, &back)
+	assert.Nil(t, back.Extras.MIG[0].Utilization)
+}
+
+func TestTickXIDsSeedsInitialOnce(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1)
+	backend := &Backend{rng: newDemoRand(&seed), xids: map[string]map[uint64]*xidStat{}}
+	extras, err := extrasFrom(t, `extras:
+  xids:
+    initial:
+      - {gpu: 0, xid: 79, count: 2}
+      - {gpu: 5, xid: 13, count: 1}
+      - {gpu: 0, xid: 31, count: 0}
+`)
+	require.NoError(t, err)
+
+	uuids := []string{"u0", "u1"}
+	now := time.Unix(1000, 0)
+
+	backend.tickXIDs(uuids, extras, now)
+	backend.tickXIDs(uuids, extras, now.Add(time.Second))
+
+	counters := backend.XIDCounts()
+	require.Len(t, counters, 1, "out-of-range and zero-count events are skipped, seeding happens once")
+	assert.Equal(t, "u0", counters[0].UUID)
+	assert.Equal(t, uint64(79), counters[0].XID)
+	assert.Equal(t, uint64(2), counters[0].Count)
+}
+
+func TestTickXIDsCadenceAndCatchUpBound(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1)
+	backend := &Backend{rng: newDemoRand(&seed), xids: map[string]map[uint64]*xidStat{}}
+	extras, err := extrasFrom(t, "extras:\n  xids:\n    interval: 1m\n")
+	require.NoError(t, err)
+
+	uuids := []string{"u0"}
+	start := time.Unix(1000, 0)
+
+	backend.tickXIDs(uuids, extras, start)
+	assert.Empty(t, backend.XIDCounts(), "the first slot lies at least half an interval away")
+
+	// a long pause covers dozens of slots but the catch-up is bounded
+	backend.tickXIDs(uuids, extras, start.Add(time.Hour))
+
+	var total uint64
+	for _, counter := range backend.XIDCounts() {
+		total += counter.Count
+	}
+
+	assert.Equal(t, uint64(10), total)
+}
+
+func TestAttributeApps(t *testing.T) {
+	t.Parallel()
+
+	extras, err := extrasFrom(t, `extras:
+  mig:
+    - gpu: 0
+      instances:
+        - {gi: 2, profile: 3g.71gb, cis: 2}
+        - {gi: 7, profile: 1g.18gb}
+`)
+	require.NoError(t, err)
+
+	reading := func() collect.Reading {
+		return collect.Reading{Apps: []nvidiasmi.ComputeApp{
+			{GPUUUID: "u0", PID: "101"},
+			{GPUUUID: "u0", PID: "202"},
+			{GPUUUID: "u1", PID: "303"},
+		}}
+	}
+
+	first := reading()
+	attributeApps([]string{"u0", "u1"}, extras, &first)
+
+	for _, app := range first.Apps[:2] {
+		assert.Contains(t, []string{"2", "7"}, app.GPUInstanceID, "pid %s", app.PID)
+		assert.NotEmpty(t, app.ComputeInstanceID)
+	}
+
+	assert.Empty(t, first.Apps[2].GPUInstanceID, "a GPU without a topology keeps empty attribution")
+	assert.Empty(t, first.Apps[2].ComputeInstanceID)
+
+	second := reading()
+	attributeApps([]string{"u0", "u1"}, extras, &second)
+	assert.Equal(t, first.Apps, second.Apps, "the process-to-instance mapping must be stable")
+}
+
+func TestNewBuiltinConfigAndRunFunc(t *testing.T) {
+	t.Parallel()
+
+	backend, err := New(testSource(), "", testLogger())
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := &exec.Cmd{Args: []string{"demo-nvidia-smi", "--version"}, Stdout: &stdout, Stderr: &stderr}
+	require.NoError(t, backend.RunFunc()(cmd))
+	assert.Contains(t, stdout.String(), "CUDA")
+
+	var bad bytes.Buffer
+
+	cmd = &exec.Cmd{Args: []string{"demo-nvidia-smi", "--no-such-flag"}, Stdout: &bad, Stderr: &bad}
+	require.ErrorContains(t, backend.RunFunc()(cmd), "demo invocation failed")
+}
+
+func TestNewInvalidConfigFailsStartup(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "demo.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("extras:\n  xids:\n    interval: often\n"), 0o600))
+
+	_, err := New(testSource(), path, testLogger())
+	require.ErrorContains(t, err, "invalid demo config")
+}
+
+func TestWrapQueryFuncReloadFailureFailsTheCollection(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "demo.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("extras:\n  seed: 1\n"), 0o600))
+
+	backend, err := New(testSource(), path, testLogger())
+	require.NoError(t, err)
+
+	inner := func(_ context.Context) (collect.Reading, int, error) {
+		return collect.Reading{}, 0, nil
+	}
+	wrapped := backend.WrapQueryFunc(inner)
+
+	_, code, err := wrapped(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, code)
+
+	// a broken edit fails that collection instead of crashing or serving
+	// mismatched data
+	require.NoError(t, os.WriteFile(path, []byte("extras:\n  bogus: 1\n"), 0o600))
+
+	_, code, err = wrapped(t.Context())
+	require.Error(t, err)
+	assert.Equal(t, -1, code)
+
+	// fixing the file recovers without a restart
+	require.NoError(t, os.WriteFile(path, []byte("extras:\n  seed: 1\n"), 0o600))
+
+	_, _, err = wrapped(t.Context())
+	require.NoError(t, err)
+}
+
+func TestNewPreflightRejectsBadCaptureAndState(t *testing.T) {
+	t.Parallel()
+
+	for name, doc := range map[string]string{
+		"missing capture": "capture: no-such-capture\n",
+		"unknown state":   "state: exploded\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "demo.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(doc), 0o600))
+
+			_, err := New(testSource(), path, testLogger())
+			require.ErrorContains(t, err, "cannot serve a GPU table")
+		})
+	}
+}
+
+func TestReconcileServesMIGModeEnabled(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "demo.yaml")
+	doc := "gpus: 2\nextras:\n  mig:\n    - {gpu: 0, instances: [{gi: 1, profile: 1g.18gb}]}\n"
+	require.NoError(t, os.WriteFile(path, []byte(doc), 0o600))
+
+	backend, err := New(testSource(), path, testLogger())
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+
+	cmd := &exec.Cmd{
+		Args:   []string{"demo-nvidia-smi", "--query-gpu=mig.mode.current", "--format=csv"},
+		Stdout: &out, Stderr: io.Discard,
+	}
+	require.NoError(t, backend.RunFunc()(cmd))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 3, "a header and one row per simulated GPU")
+	assert.Equal(t, "Enabled", strings.TrimSpace(lines[1]), "the MIG GPU must report the mode on")
+	assert.NotEqual(t, "Enabled", strings.TrimSpace(lines[2]), "the plain GPU keeps the captured mode")
+}
+
+func TestReconcileRejectsOutOfRangeIndexes(t *testing.T) {
+	t.Parallel()
+
+	for name, doc := range map[string]string{
+		"mig gpu": "gpus: 2\nextras:\n  mig:\n    - {gpu: 5, instances: [{gi: 1, profile: 1g.18gb}]}\n",
+		"xid gpu": "extras:\n  xids:\n    initial: [{gpu: 3, xid: 79, count: 1}]\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "demo.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(doc), 0o600))
+
+			_, err := New(testSource(), path, testLogger())
+			require.ErrorContains(t, err, "out of range")
+		})
+	}
+}
+
+func TestFailureInjectionIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "demo.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("exit: 7\ndelay: 5s\n"), 0o600))
+
+	start := time.Now()
+
+	backend, err := New(testSource(), path, testLogger())
+	require.NoError(t, err, "failure injection must not reach the in-process path")
+
+	var out bytes.Buffer
+
+	cmd := &exec.Cmd{
+		Args:   []string{"demo-nvidia-smi", "--query-gpu=uuid", "--format=csv"},
+		Stdout: &out, Stderr: io.Discard,
+	}
+	require.NoError(t, backend.RunFunc()(cmd))
+	assert.Less(t, time.Since(start), 2*time.Second, "the configured delay must not apply")
+	assert.NotEmpty(t, out.String())
+}
+
+func TestBeginCycleResetsStateOnConfigChange(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "demo.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("extras:\n  seed: 1\n"), 0o600))
+
+	backend, err := New(testSource(), path, testLogger())
+	require.NoError(t, err)
+
+	backend.energy["u0"] = &energyState{joules: 5}
+	backend.xidsSeeded = true
+
+	// an unchanged document keeps the accumulated state
+	require.NoError(t, backend.beginCycle())
+	assert.Contains(t, backend.energy, "u0")
+	assert.True(t, backend.xidsSeeded)
+
+	// a changed document resets it, so seed and initial-event edits apply
+	require.NoError(t, os.WriteFile(path, []byte("extras:\n  seed: 2\n"), 0o600))
+	require.NoError(t, backend.beginCycle())
+	assert.Empty(t, backend.energy)
+	assert.False(t, backend.xidsSeeded)
+}
+
+func TestWrapQueryFuncSerializesCycles(t *testing.T) {
+	t.Parallel()
+
+	backend, err := New(testSource(), "", testLogger())
+	require.NoError(t, err)
+
+	var active, peak atomic.Int64
+
+	inner := func(_ context.Context) (collect.Reading, int, error) {
+		current := active.Add(1)
+		defer active.Add(-1)
+
+		for {
+			seen := peak.Load()
+			if current <= seen || peak.CompareAndSwap(seen, current) {
+				break
+			}
+		}
+
+		time.Sleep(time.Millisecond)
+
+		return collect.Reading{}, 0, nil
+	}
+
+	wrapped := backend.WrapQueryFunc(inner)
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Go(func() {
+			_, _, err := wrapped(t.Context())
+			assert.NoError(t, err)
+		})
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(1), peak.Load(), "cycles must never overlap: one snapshot rules one whole cycle")
+}

--- a/internal/demo/synth.go
+++ b/internal/demo/synth.go
@@ -1,0 +1,351 @@
+package demo
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+)
+
+// demoRand is the seeded source behind every synthesized draw. One source,
+// advanced per draw: with a fixed seed and a fixed cycle sequence the values
+// reproduce (the golden test does exactly one cycle).
+type demoRand struct {
+	src *rand.Rand
+}
+
+func newDemoRand(seed *int64) *demoRand {
+	value := time.Now().UnixNano()
+	if seed != nil {
+		value = *seed
+	}
+
+	//nolint:gosec // not cryptographic: deterministic fake data
+	return &demoRand{src: rand.New(rand.NewSource(value))}
+}
+
+// draw returns a uniform value from the range.
+func (r *demoRand) draw(rng rangeCfg) float64 {
+	return rng.Min + r.src.Float64()*(rng.Max-rng.Min)
+}
+
+// synthEnergy integrates each GPU's power draw over the injected clock into
+// the cumulative energy counter, trapezoidally between the previous and
+// current samples. The power source is the cycle's own table value when the
+// query included the field, so the counter's rate matches the displayed
+// power; the configured fallback keeps the counter alive when an explicit
+// field selection excluded it (the extra never depends on the public
+// schema). The first sample of a GPU emits zero, a documented convention.
+func (b *Backend) synthEnergy(
+	uuids []string,
+	power map[string]float64,
+	extras *extrasConfig,
+	now time.Time,
+	reading *collect.Reading,
+) {
+	seen := map[string]bool{}
+
+	for _, uuid := range uuids {
+		seen[uuid] = true
+
+		watts, ok := power[uuid]
+		if !ok {
+			watts = extras.EnergyFallbackPowerWatts
+		}
+
+		state := b.energy[uuid]
+		if state == nil {
+			state = &energyState{}
+			b.energy[uuid] = state
+		} else {
+			elapsed := now.Sub(state.lastAt).Seconds()
+			if elapsed > 0 {
+				state.joules += (state.lastPower + watts) / 2 * elapsed
+			}
+		}
+
+		state.lastPower = watts
+		state.lastAt = now
+
+		reading.Extras.Energy = append(reading.Extras.Energy, collect.EnergyCounter{
+			UUID:   uuid,
+			Joules: state.joules,
+		})
+	}
+
+	// a GPU that left the config stops integrating and disappears
+	for uuid := range b.energy {
+		if !seen[uuid] {
+			delete(b.energy, uuid)
+		}
+	}
+}
+
+// synthPCIe draws each GPU's throughput from the configured ranges.
+func (b *Backend) synthPCIe(uuids []string, extras *extrasConfig, reading *collect.Reading) {
+	for _, uuid := range uuids {
+		reading.Extras.PCIe = append(reading.Extras.PCIe, collect.PCIeThroughput{
+			UUID:             uuid,
+			TXBytesPerSecond: b.rng.draw(extras.PCIe.TXBytesPerSecond),
+			RXBytesPerSecond: b.rng.draw(extras.PCIe.RXBytesPerSecond),
+		})
+	}
+}
+
+// synthMIG builds the configured MIG topology, mirroring the real backend's
+// semantics: deterministic MIG uuids, sibling compute instances carrying
+// identical GPU-instance-scoped memory and utilization (the exporter dedups
+// per GPU instance), deterministic list order, and no utilization on the
+// first cycle that sees a GPU instance (the real backend's GPM sampling
+// needs a sample pair, and the exporter's metric help documents exactly
+// that).
+func (b *Backend) synthMIG(uuids []string, extras *extrasConfig, reading *collect.Reading) {
+	live := map[string]bool{}
+
+	for _, gpu := range extras.MIG {
+		if gpu.GPU < 0 || gpu.GPU >= len(uuids) {
+			continue
+		}
+
+		parent := uuids[gpu.GPU]
+
+		for _, instance := range gpu.Instances {
+			memory := b.migMemory(instance)
+
+			key := parent + "/" + strconv.Itoa(instance.GI)
+			live[key] = true
+
+			var util *collect.MIGUtilization
+			if b.seenGIs[key] {
+				util = b.migUtilization(instance, extras)
+			} else {
+				b.seenGIs[key] = true
+			}
+
+			for ci := range instance.CIs {
+				reading.Extras.MIG = append(reading.Extras.MIG, collect.MIGInstance{
+					ParentUUID:        parent,
+					UUID:              migUUID(parent, instance.GI, ci, instance.Profile),
+					GPUInstanceID:     strconv.Itoa(instance.GI),
+					ComputeInstanceID: strconv.Itoa(ci),
+					Profile:           ciProfile(instance),
+					Memory:            memory,
+					Utilization:       util,
+				})
+			}
+		}
+	}
+
+	// a GPU instance that left the topology starts over if it comes back
+	for key := range b.seenGIs {
+		if !live[key] {
+			delete(b.seenGIs, key)
+		}
+	}
+}
+
+// migMemory synthesizes one GPU instance's memory, upholding the
+// used + free + reserved = total invariant.
+func (b *Backend) migMemory(instance migInstanceConfig) *collect.MIGMemory {
+	total := instance.MemoryTotalBytes
+
+	usedShare := rangeCfg{Min: 0.02, Max: 0.10}
+	if instance.Busy {
+		usedShare = rangeCfg{Min: 0.55, Max: 0.90}
+	}
+
+	reserved := total / 200
+	used := uint64(b.rng.draw(usedShare) * float64(total-reserved))
+
+	return &collect.MIGMemory{
+		Total:    total,
+		Used:     used,
+		Free:     total - used - reserved,
+		Reserved: reserved,
+	}
+}
+
+// migUtilization synthesizes one GPU instance's activity: the busy instance
+// runs hot, the rest idle.
+func (b *Backend) migUtilization(instance migInstanceConfig, extras *extrasConfig) *collect.MIGUtilization {
+	activity := rangeCfg{Min: 0, Max: 0.05}
+	pcieShare := rangeCfg{Min: 0, Max: 0.02}
+
+	if instance.Busy {
+		activity = rangeCfg{Min: 0.70, Max: 1.0}
+		pcieShare = rangeCfg{Min: 0.2, Max: 0.6}
+	}
+
+	value := func(rng rangeCfg) *float64 {
+		v := b.rng.draw(rng)
+
+		return &v
+	}
+
+	return &collect.MIGUtilization{
+		GraphicsActivityRatio: value(activity),
+		SMActivityRatio:       value(activity),
+		SMOccupancyRatio:      value(activity),
+		TensorActivityRatio:   value(rangeCfg{Min: activity.Min * 0.5, Max: activity.Max * 0.8}),
+		PCIeTXBytesPerSecond: value(rangeCfg{
+			Min: extras.PCIe.TXBytesPerSecond.Min * pcieShare.Min,
+			Max: extras.PCIe.TXBytesPerSecond.Max * pcieShare.Max,
+		}),
+		PCIeRXBytesPerSecond: value(rangeCfg{
+			Min: extras.PCIe.RXBytesPerSecond.Min * pcieShare.Min,
+			Max: extras.PCIe.RXBytesPerSecond.Max * pcieShare.Max,
+		}),
+	}
+}
+
+// tickXIDs applies the pre-seeded events on the first cycle and emits ongoing
+// events per the configured cadence, deterministically given the seed.
+func (b *Backend) tickXIDs(uuids []string, extras *extrasConfig, now time.Time) {
+	b.seedInitialXIDs(uuids, extras, now)
+
+	interval := extras.xidInterval()
+	if interval <= 0 || len(uuids) == 0 {
+		return
+	}
+
+	if b.nextXIDAt.IsZero() {
+		b.nextXIDAt = now.Add(b.jitteredInterval(interval))
+	}
+
+	// catch up missed slots, bounded so a long pause cannot burst
+	for fired := 0; fired < 10 && now.After(b.nextXIDAt); fired++ {
+		uuid := uuids[b.rng.src.Intn(len(uuids))]
+		code := extras.XIDs.Codes[b.rng.src.Intn(len(extras.XIDs.Codes))]
+
+		b.bumpXID(uuid, code, 1, b.nextXIDAt)
+		b.nextXIDAt = b.nextXIDAt.Add(b.jitteredInterval(interval))
+	}
+
+	// a pause longer than the bounded catch-up covers is forgiven, so the
+	// schedule does not spend days replaying stale-timestamped events
+	if now.After(b.nextXIDAt) {
+		b.nextXIDAt = now.Add(b.jitteredInterval(interval))
+	}
+}
+
+// seedInitialXIDs applies the configured error history once, on the first
+// cycle, resolving GPU indexes against the served table.
+func (b *Backend) seedInitialXIDs(uuids []string, extras *extrasConfig, now time.Time) {
+	if b.xidsSeeded {
+		return
+	}
+
+	b.xidsSeeded = true
+
+	for _, event := range extras.XIDs.Initial {
+		if event.GPU < 0 || event.GPU >= len(uuids) || event.Count == 0 {
+			continue
+		}
+
+		b.bumpXID(uuids[event.GPU], event.XID, event.Count, now)
+	}
+}
+
+// jitteredInterval spreads the cadence to 50-150% of the mean.
+func (b *Backend) jitteredInterval(mean time.Duration) time.Duration {
+	return time.Duration(float64(mean) * (0.5 + b.rng.src.Float64()))
+}
+
+// bumpXID folds events into the accumulator.
+func (b *Backend) bumpXID(uuid string, xid, count uint64, at time.Time) {
+	perGPU := b.xids[uuid]
+	if perGPU == nil {
+		perGPU = map[uint64]*xidStat{}
+		b.xids[uuid] = perGPU
+	}
+
+	stat := perGPU[xid]
+	if stat == nil {
+		stat = &xidStat{}
+		perGPU[xid] = stat
+	}
+
+	stat.count += count
+	stat.last = at
+}
+
+// migUUID derives a stable MIG device uuid from the identity tuple, like the
+// real driver's deterministic placement-derived uuids.
+func migUUID(parent string, gi, ci int, profile string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s/%d/%d/%s", parent, gi, ci, profile))
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16])
+}
+
+// ciProfile spells the compute-instance-qualified profile the way nvidia-smi
+// names sliced instances ("1c.3g.71gb") when a GPU instance hosts several
+// compute instances.
+func ciProfile(instance migInstanceConfig) string {
+	if instance.CIs <= 1 {
+		return instance.Profile
+	}
+
+	return "1c." + instance.Profile
+}
+
+// sortXIDCounters orders the scrape output deterministically.
+func sortXIDCounters(counters []collect.XIDCounter) {
+	sort.Slice(counters, func(i, j int) bool {
+		if counters[i].UUID != counters[j].UUID {
+			return counters[i].UUID < counters[j].UUID
+		}
+
+		return counters[i].XID < counters[j].XID
+	})
+}
+
+// attributeApps assigns per-process readings to the configured MIG topology,
+// the way the real nvml backend attributes processes to their compute
+// instance. The mapping is stable: a process keeps its instance across
+// cycles (hash of the pid over the flattened instance list). Processes on
+// GPUs without a topology keep empty attribution, like non-MIG GPUs.
+func attributeApps(uuids []string, extras *extrasConfig, reading *collect.Reading) {
+	if len(reading.Apps) == 0 || len(extras.MIG) == 0 {
+		return
+	}
+
+	type instanceRef struct{ gi, ci int }
+
+	topology := map[string][]instanceRef{}
+
+	for _, gpu := range extras.MIG {
+		if gpu.GPU < 0 || gpu.GPU >= len(uuids) {
+			continue
+		}
+
+		for _, instance := range gpu.Instances {
+			for ci := range instance.CIs {
+				topology[uuids[gpu.GPU]] = append(topology[uuids[gpu.GPU]], instanceRef{gi: instance.GI, ci: ci})
+			}
+		}
+	}
+
+	for i := range reading.Apps {
+		app := &reading.Apps[i]
+
+		refs := topology[app.GPUUUID]
+		if len(refs) == 0 {
+			continue
+		}
+
+		ref := refs[pidSlot(app.PID, len(refs))]
+		app.GPUInstanceID = strconv.Itoa(ref.gi)
+		app.ComputeInstanceID = strconv.Itoa(ref.ci)
+	}
+}
+
+// pidSlot picks a stable slot for a pid.
+func pidSlot(pid string, slots int) int {
+	sum := sha256.Sum256([]byte(pid))
+
+	return int(sum[0]) % slots
+}

--- a/internal/demodata/demodata.go
+++ b/internal/demodata/demodata.go
@@ -1,0 +1,18 @@
+// Package demodata embeds the small curated capture set the exporter's demo
+// backend serves synthetic data from. It is deliberately separate from the
+// full test corpus in internal/captures: the corpus must never be embedded
+// into the exporter binary (a guard test enforces it), while these two
+// captures are a deliberate, size-budgeted part of the demo feature.
+package demodata
+
+import "embed"
+
+// FS holds the curated captures: a consumer RTX 4080 SUPER box and an H200
+// datacenter card, both replicable into multi-GPU shapes by the fake's gpus
+// setting.
+//
+//go:embed *.txt
+var FS embed.FS
+
+// Default is the capture the demo backend serves when none is configured.
+const Default = "linux-x86_64__nvidia-h200__590.48.01.txt"

--- a/internal/demodata/demodata_test.go
+++ b/internal/demodata/demodata_test.go
@@ -1,0 +1,48 @@
+package demodata_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/demodata"
+)
+
+// TestExactlyTheCuratedCaptures pins the embedded set: the demo data is a
+// deliberate size budget, and a stray capture landing in this directory
+// would silently bloat every shipped binary.
+func TestExactlyTheCuratedCaptures(t *testing.T) {
+	t.Parallel()
+
+	names, err := fs.Glob(demodata.FS, "*.txt")
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{
+		"linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05.txt",
+		"linux-x86_64__nvidia-h200__590.48.01.txt",
+	}, names)
+}
+
+// TestCapturesMatchTheCorpusSources keeps the curated copies byte-identical
+// to their internal/captures sources, so the demo never drifts from the
+// corpus the rest of the machinery is verified against.
+func TestCapturesMatchTheCorpusSources(t *testing.T) {
+	t.Parallel()
+
+	names, err := fs.Glob(demodata.FS, "*.txt")
+	require.NoError(t, err)
+
+	for _, name := range names {
+		embedded, err := fs.ReadFile(demodata.FS, name)
+		require.NoError(t, err)
+
+		source, err := os.ReadFile(filepath.Join("..", "captures", name))
+		require.NoError(t, err, "every demo capture must come from the corpus")
+
+		assert.Equal(t, source, embedded, "capture %s drifted from its corpus source", name)
+	}
+}

--- a/internal/demodata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05.txt
+++ b/internal/demodata/linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05.txt
@@ -1,0 +1,2197 @@
+################################################################################
+# nvidia_gpu_exporter GPU capture
+# https://github.com/utkuozdemir/nvidia_gpu_exporter - see internal/captures/README.md
+################################################################################
+# The GPU model and driver are in the filename. Every other nvidia-smi
+# value is in the raw sections below, not re-parsed here. This header only
+# carries what nvidia-smi does not report: collection time, mask status,
+# host OS (from uname), and the synthetic load used.
+collected_at:   2026-06-26T09:59:43Z
+masked:         yes
+os:             linux (Fedora Linux 44 (KDE Plasma Desktop Edition))
+kernel:         7.0.12-201.fc44.x86_64
+arch:           x86_64
+load:           ffmpeg NVENC x2 (1080p120 testsrc2)
+
+
+################################################################################
+# capabilities :: version
+# $ nvidia-smi --version
+################################################################################
+NVIDIA-SMI version  : 595.71.05
+NVML version        : 595.71
+DRIVER version      : 595.71.05
+CUDA Version        : 13.2
+
+
+################################################################################
+# capabilities :: help (-h)
+# $ nvidia-smi -h
+################################################################################
+NVIDIA System Management Interface -- v595.71.05
+
+NVSMI provides monitoring information for Tesla and select Quadro devices.
+The data is presented in either a plain text or an XML format, via stdout or a file.
+NVSMI also provides several management operations for changing the device state.
+
+Note that the functionality of NVSMI is exposed through the NVML C-based
+library. See the NVIDIA developer website for more information about NVML.
+Python wrappers to NVML are also available.  The output of NVSMI is
+not guaranteed to be backwards compatible; NVML and the bindings are backwards
+compatible.
+
+http://developer.nvidia.com/nvidia-management-library-nvml/
+http://pypi.python.org/pypi/nvidia-ml-py/
+Supported products:
+- Full Support
+    - All Tesla products, starting with the Kepler architecture
+    - All Quadro products, starting with the Kepler architecture
+    - All GRID products, starting with the Kepler architecture
+    - GeForce Titan products, starting with the Kepler architecture
+- Limited Support
+    - All Geforce products, starting with the Kepler architecture
+nvidia-smi [OPTION1 [ARG1]] [OPTION2 [ARG2]] ...
+
+    -h,   --help                Print usage information and exit.
+
+          --version             Print version information and exit.
+
+  LIST OPTIONS:
+
+    -L,   --list-gpus           Display a list of GPUs connected to the system.
+
+    -B,   --list-excluded-gpus  Display a list of excluded GPUs in the system.
+
+  SUMMARY OPTIONS:
+
+    <no arguments>              Show a summary of GPUs connected to the system.
+
+    -col, --columns             Show a summary of GPUs connected to the system in multi-column format.
+
+    [plus any of]
+
+    -i,   --id=                 Target a specific GPU.
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -l,   --loop=               Probe until Ctrl+C at specified second interval.
+
+  QUERY OPTIONS:
+
+    -q,   --query               Display GPU or Unit info.
+
+    [plus any of]
+
+    -u,   --unit                Show unit, rather than GPU, attributes.
+    -i,   --id=                 Target a specific GPU or Unit.
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -x,   --xml-format          Produce XML output.
+          --dtd                 When showing xml output, embed DTD.
+    -d,   --display=            Display only selected information: MEMORY,
+                                    UTILIZATION, ECC, TEMPERATURE, POWER, CLOCK,
+                                    COMPUTE, PIDS, PERFORMANCE, SUPPORTED_CLOCKS,
+                                    PAGE_RETIREMENT, ACCOUNTING, ENCODER_STATS,
+                                    SUPPORTED_GPU_TARGET_TEMP, VOLTAGE, FBC_STATS
+                                    ROW_REMAPPER, GSP_FIRMWARE_VERSION
+                                    POWER_SMOOTHING, POWER_PROFILES
+                                Flags can be combined with comma e.g. ECC,POWER.
+                                Sampling data with max/min/avg is also returned 
+                                for POWER, UTILIZATION and CLOCK display types.
+                                Doesn't work with -u or -x flags.
+    -l,   --loop=               Probe until Ctrl+C at specified second interval.
+
+    -lms, --loop-ms=            Probe until Ctrl+C at specified millisecond interval.
+
+  SELECTIVE QUERY OPTIONS:
+
+    Allows the caller to pass an explicit list of properties to query.
+
+    [one of]
+
+    --query-gpu                 Information about GPU.
+                                Call --help-query-gpu for more info.
+    --query-supported-clocks    List of supported clocks.
+                                Call --help-query-supported-clocks for more info.
+    --query-compute-apps        List of currently active compute processes.
+                                Call --help-query-compute-apps for more info.
+    --query-accounted-apps      List of accounted compute processes.
+                                Call --help-query-accounted-apps for more info.
+                                This query is not supported on vGPU host.
+    --query-retired-pages       List of device memory pages that have been retired.
+                                Call --help-query-retired-pages for more info.
+    --query-remapped-rows       Information about remapped rows.
+                                Call --help-query-remapped-rows for more info.
+
+    [mandatory]
+
+    --format=                   Comma separated list of format options:
+                                  csv - comma separated values (MANDATORY)
+                                  noheader - skip the first line with column headers
+                                  nounits - don't print units for numerical
+                                             values
+
+    [plus any of]
+
+    -i,   --id=                 Target a specific GPU or Unit.
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -l,   --loop=               Probe until Ctrl+C at specified second interval.
+    -lms, --loop-ms=            Probe until Ctrl+C at specified millisecond interval.
+
+  DEVICE MODIFICATION OPTIONS:
+
+    [any one of]
+
+    -pm,  --persistence-mode=   Set persistence mode: 0/DISABLED, 1/ENABLED
+    -e,   --ecc-config=         Toggle ECC support: 0/DISABLED, 1/ENABLED
+    -p,   --reset-ecc-errors=   Reset ECC error counts: 0/VOLATILE, 1/AGGREGATE
+    -c,   --compute-mode=       Set MODE for compute applications:
+                                0/DEFAULT, 1/EXCLUSIVE_THREAD (DEPRECATED),
+                                2/PROHIBITED, 3/EXCLUSIVE_PROCESS
+          --gom=                Set GPU Operation Mode:
+                                    0/ALL_ON, 1/COMPUTE, 2/LOW_DP
+    -r    --gpu-reset           Trigger reset of the GPU.
+                                Can be used to reset the GPU HW state in situations
+                                that would otherwise require a machine reboot.
+                                Typically useful if a double bit ECC error has
+                                occurred.
+                                Reset operations are not guaranteed to work in
+                                all cases and should be used with caution.
+                                Reset triggered without extra arguments, will be a.
+                                default Function Level Reset (FLR). To issue a
+                                Bus Reset, use -r bus.
+    -vm   --virt-mode=          Switch GPU Virtualization Mode:
+                                Sets GPU virtualization mode to 3/VGPU or 4/VSGA
+                                Virtualization mode of a GPU can only be set when
+                                it is running on a hypervisor.
+    -lgc  --lock-gpu-clocks=    Specifies <minGpuClock,maxGpuClock> clocks as a
+                                    pair (e.g. 1500,1500) that defines the range 
+                                    of desired locked GPU clock speed in MHz.
+                                    Setting this will supersede application clocks
+                                    and take effect regardless if an app is running.
+                                    Input can also be a singular desired clock value
+                                    (e.g. <GpuClockValue>). Optionally, --mode can be
+                                    specified to indicate a special mode.
+    -m    --mode=               Specifies the mode for --lock-gpu-clocks.
+                                    Valid modes: 0, 1
+    -rgc  --reset-gpu-clocks
+                                Resets the GPU clocks to the default values.
+    -lmc  --lock-memory-clocks=  Specifies <minMemClock,maxMemClock> clocks as a
+                                    pair (e.g. 5100,5100) that defines the range 
+                                    of desired locked Memory clock speed in MHz.
+                                    Input can also be a singular desired clock value
+                                    (e.g. <MemClockValue>).
+    -rmc  --reset-memory-clocks
+                                Resets the Memory clocks to the default values.
+    -lmcd --lock-memory-clocks-deferred=
+                                    Specifies memClock clock to lock. This limit is
+                                    applied the next time GPU is initialized.
+                                    This is guaranteed by unloading and reloading the kernel module.
+                                    Requires root.
+    -rmcd --reset-memory-clocks-deferred
+                                Resets the deferred Memory clocks applied.
+    -ac   --applications-clocks= Specifies <memory,graphics> clocks as a
+                                    pair (e.g. 2000,800) that defines GPU's
+                                    speed in MHz while running applications on a GPU.
+    -rac  --reset-applications-clocks
+                                Resets the applications clocks to the default values.
+    -pl   --power-limit=        Specifies maximum power management limit in watts.
+                                Takes an optional argument --scope.
+    -sc   --scope=              Specifies the device type for --scope: 0/GPU, 1/TOTAL_MODULE (Grace Hopper Only)
+    -cc   --cuda-clocks=        Overrides or restores default CUDA clocks.
+                                In override mode, GPU clocks higher frequencies when running CUDA applications.
+                                Only on supported devices starting from the Volta series.
+                                Requires administrator privileges.
+                                0/RESTORE_DEFAULT, 1/OVERRIDE
+    -am   --accounting-mode=    Enable or disable Accounting Mode: 0/DISABLED, 1/ENABLED
+    -caa  --clear-accounted-apps
+                                Clears all the accounted PIDs in the buffer.
+          --auto-boost-default= Set the default auto boost policy to 0/DISABLED
+                                or 1/ENABLED, enforcing the change only after the
+                                last boost client has exited.
+          --auto-boost-permission=
+                                Allow non-admin/root control over auto boost mode:
+                                0/UNRESTRICTED, 1/RESTRICTED
+    -mig  --multi-instance-gpu= Enable or disable Multi Instance GPU: 0/DISABLED, 1/ENABLED
+                                Requires root.
+    -gtt  --gpu-target-temp=    Set GPU Target Temperature for a GPU in degree celsius.
+                                Requires administrator privileges
+    -den, --dram-encryption=    Toggle DRAM Encryption support: 0/DISABLED, 1/ENABLED
+                                Requires root.
+           --set-hostname=      Set the hostname associated with the GPU.
+                                Requires root.
+           --get-hostname       Get the hostname associated with the GPU.
+
+   [plus optional]
+
+    -i,   --id=                 Target a specific GPU.
+    -eow, --error-on-warning    Return a non-zero error for warnings.
+
+  UNIT MODIFICATION OPTIONS:
+
+    -t,   --toggle-led=         Set Unit LED state: 0/GREEN, 1/AMBER
+
+   [plus optional]
+
+    -i,   --id=                 Target a specific Unit.
+
+  SHOW DTD OPTIONS:
+
+          --dtd                 Print device DTD and exit.
+
+     [plus optional]
+
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -u,   --unit                Show unit, rather than device, DTD.
+
+    --debug=                    Log encrypted debug information to a specified file. 
+
+ Device Monitoring:
+    dmon                        Displays device stats in scrolling format.
+                                "nvidia-smi dmon -h" for more information.
+
+    daemon                      Runs in background and monitor devices as a daemon process.
+                                This is an experimental feature. Not supported on Windows baremetal
+                                "nvidia-smi daemon -h" for more information.
+
+    replay                      Used to replay/extract the persistent stats generated by daemon.
+                                This is an experimental feature.
+                                "nvidia-smi replay -h" for more information.
+
+ Process Monitoring:
+    pmon                        Displays process stats in scrolling format.
+                                "nvidia-smi pmon -h" for more information.
+
+ TOPOLOGY:
+    topo                        Displays device/system topology. "nvidia-smi topo -h" for more information.
+
+ DRAIN STATES:
+    drain                       Displays/modifies GPU drain states for power idling. "nvidia-smi drain -h" for more information.
+
+ NVLINK:
+    nvlink                      Displays device nvlink information. "nvidia-smi nvlink -h" for more information.
+
+ C2C:
+    c2c                         Displays device C2C information. "nvidia-smi c2c -h" for more information.
+
+ CLOCKS:
+    clocks                      Control and query clock information. "nvidia-smi clocks -h" for more information.
+
+ ENCODER SESSIONS:
+    encodersessions             Displays device encoder sessions information. "nvidia-smi encodersessions -h" for more information.
+
+ FBC SESSIONS:
+    fbcsessions                 Displays device FBC sessions information. "nvidia-smi fbcsessions -h" for more information.
+
+ GRID vGPU:
+    vgpu                        Displays vGPU information. "nvidia-smi vgpu -h" for more information.
+
+ MIG:
+    mig                         Provides controls for MIG management. "nvidia-smi mig -h" for more information.
+
+ COMPUTE POLICY:
+    compute-policy              Control and query compute policies. "nvidia-smi compute-policy -h" for more information. 
+
+ BOOST SLIDER:
+    boost-slider                Control and query boost sliders. "nvidia-smi boost-slider -h" for more information. 
+
+ POWER HINT:
+    power-hint                  Estimates GPU power usage. "nvidia-smi power-hint -h" for more information. 
+
+ BASE CLOCKS:
+    base-clocks                 Query GPU base clocks. "nvidia-smi base-clocks -h" for more information. 
+
+ CONFIDENTIAL COMPUTE:
+    conf-compute                Control and query confidential compute. "nvidia-smi conf-compute -h" for more information. 
+
+ GPU PERFORMANCE MONITORING: 
+    gpm                         Control and query GPU performance monitoring unit. "nvidia-smi gpm -h" for more information. 
+
+ PCI:
+    pci                         Display device PCI information. "nvidia-smi pci -h" for more information.
+
+ Power Smoothing:
+    power-smoothing             Control and query power smoothing information. "nvidia-smi power-smoothing -h" for more information.
+
+ Power Profiles:
+    power-profiles              Control and query workload power profiles information. "nvidia-smi power-profiles -h" for more information.
+
+ RUSD:
+    rusd                         Set RUSD (read only shared data buffer) settings. "nvidia-smi rusd -h" for more information.
+
+ PRM:
+    prm                         Query GPU PRM registers. "nvidia-smi prm -h" for more information.
+
+ SOC:
+    soc                          Query system on chip metrics. "nvidia-smi soc -h" for more information.
+
+Please see the nvidia-smi(1) manual page for more detailed information.
+
+
+################################################################################
+# capabilities :: help-query-gpu
+# $ nvidia-smi --help-query-gpu
+################################################################################
+List of valid properties to query for the switch "--query-gpu":
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"driver_version"
+The version of the installed NVIDIA display driver. This is an alphanumeric string. Deprecated; use "kmd_version" instead.
+
+"kmd_version"
+The version of the installed NVIDIA display driver. This is an alphanumeric string.
+
+Section about vgpu_driver_capability properties
+Retrieves information about driver level caps.
+
+"vgpu_driver_capability.heterogenous_multivGPU"
+Whether heterogeneuos multi-vGPU is supported by driver.
+
+"count"
+The number of NVIDIA GPUs in the system.
+
+"name" or "gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"serial" or "gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"uuid" or "gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"pci.bus_id" or "gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"pci.domain"
+PCI domain number, in hex.
+
+"pci.bus"
+PCI bus number, in hex.
+
+"pci.device"
+PCI device number, in hex.
+
+"pci.baseClass"
+PCI Base Classcode, in hex.
+
+"pci.subClass"
+PCI Sub Classcode, in hex.
+
+"pci.device_id"
+PCI vendor device id, in hex
+
+"pci.sub_device_id"
+PCI Sub System id, in hex
+
+Section about vgpu_device_capability properties
+Retrieves information about device level caps.
+
+"vgpu_device_capability.fractional_multiVgpu"
+Fractional vGPU profiles on this GPU can be used in multi-vGPU configurations.
+
+"vgpu_device_capability.heterogeneous_timeSlice_profile"
+Supports concurrent execution of timesliced vGPU profiles of differing types.
+
+"vgpu_device_capability.heterogeneous_timeSlice_sizes"
+Supports concurrent execution of timesliced vGPU profiles of differing framebuffer sizes.
+
+"vgpu_device_capability.homogeneous_placements"
+Supports reporting of placements of timesliced vGPU profiles of identical framebuffer sizes.
+
+"vgpu_device_capability.mig_timeSlicing"
+Reports whether GPU supports timesliced vGPU on MIG.
+
+"vgpu_device_capability.mig_timeSlicing_mode"
+Reports whether MIG timesliced mode is enabled or not.
+
+"pcie.link.gen.current"
+The current PCI-E link generation. These may be reduced when the GPU is not in use. Deprecated, use pcie.link.gen.gpucurrent instead.
+
+"pcie.link.gen.gpucurrent"
+The current PCI-E link generation. These may be reduced when the GPU is not in use.
+
+"pcie.link.gen.max"
+The maximum PCI-E link generation possible with this GPU and system configuration. For example, if the GPU supports a higher PCIe generation than the system supports then this reports the system PCIe generation.
+
+"pcie.link.gen.gpumax"
+The maximum PCI-E link generation supported by this GPU.
+
+"pcie.link.gen.hostmax"
+The maximum PCI-E link generation supported by the root port corresponding to this GPU.
+
+"pcie.link.width.current"
+The current PCI-E link width. These may be reduced when the GPU is not in use.
+
+"pcie.link.width.max"
+The maximum PCI-E link width possible with this GPU and system configuration. For example, if the GPU supports a higher PCIe generation than the system supports then this reports the system PCIe generation.
+
+"index"
+Zero based index of the GPU. Can change at each boot.
+
+"display_mode"
+Deprecated, do not use.
+
+"display_attached"
+A flag that indicates whether a physical display (e.g. monitor) is currently connected to any of the GPU's connectors. "Yes" indicates an attached display. "No" indicates otherwise.
+
+"display_active"
+A flag that indicates whether a display is initialized on the GPU's (e.g. memory is allocated on the device for display). Display can be active even when no monitor is physically attached. "Enabled" indicates an active display. "Disabled" indicates otherwise.
+
+"persistence_mode"
+A flag that indicates whether persistence mode is enabled for the GPU. Value is either "Enabled" or "Disabled". When persistence mode is enabled the NVIDIA driver remains loaded even when no active clients, such as X11 or nvidia-smi, exist. This minimizes the driver load latency associated with running dependent apps, such as CUDA programs. Linux only.
+
+"addressing_mode"
+A flag that indicates the type of addressing mode enabled for the GPU. Value is either "HMM" or "ATS" or "None". When the mode is HMM, system allocated memory (malloc, mmap) is addressable from the device (GPU), via software-based mirroring of the CPU's page tables, on the GPU. When the mode is ATS, system allocated memory (malloc, mmap) is addressable from the device (GPU), via Address Translation Services. This means that there is (effectively) a single set of page tables, and the CPU and GPU both use them. The mode is None when neither HMM nor ATS is active. Linux only.
+
+"accounting.mode"
+A flag that indicates whether accounting mode is enabled for the GPU. Value is either "Enabled" or "Disabled". When accounting is enabled statistics are calculated for each compute process running on the GPU.Statistics can be queried during the lifetime or after termination of the process.The execution time of process is reported as 0 while the process is in running state and updated to actualexecution time after the process has terminated. See --help-query-accounted-apps for more info.
+
+"accounting.buffer_size"
+The size of the circular buffer that holds list of processes that can be queried for accounting stats. This is the maximum number of processes that accounting information will be stored for before information about oldest processes will get overwritten by information about new processes.
+
+Section about driver_model properties
+On Windows, the TCC, WDDM and MCDM driver models are supported. The driver model can be changed with the (-dm) or (-fdm) flags. The TCC and MCDM driver models are optimized for compute applications. I.E. kernel launch times will be quicker. The WDDM driver model is designed for graphics applications and is not recommended for compute applications. Linux does not support multiple driver models, and will always have the value of "N/A". Only for selected products. Please see feature matrix in NVML documentation.
+
+"driver_model.current"
+The driver model currently in use. Always "N/A" on Linux.
+
+"driver_model.pending"
+The driver model that will be used on the next reboot. Always "N/A" on Linux.
+
+"vbios_version"
+The BIOS of the GPU board.
+
+Section about inforom properties
+Version numbers for each object in the GPU board's inforom storage. The inforom is a small, persistent store of configuration and state data for the GPU. All inforom version fields are numerical. It can be useful to know these version numbers because some GPU features are only available with inforoms of a certain version or higher.
+
+"inforom.img" or "inforom.image"
+Global version of the infoROM image. Image version just like VBIOS version uniquely describes the exact version of the infoROM flashed on the board in contrast to infoROM object version which is only an indicator of supported features.
+
+"inforom.oem"
+Version for the OEM configuration data.
+
+"inforom.ecc"
+Version for the ECC recording data.
+
+"inforom.pwr" or "inforom.power"
+Version for the power management data.
+
+"inforom.checksum_validation"
+Inforom Checksum Validation information.
+
+"gpu_recovery_action"
+GPU recovery action information. Reports the GPU Recovery action recommended to recover from a bad state. 'N/A' indicates that the field is not supported on the current device or device configuration. An error message indicates that retrieving the field failed.
+
+Section about gom properties
+GOM allows to reduce power usage and optimize GPU throughput by disabling GPU features. Each GOM is designed to meet specific user needs.
+In "All On" mode everything is enabled and running at full speed.
+The "Compute" mode is designed for running only compute tasks. Graphics operations are not allowed.
+The "Low Double Precision" mode is designed for running graphics applications that don't require high bandwidth double precision.
+GOM can be changed with the (--gom) flag.
+
+"gom.current" or "gpu_operation_mode.current"
+The GOM currently in use.
+
+"gom.pending" or "gpu_operation_mode.pending"
+The GOM that will be used on the next reboot.
+
+"fan.speed"
+The fan speed value is the percent of the product's maximum noise tolerance fan speed that the device's fan is currently intended to run at. This value may exceed 100% in certain cases. Note: The reported speed is the intended fan speed. If the fan is physically blocked and unable to spin, this output will not match the actual fan speed. Many parts do not report fan speeds because they rely on cooling via fans in the surrounding enclosure.
+
+"pstate"
+The current performance state for the GPU. States range from P0 (maximum performance) to P12 (minimum performance).
+
+Section about clocks_event_reasons properties
+Retrieves information about factors that are reducing the frequency of clocks. If all event reasons are returned as "Not Active" it means that clocks are running as high as possible.
+
+"clocks_event_reasons.supported" or "clocks_throttle_reasons.supported"
+Bitmask of supported clock event reasons. See nvml.h for more details.
+
+"clocks_event_reasons.active" or "clocks_throttle_reasons.active"
+Bitmask of active clock event reasons. See nvml.h for more details.
+
+"clocks_event_reasons.gpu_idle" or "clocks_throttle_reasons.gpu_idle"
+Nothing is running on the GPU and the clocks are dropping to Idle state. This limiter may be removed in a later release.
+
+"clocks_event_reasons.applications_clocks_setting" or "clocks_throttle_reasons.applications_clocks_setting"
+GPU clocks are limited by applications clocks setting. E.g. can be changed by nvidia-smi --applications-clocks=
+
+"clocks_event_reasons.sw_power_cap" or "clocks_throttle_reasons.sw_power_cap"
+SW Power Scaling algorithm is reducing the clocks below requested clocks because the GPU is consuming too much power. E.g. SW power cap limit can be changed with nvidia-smi --power-limit=
+
+"clocks_event_reasons.hw_slowdown" or "clocks_throttle_reasons.hw_slowdown"
+HW Slowdown (reducing the core clocks by a factor of 2 or more) is engaged. This is an indicator of:
+ HW Thermal Slowdown: temperature being too high
+ HW Power Brake Slowdown: External Power Brake Assertion is triggered (e.g. by the system power supply)
+ * Power draw is too high and Fast Trigger protection is reducing the clocks
+ * May be also reported during PState or clock change
+ * This behavior may be removed in a later release
+
+"clocks_event_reasons.hw_thermal_slowdown" or "clocks_throttle_reasons.hw_thermal_slowdown"
+HW Thermal Slowdown (reducing the core clocks by a factor of 2 or more) is engaged. This is an indicator of temperature being too high
+
+"clocks_event_reasons.hw_power_brake_slowdown" or "clocks_throttle_reasons.hw_power_brake_slowdown"
+HW Power Brake Slowdown (reducing the core clocks by a factor of 2 or more) is engaged. This is an indicator of External Power Brake Assertion being triggered (e.g. by the system power supply)
+
+"clocks_event_reasons.sw_thermal_slowdown" or "clocks_throttle_reasons.sw_thermal_slowdown"
+SW Thermal capping algorithm is reducing clocks below requested clocks because GPU temperature is higher than Max Operating Temp.
+
+"clocks_event_reasons.sync_boost" or "clocks_throttle_reasons.sync_boost"
+Sync Boost This GPU has been added to a Sync boost group with nvidia-smi or DCGM in
+ * order to maximize performance per watt. All GPUs in the sync boost group
+ * will boost to the minimum possible clocks across the entire group. Look at
+ * the event reasons for other GPUs in the system to see why those GPUs are
+ * holding this one at lower clocks.
+
+Section about clocks_event_reasons_counters properties
+Retrieves counters in microseconds for events which have reduced the frequency of clocks.
+
+"clocks_event_reasons_counters.sw_power_cap"
+Amount of time SW Power Scaling algorithm has reduced the clocks below requested clocks because the GPU was consuming too much power.
+
+"clocks_event_reasons_counters.sync_boost"
+Amount of time the clock frequency of this GPU was reduced to match the minimum possible clock across the sync boost group.
+
+"clocks_event_reasons_counters.sw_thermal_slowdown"
+Amount of time SW Thermal capping algorithm has reduced clocks below requested clocks because GPU temperature was higher than Max Operating Temp.
+
+"clocks_event_reasons_counters.hw_thermal_slowdown"
+Amount of time HW Thermal Slowdown was engaged, reducing the core clocks by a factor of 2 or more, due to temperature being too high.
+
+"clocks_event_reasons_counters.hw_power_brake_slowdown"
+Amount of time External Power Brake Assertion was triggered (e.g. by the system power supply).
+
+Section about memory properties
+On-board memory information. Reported total memory is affected by ECC state. If ECC is enabled the total available memory is decreased by several percent, due to the requisite parity bits. The driver may also reserve a small amount of memory for internal use, even without active work on the GPU.
+
+"memory.total"
+Total installed GPU memory.
+
+"memory.reserved"
+Total memory reserved by the NVIDIA driver and firmware.
+
+"memory.used"
+Total memory allocated by active contexts.
+
+"memory.free"
+Total free memory.
+
+"compute_mode"
+The compute mode flag indicates whether individual or multiple compute applications may run on the GPU.
+"0: Default" means multiple contexts are allowed per device.
+"1: Exclusive_Thread", deprecated, use Exclusive_Process instead
+"2: Prohibited" means no contexts are allowed per device (no compute apps).
+"3: Exclusive_Process" means only one context is allowed per device, usable from multiple threads at a time.
+
+"compute_cap"
+The CUDA Compute Capability, represented as Major DOT Minor.
+
+Section about utilization properties
+Utilization rates report how busy each GPU is over time, and can be used to determine how much an application is using the GPUs in the system.
+Note: On MIG-enabled GPUs, querying the utilization of encoder, decoder, jpeg, ofa, gpu, and memory is not currently supported.
+
+"utilization.gpu"
+Percent of time over the past sample period during which one or more kernels was executing on the GPU.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.memory"
+Percent of time over the past sample period during which global (device) memory was being read or written.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.encoder"
+Percent of time over the past sample period during which one or more kernels was executing on the Encoder Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.decoder"
+Percent of time over the past sample period during which one or more kernels was executing on the Decoder Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.jpeg"
+Percent of time over the past sample period during which one or more kernels was executing on the Jpeg Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.ofa"
+Percent of time over the past sample period during which one or more kernels was executing on the Optical Flow Accelerator Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+Section about encoder.stats properties
+Encoder stats report number of encoder sessions, average FPS and average latency in us for given GPUs in the system.
+
+"encoder.stats.sessionCount"
+Number of encoder sessions running on the GPU.
+
+"encoder.stats.averageFps"
+Average FPS of all sessions running on the GPU.
+
+"encoder.stats.averageLatency"
+Average latency in microseconds of all sessions running on the GPU.
+
+Section about dramEncryption.mode properties
+A flag that indicates whether DRAM Encryption support is enabled. May be either "Enabled" or "Disabled". Changes to DRAM Encryption mode require a reboot. Requires Inforom DRAM Encryption object version 1.0 or higher.
+
+"dramEncryption.mode.current"
+The DRAM Encryption mode that the GPU is currently operating under.
+
+"dramEncryption.mode.pending"
+The DRAM Encryption mode that the GPU will operate under after the next reboot.
+
+Section about ecc.mode properties
+A flag that indicates whether ECC support is enabled. May be either "Enabled" or "Disabled". Changes to ECC mode require a reboot. Requires Inforom ECC object version 1.0 or higher.
+
+"ecc.mode.current"
+The ECC mode that the GPU is currently operating under.
+
+"ecc.mode.pending"
+The ECC mode that the GPU will operate under after the next reboot.
+
+Section about ecc.errors properties
+NVIDIA GPUs can provide error counts for various types of ECC errors. Some ECC errors are either single or double bit, where single bit errors are corrected and double bit errors are uncorrectable. Texture memory errors may be correctable via resend or uncorrectable if the resend fails. These errors are available across two timescales (volatile and aggregate). Single bit ECC errors are automatically corrected by the HW and do not result in data corruption. Double bit errors are detected but not corrected. Please see the ECC documents on the web for information on compute application behavior when double bit errors occur. Volatile error counters track the number of errors detected since the last driver load. Aggregate error counts persist indefinitely and thus act as a lifetime counter.
+
+"ecc.errors.corrected.volatile.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.volatile.dram"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.volatile.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.corrected.volatile.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.corrected.volatile.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.corrected.volatile.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.corrected.volatile.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.corrected.volatile.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.corrected.volatile.total"
+Total errors detected across entire chip.
+
+"ecc.errors.corrected.aggregate.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.aggregate.dram"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.aggregate.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.corrected.aggregate.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.corrected.aggregate.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.corrected.aggregate.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.corrected.aggregate.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.corrected.aggregate.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.corrected.aggregate.total"
+Total errors detected across entire chip.
+
+"ecc.errors.uncorrected.volatile.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.volatile.dram"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.volatile.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.uncorrected.volatile.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.uncorrected.volatile.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.uncorrected.volatile.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.uncorrected.volatile.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.uncorrected.volatile.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.uncorrected.volatile.total"
+Total errors detected across entire chip.
+
+"ecc.errors.uncorrected.aggregate.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.aggregate.dram"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.aggregate.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.uncorrected.aggregate.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.uncorrected.aggregate.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.uncorrected.aggregate.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.uncorrected.aggregate.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.uncorrected.aggregate.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.uncorrected.aggregate.total"
+Total errors detected across entire chip.
+
+"ecc.errors.uncorrected.volatile.sram.parity"
+Unique volatile parity errors detected in SRAM
+
+"ecc.errors.uncorrected.volatile.sram.secded"
+Unique volatile SEC-DED errors detected in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.parity"
+Unique aggregate parity errors detected in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.secded"
+Unique aggregate SEC-DED errors detected in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.thresholdExceeded"
+Unique aggregate error threshold exceeded flag in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.l2"
+Unique aggregate errors detected in L2 cache
+
+"ecc.errors.uncorrected.aggregate.sram.sm"
+Unique aggregate errors detected in SM
+
+"ecc.errors.uncorrected.aggregate.sram.mcu"
+Unique aggregate errors detected in microcontrollers
+
+"ecc.errors.uncorrected.aggregate.sram.pcie"
+Aggregate errors detected in PCIe
+
+"ecc.errors.uncorrected.aggregate.sram.other"
+Unique aggregate SRAM errors detected not in L2 cache, SM, microcontrollers and PCIe
+
+Section about retired_pages properties
+NVIDIA GPUs can retire pages of GPU device memory when they become unreliable. This can happen when multiple single bit ECC errors occur for the same page, or on a double bit ECC error. When a page is retired, the NVIDIA driver will hide it such that no driver, or application memory allocations can access it.
+
+"retired_pages.single_bit_ecc.count" or "retired_pages.sbe"
+The number of GPU device memory pages that have been retired due to multiple single bit ECC errors.
+
+"retired_pages.double_bit.count" or "retired_pages.dbe"
+The number of GPU device memory pages that have been retired due to a double bit ECC error.
+
+"retired_pages.pending"
+Checks if any GPU device memory pages are pending retirement on the next reboot. Pages that are pending retirement can still be allocated, and may cause further reliability issues.
+
+Section about remapped_rows properties
+NVIDIA GPUs can remap bank rows of GPU device memory when they become unreliable. This can happen when multiple single bit ECC errors occur for the same row, or on a double bit ECC error. When a pending row remapping happens, GPU reset is required to complete row remapping.
+
+"remapped_rows.correctable" or "remapped_rows.sbe"
+The number of rows that have been remapped due to multiple single bit ECC errors.
+
+"remapped_rows.correctable_inactive"
+The number of rows that have been remapped due to multiple single bit ECC errors but are inactive.
+
+"remapped_rows.uncorrectable" or "remapped_rows.dbe"
+The number of rows that have been remapped due to a double bit ECC error.
+
+"remapped_rows.uncorrectable_inactive"
+The number of rows that have been remapped due to a double bit ECC error but are inactive.
+
+"remapped_rows.pending"
+Checks if any row remapping are pending on the next reboot.
+
+"remapped_rows.failure"
+Checks if any row remapping failure happens in the GPU lifespan.
+
+Section about remapped_rows.histogram properties
+The histogram of bank remap availability.
+
+"remapped_rows.histogram.max"
+The number of banks with full remap availability.
+
+"remapped_rows.histogram.high"
+The number of banks with high remap availability.
+
+"remapped_rows.histogram.partial"
+The number of banks with partial remap availability.
+
+"remapped_rows.histogram.low"
+The number of banks with low remap availability.
+
+"remapped_rows.histogram.none"
+The number of banks without remap availability.
+
+"temperature.gpu"
+ Core GPU temperature. in degrees C.
+
+"temperature.gpu.tlimit"
+ GPU T.Limit temperature. in degrees C.
+
+"temperature.memory"
+ HBM memory temperature. in degrees C.
+
+"power.management"
+A flag that indicates whether power management is enabled. Either "Supported" or "[Not Supported]". Requires Inforom PWR object version 3.0 or higher or Kepler device.
+
+"power.draw"
+The last measured power draw for the entire board, in watts. On Ampere or newer devices, returns average power draw over 1 sec. On older devices, returns instantaneous power draw. Only available if power management is supported. This reading is accurate to within +/- 5 watts.
+
+"power.draw.average" or "gpu.power.draw.average"
+The last measured average power draw for the entire board, in watts. Only available if power management is supported and Ampere (except GA100) or newer devices. This reading is accurate to within +/- 5 watts.
+
+"power.draw.instant" or "gpu.power.draw.instant"
+The last measured instant power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts.
+
+"power.limit" or "gpu.power.requested_limit"
+The software power limit in watts. Set by software like nvidia-smi. On Kepler devices Power Limit can be adjusted using [-pl | --power-limit=] switches.
+
+"enforced.power.limit" or "gpu.power.current_limit"
+The power management algorithm's power ceiling, in watts. Total board power draw is manipulated by the power management algorithm such that it stays under this value. This value is the minimum of various power limiters.
+
+"power.default_limit" or "gpu.power.default_limit"
+The default power management algorithm's power ceiling, in watts. Power Limit will be set back to Default Power Limit after driver unload.
+
+"power.min_limit" or "gpu.power.min_limit"
+The minimum value in watts that power limit can be set to.
+
+"power.max_limit" or "gpu.power.max_limit"
+The maximum value in watts that power limit can be set to.
+
+"module.power.draw.average"
+The last measured average power draw for the entire module, in watts. This reading is accurate to within +/- 5 watts.
+
+"module.power.draw.instant"
+The last measured instant power draw for the entire module, in watts. This reading is accurate to within +/- 5 watts.
+
+"module.power.limit" or "module.power.requested_limit"
+The software power limit in watts for the entire module.
+
+"module.enforced.power.limit" or "module.power.current_limit"
+The power management algorithm's power ceiling for the entire module, in watts. This value is the minimum of various power limiters.
+
+"module.power.default_limit"
+The default power management algorithm's power ceiling for the entire module, in watts. Power Limit will be set back to Default Power Limit after driver unload.
+
+"module.power.min_limit"
+The minimum value in watts that module power limit can be set to.
+
+"module.power.max_limit"
+The maximum value in watts that module power limit can be set to.
+
+"edpp_multiplier"
+The EDPp multiplier expressed as a percentage.
+
+"clocks.current.graphics" or "clocks.gr"
+Current frequency of graphics (shader) clock.
+
+"clocks.current.sm" or "clocks.sm"
+Current frequency of SM (Streaming Multiprocessor) clock.
+
+"clocks.current.memory" or "clocks.mem"
+Current frequency of memory clock.
+
+"clocks.current.video" or "clocks.video"
+Current frequency of video encoder/decoder clock.
+
+Section about clocks.applications properties
+User specified frequency at which applications will be running at. Can be changed with [-ac | --applications-clocks] switches.
+
+"clocks.applications.graphics" or "clocks.applications.gr"
+User specified frequency of graphics (shader) clock.
+
+"clocks.applications.memory" or "clocks.applications.mem"
+User specified frequency of memory clock.
+
+Section about clocks.default_applications properties
+Default frequency at which applications will be running at. Application clocks can be changed with [-ac | --applications-clocks] switches. Application clocks can be set to default using [-rac | --reset-applications-clocks] switches.
+
+"clocks.default_applications.graphics" or "clocks.default_applications.gr"
+Default frequency of applications graphics (shader) clock.
+
+"clocks.default_applications.memory" or "clocks.default_applications.mem"
+Default frequency of applications memory clock.
+
+Section about clocks.max properties
+Maximum frequency at which parts of the GPU are design to run.
+
+"clocks.max.graphics" or "clocks.max.gr"
+Maximum frequency of graphics (shader) clock.
+
+"clocks.max.sm" or "clocks.max.sm"
+Maximum frequency of SM (Streaming Multiprocessor) clock.
+
+"clocks.max.memory" or "clocks.max.mem"
+Maximum frequency of memory clock.
+
+Section about mig.mode properties
+A flag that indicates whether MIG mode is enabled. May be either "Enabled" or "Disabled". Changes to MIG mode require a GPU reset.
+
+"mig.mode.current"
+The MIG mode that the GPU is currently operating under.
+
+"mig.mode.pending"
+The MIG mode that the GPU will operate under after reset.
+
+Section about gsp.mode properties
+A flag that indicates whether GSP firmware is enabled.May be either "Enabled" or "Disabled".
+
+"gsp.mode.current"
+The current status of GSP firmware.
+
+"gsp.mode.default"
+The default status of GSP firmware.
+
+"c2c.mode"
+A flag the indicates whether the device is in C2C mode, if supported.May be either "Enabled" or "Disabled".
+
+Section about protected_memory properties
+On-board protected memory information.
+
+"protected_memory.total"
+Total installed GPU conf compute protected memory.
+
+"protected_memory.used"
+Total conf compute protected memory allocated by active contexts.
+
+"protected_memory.free"
+Total free conf compute protected memory.
+
+"fabric.state"
+Current state of GPU fabric registration process.
+
+"fabric.status"
+Error status, valid only if gpu fabric registration state is "completed"
+
+"fabric.cliqueId"
+ID of the fabric clique to which this GPU belongs
+
+"fabric.clusterUuid"
+Uuid of the cluster to which this GPU belongs
+
+"fabric.health.summary"
+Fabric Health summary
+
+"fabric.health.bandwidth"
+Fabric Degraded bandwidth
+
+"fabric.health.route_recovery_in_progress"
+Fabric Route Recovery
+
+"fabric.health.route_unhealthy"
+Fabric Route Unhealthy
+
+"fabric.health.access_timeout_recovery"
+Fabric Access Timeout Recovery
+
+"fabric.health.incorrect_configuration"
+Fabric Incorrect Configuration
+
+"fabric.health.partition_assigned"
+Fabric Partition Assigned
+
+Section about platform properties
+Platform Information.
+
+"platform.chassis_serial_number"
+Serial number of the chassis containing this GPU.
+
+"platform.slot_number"
+The slot number in the chassis containing this GPU (includes switches).
+
+"platform.tray_index"
+The tray index within the compute slots in the chassis containing this GPU (does not include switches).
+
+"platform.host_id"
+Index of the node within the slot containing this GPU.
+
+"platform.peer_type"
+Platform indicated NVLink-peer type (e.g. switch present or not).
+
+"platform.module_id"
+ID of this GPU within the node.
+
+"platform.gpu_fabric_guid"
+Fabric ID for this GPU.
+
+"hostname"
+Hostname associated with the GPU.
+
+
+
+################################################################################
+# capabilities :: help-query-compute-apps
+# $ nvidia-smi --help-query-compute-apps
+################################################################################
+List of valid properties to query for the switch "--query-compute-apps":
+
+Section about Active Compute Processes properties
+List of processes having compute context on the device.
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"pid"
+Process ID of the compute application
+
+"process_name" or "name"
+Process Name
+
+"used_gpu_memory" or "used_memory"
+Amount memory used on the device by the context. Not available on Windows when running in WDDM mode because Windows KMD manages all the memory not NVIDIA driver.
+
+
+
+################################################################################
+# capabilities :: help-query-accounted-apps
+# $ nvidia-smi --help-query-accounted-apps
+################################################################################
+List of valid properties to query for the switch "--query-accounted-apps":
+
+Section about Accounted Graphics/Compute Processes properties
+List of accounted processes having had a graphics/compute context on the device.
+
+Format options and one or more properties to be queried need to be provided as comma separated values for this switch.
+For example:
+nvidia-smi --query-accounted-apps=gpu_name,pid,time,gpu_util,mem_util,max_memory_usage --format=csv
+
+List of properties that can be queried are:
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"vgpu_instance"
+vGPU instance
+
+"pid"
+Process ID of the compute application
+
+"gpu_utilization" or "gpu_util"
+GPU Utilization
+
+"mem_utilization" or "mem_util"
+Percentage of GPU memory utilized on the device by the context.
+
+"max_memory_usage"
+Maximum amount memory used on the device by the context.
+
+"time"
+Amount of time in ms during which the compute context was active.
+
+
+
+################################################################################
+# capabilities :: help-query-retired-pages
+# $ nvidia-smi --help-query-retired-pages
+################################################################################
+List of valid properties to query for the switch "--query-retired-pages":
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"retired_pages.address"
+Address of a retired page. Address might be different when ECC is Enabled or Disabled.
+
+"retired_pages.timestamp"
+Timestamp at which the page was retired.
+
+"retired_pages.cause"
+Reason that describes why the page was retired. Can take one of two values: 
+ - Double Bit ECC - The number of GPU device memory pages that have been retired due to a double bit ECC error.
+ - Single Bit ECC - The number of GPU device memory pages that have been retired due to multiple single bit ECC errors.
+
+
+
+################################################################################
+# capabilities :: list (-L)
+# $ nvidia-smi -L
+################################################################################
+GPU 0: NVIDIA GeForce RTX 4080 SUPER (UUID: GPU-00000000-0000-0000-0000-000000000000)
+
+
+################################################################################
+# capabilities :: topo -m
+# $ nvidia-smi topo -m
+################################################################################
+	[4mGPU0	CPU Affinity	NUMA Affinity	GPU NUMA ID[0m
+GPU0	 X 	0-15	0		N/A
+
+Legend:
+
+  X    = Self
+  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
+  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
+  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
+  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
+  PIX  = Connection traversing at most a single PCIe bridge
+  NV#  = Connection traversing a bonded set of # NVLinks
+
+
+################################################################################
+# capabilities :: nvlink -s
+# $ nvidia-smi nvlink -s
+################################################################################
+GPU 0: NVIDIA GeForce RTX 4080 SUPER (UUID: GPU-00000000-0000-0000-0000-000000000000)
+Device does not have or support Nvlink
+
+
+################################################################################
+# capabilities :: query-gpu field list (derived, used for query-gpu above)
+################################################################################
+timestamp
+driver_version
+kmd_version
+vgpu_driver_capability.heterogenous_multivGPU
+count
+name
+serial
+uuid
+pci.bus_id
+pci.domain
+pci.bus
+pci.device
+pci.baseClass
+pci.subClass
+pci.device_id
+pci.sub_device_id
+vgpu_device_capability.fractional_multiVgpu
+vgpu_device_capability.heterogeneous_timeSlice_profile
+vgpu_device_capability.heterogeneous_timeSlice_sizes
+vgpu_device_capability.homogeneous_placements
+vgpu_device_capability.mig_timeSlicing
+vgpu_device_capability.mig_timeSlicing_mode
+pcie.link.gen.current
+pcie.link.gen.gpucurrent
+pcie.link.gen.max
+pcie.link.gen.gpumax
+pcie.link.gen.hostmax
+pcie.link.width.current
+pcie.link.width.max
+index
+display_mode
+display_attached
+display_active
+persistence_mode
+addressing_mode
+accounting.mode
+accounting.buffer_size
+driver_model.current
+driver_model.pending
+vbios_version
+inforom.img
+inforom.oem
+inforom.ecc
+inforom.pwr
+inforom.checksum_validation
+gpu_recovery_action
+gom.current
+gom.pending
+fan.speed
+pstate
+clocks_event_reasons.supported
+clocks_event_reasons.active
+clocks_event_reasons.gpu_idle
+clocks_event_reasons.applications_clocks_setting
+clocks_event_reasons.sw_power_cap
+clocks_event_reasons.hw_slowdown
+clocks_event_reasons.hw_thermal_slowdown
+clocks_event_reasons.hw_power_brake_slowdown
+clocks_event_reasons.sw_thermal_slowdown
+clocks_event_reasons.sync_boost
+clocks_event_reasons_counters.sw_power_cap
+clocks_event_reasons_counters.sync_boost
+clocks_event_reasons_counters.sw_thermal_slowdown
+clocks_event_reasons_counters.hw_thermal_slowdown
+clocks_event_reasons_counters.hw_power_brake_slowdown
+memory.total
+memory.reserved
+memory.used
+memory.free
+compute_mode
+compute_cap
+utilization.gpu
+utilization.memory
+utilization.encoder
+utilization.decoder
+utilization.jpeg
+utilization.ofa
+encoder.stats.sessionCount
+encoder.stats.averageFps
+encoder.stats.averageLatency
+dramEncryption.mode.current
+dramEncryption.mode.pending
+ecc.mode.current
+ecc.mode.pending
+ecc.errors.corrected.volatile.device_memory
+ecc.errors.corrected.volatile.dram
+ecc.errors.corrected.volatile.register_file
+ecc.errors.corrected.volatile.l1_cache
+ecc.errors.corrected.volatile.l2_cache
+ecc.errors.corrected.volatile.texture_memory
+ecc.errors.corrected.volatile.cbu
+ecc.errors.corrected.volatile.sram
+ecc.errors.corrected.volatile.total
+ecc.errors.corrected.aggregate.device_memory
+ecc.errors.corrected.aggregate.dram
+ecc.errors.corrected.aggregate.register_file
+ecc.errors.corrected.aggregate.l1_cache
+ecc.errors.corrected.aggregate.l2_cache
+ecc.errors.corrected.aggregate.texture_memory
+ecc.errors.corrected.aggregate.cbu
+ecc.errors.corrected.aggregate.sram
+ecc.errors.corrected.aggregate.total
+ecc.errors.uncorrected.volatile.device_memory
+ecc.errors.uncorrected.volatile.dram
+ecc.errors.uncorrected.volatile.register_file
+ecc.errors.uncorrected.volatile.l1_cache
+ecc.errors.uncorrected.volatile.l2_cache
+ecc.errors.uncorrected.volatile.texture_memory
+ecc.errors.uncorrected.volatile.cbu
+ecc.errors.uncorrected.volatile.sram
+ecc.errors.uncorrected.volatile.total
+ecc.errors.uncorrected.aggregate.device_memory
+ecc.errors.uncorrected.aggregate.dram
+ecc.errors.uncorrected.aggregate.register_file
+ecc.errors.uncorrected.aggregate.l1_cache
+ecc.errors.uncorrected.aggregate.l2_cache
+ecc.errors.uncorrected.aggregate.texture_memory
+ecc.errors.uncorrected.aggregate.cbu
+ecc.errors.uncorrected.aggregate.sram
+ecc.errors.uncorrected.aggregate.total
+ecc.errors.uncorrected.volatile.sram.parity
+ecc.errors.uncorrected.volatile.sram.secded
+ecc.errors.uncorrected.aggregate.sram.parity
+ecc.errors.uncorrected.aggregate.sram.secded
+ecc.errors.uncorrected.aggregate.sram.thresholdExceeded
+ecc.errors.uncorrected.aggregate.sram.l2
+ecc.errors.uncorrected.aggregate.sram.sm
+ecc.errors.uncorrected.aggregate.sram.mcu
+ecc.errors.uncorrected.aggregate.sram.pcie
+ecc.errors.uncorrected.aggregate.sram.other
+retired_pages.single_bit_ecc.count
+retired_pages.double_bit.count
+retired_pages.pending
+remapped_rows.correctable
+remapped_rows.correctable_inactive
+remapped_rows.uncorrectable
+remapped_rows.uncorrectable_inactive
+remapped_rows.pending
+remapped_rows.failure
+remapped_rows.histogram.max
+remapped_rows.histogram.high
+remapped_rows.histogram.partial
+remapped_rows.histogram.low
+remapped_rows.histogram.none
+temperature.gpu
+temperature.gpu.tlimit
+temperature.memory
+power.management
+power.draw
+power.draw.average
+power.draw.instant
+power.limit
+enforced.power.limit
+power.default_limit
+power.min_limit
+power.max_limit
+module.power.draw.average
+module.power.draw.instant
+module.power.limit
+module.enforced.power.limit
+module.power.default_limit
+module.power.min_limit
+module.power.max_limit
+edpp_multiplier
+clocks.current.graphics
+clocks.current.sm
+clocks.current.memory
+clocks.current.video
+clocks.applications.graphics
+clocks.applications.memory
+clocks.default_applications.graphics
+clocks.default_applications.memory
+clocks.max.graphics
+clocks.max.sm
+clocks.max.memory
+mig.mode.current
+mig.mode.pending
+gsp.mode.current
+gsp.mode.default
+c2c.mode
+protected_memory.total
+protected_memory.used
+protected_memory.free
+fabric.state
+fabric.status
+fabric.cliqueId
+fabric.clusterUuid
+fabric.health.summary
+fabric.health.bandwidth
+fabric.health.route_recovery_in_progress
+fabric.health.route_unhealthy
+fabric.health.access_timeout_recovery
+fabric.health.incorrect_configuration
+fabric.health.partition_assigned
+platform.chassis_serial_number
+platform.slot_number
+platform.tray_index
+platform.host_id
+platform.peer_type
+platform.module_id
+platform.gpu_fabric_guid
+hostname
+
+
+################################################################################
+# idle :: nvidia-smi (default table)
+# $ nvidia-smi 
+################################################################################
+Fri Jun 26 11:59:44 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 595.71.05              Driver Version: 595.71.05      CUDA Version: 13.2     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 4080 ...    Off |   00000000:01:00.0  On |                  N/A |
+|  0%   43C    P8             25W /  320W |     596MiB /  16376MiB |      0%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            2165    C+G   /usr/bin/kwin_wayland                    25MiB |
+|    0   N/A  N/A            2496      G   /usr/bin/plasma-keyboard                200MiB |
+|    0   N/A  N/A            2620      G   /usr/bin/Xwayland                         4MiB |
+|    0   N/A  N/A            2954      G   /usr/bin/plasmashell                    120MiB |
+|    0   N/A  N/A            3527      G   /usr/bin/xwaylandvideobridge              3MiB |
++-----------------------------------------------------------------------------------------+
+
+
+################################################################################
+# idle :: query (-q)
+# $ nvidia-smi -q
+################################################################################
+
+==============NVSMI LOG==============
+
+Timestamp                                              : Fri Jun 26 11:59:44 2026
+Driver Version                                         : 595.71.05
+CUDA Version                                           : 13.2
+
+Attached GPUs                                          : 1
+GPU 00000000:01:00.0
+    Product Name                                       : NVIDIA GeForce RTX 4080 SUPER
+    Product Brand                                      : GeForce
+    Product Architecture                               : Ada Lovelace
+    Display Mode                                       : Requested functionality has been deprecated
+    Display Attached                                   : Yes
+    Display Active                                     : Enabled
+    Persistence Mode                                   : Disabled
+    Addressing Mode                                    : HMM
+    MIG Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    Accounting Mode                                    : Disabled
+    Accounting Mode Buffer Size                        : 4000
+    Driver Model
+        Current                                        : N/A
+        Pending                                        : N/A
+    Serial Number                                      : N/A
+    GPU UUID                                           : GPU-00000000-0000-0000-0000-000000000000
+    GPU PDI                                            : 0x427f47bdf3c96203
+    Minor Number                                       : 0
+    VBIOS Version                                      : 95.03.44.00.B2
+    MultiGPU Board                                     : No
+    Board ID                                           : 0x100
+    Board Part Number                                  : N/A
+    GPU Part Number                                    : 2702-400-A1
+    FRU Part Number                                    : N/A
+    Platform Info
+        Chassis Serial Number                          : N/A
+        Slot Number                                    : N/A
+        Tray Index                                     : N/A
+        Host ID                                        : N/A
+        Peer Type                                      : N/A
+        Module Id                                      : 1
+        GPU Fabric GUID                                : N/A
+    Inforom Version
+        Image Version                                  : G002.0000.00.03
+        OEM Object                                     : 2.0
+        ECC Object                                     : N/A
+        Power Management Object                        : N/A
+    Inforom BBX Object Flush
+        Latest Timestamp                               : N/A
+        Latest Duration                                : N/A
+    GPU Operation Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    GPU C2C Mode                                       : N/A
+    GPU Virtualization Mode
+        Virtualization Mode                            : None
+        Host VGPU Mode                                 : N/A
+        vGPU Heterogeneous Mode                        : N/A
+    GPU Recovery Action                                : None
+    GSP Firmware Version                               : 595.71.05
+    IBMNPU
+        Relaxed Ordering Mode                          : N/A
+    PCI
+        Bus                                            : 0x01
+        Device                                         : 0x00
+        Domain                                         : 0x0000
+        Base Classcode                                 : 0x3
+        Sub Classcode                                  : 0x0
+        Device Id                                      : 0x270210DE
+        Bus Id                                         : 00000000:01:00.0
+        Sub System Id                                  : 0x51101462
+        GPU Link Info
+            PCIe Generation
+                Max                                    : 4
+                Current                                : 1
+                Device Current                         : 1
+                Device Max                             : 4
+                Host Max                               : 5
+            Link Width
+                Max                                    : 16x
+                Current                                : 16x
+        Bridge Chip
+            Type                                       : N/A
+            Firmware                                   : N/A
+        Replays Since Reset                            : 0
+        Replay Number Rollovers                        : 0
+        Tx Throughput                                  : 488 KB/s
+        Rx Throughput                                  : 537 KB/s
+        Atomic Caps Outbound                           : N/A
+        Atomic Caps Inbound                            : N/A
+    Fan Speed                                          : 0 %
+    Performance State                                  : P8
+    Clocks Event Reasons
+        Idle                                           : Active
+        Applications Clocks Setting                    : Not Active
+        SW Power Cap                                   : Not Active
+        HW Slowdown                                    : Not Active
+            HW Thermal Slowdown                        : Not Active
+            HW Power Brake Slowdown                    : Not Active
+        Sync Boost                                     : Not Active
+        SW Thermal Slowdown                            : Not Active
+        Display Clock Setting                          : Not Active
+    Clocks Event Reasons Counters
+        SW Power Capping                               : 0 us
+        Sync Boost                                     : 0 us
+        SW Thermal Slowdown                            : 0 us
+        HW Thermal Slowdown                            : 0 us
+        HW Power Braking                               : 0 us
+    Sparse Operation Mode                              : N/A
+    FB Memory Usage
+        Total                                          : 16376 MiB
+        Reserved                                       : 434 MiB
+        Used                                           : 596 MiB
+        Free                                           : 15348 MiB
+    BAR1 Memory Usage
+        Total                                          : 16384 MiB
+        Used                                           : 30 MiB
+        Free                                           : 16354 MiB
+    Conf Compute Protected Memory Usage
+        Total                                          : 0 MiB
+        Used                                           : 0 MiB
+        Free                                           : 0 MiB
+    Compute Mode                                       : Default
+    Utilization
+        GPU                                            : 0 %
+        Memory                                         : 23 %
+        Encoder                                        : 0 %
+        Decoder                                        : 0 %
+        JPEG                                           : 0 %
+        OFA                                            : 0 %
+    Encoder Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    FBC Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    DRAM Encryption Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    ECC Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    ECC Errors
+        Volatile
+            SRAM Correctable                           : N/A
+            SRAM Uncorrectable Parity                  : N/A
+            SRAM Uncorrectable SEC-DED                 : N/A
+            DRAM Correctable                           : N/A
+            DRAM Uncorrectable                         : N/A
+        Aggregate
+            SRAM Correctable                           : N/A
+            SRAM Uncorrectable Parity                  : N/A
+            SRAM Uncorrectable SEC-DED                 : N/A
+            DRAM Correctable                           : N/A
+            DRAM Uncorrectable                         : N/A
+            SRAM Threshold Exceeded                    : N/A
+        Aggregate Uncorrectable SRAM Sources
+            SRAM L2                                    : N/A
+            SRAM SM                                    : N/A
+            SRAM Microcontroller                       : N/A
+            SRAM PCIE                                  : N/A
+            SRAM Other                                 : N/A
+        Channel Repair Pending                         : No
+        TPC Repair Pending                             : No
+        Unrepairable Memory                            : N/A
+    Retired Pages
+        Single Bit ECC                                 : N/A
+        Double Bit ECC                                 : N/A
+        Pending Page Blacklist                         : N/A
+    Remapped Rows                                      : N/A
+    Temperature
+        GPU Current Temp                               : 43 C
+        GPU T.Limit Temp                               : N/A
+        GPU Shutdown Temp                              : 101 C
+        GPU Slowdown Temp                              : 96 C
+        GPU Max Operating Temp                         : 90 C
+        GPU Target Temperature                         : 84 C
+        Memory Current Temp                            : N/A
+        Memory Max Operating Temp                      : N/A
+    GPU Power Readings
+        Average Power Draw                             : 25.92 W
+        Instantaneous Power Draw                       : 27.74 W
+        Current Power Limit                            : 320.00 W
+        Requested Power Limit                          : 320.00 W
+        Default Power Limit                            : 320.00 W
+        Min Power Limit                                : 150.00 W
+        Max Power Limit                                : 400.00 W
+    GPU Memory Power Readings 
+        Average Power Draw                             : N/A
+        Instantaneous Power Draw                       : N/A
+    Module Power Readings
+        Average Power Draw                             : N/A
+        Instantaneous Power Draw                       : N/A
+        Current Power Limit                            : N/A
+        Requested Power Limit                          : N/A
+        Default Power Limit                            : N/A
+        Min Power Limit                                : N/A
+        Max Power Limit                                : N/A
+    Power Smoothing                                    : N/A
+    Workload Power Profiles
+        Requested Profiles                             : N/A
+        Enforced Profiles                              : N/A
+    EDPp Multiplier                                    : N/A
+    Clocks
+        Graphics                                       : 210 MHz
+        SM                                             : 210 MHz
+        Memory                                         : 405 MHz
+        Video                                          : 1185 MHz
+    Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Default Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Deferred Clocks
+        Memory                                         : N/A
+    Max Clocks
+        Graphics                                       : 3165 MHz
+        SM                                             : 3165 MHz
+        Memory                                         : 11501 MHz
+        Video                                          : 2415 MHz
+    Max Customer Boost Clocks
+        Graphics                                       : N/A
+    Clock Policy
+        Auto Boost                                     : N/A
+        Auto Boost Default                             : N/A
+    Fabric
+        State                                          : N/A
+        Status                                         : N/A
+        CliqueId                                       : N/A
+        ClusterUUID                                    : N/A
+        Health
+            Summary                                    : N/A
+            Bandwidth                                  : N/A
+            Route Recovery in progress                 : N/A
+            Route Unhealthy                            : N/A
+            Access Timeout Recovery                    : N/A
+            Incorrect Configuration                    : N/A
+            Partition Assigned                         : N/A
+    Processes
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2165
+            Type                          : C+G
+            Name                          : /usr/bin/kwin_wayland
+            Used GPU Memory               : 25 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2496
+            Type                          : G
+            Name                          : /usr/bin/plasma-keyboard
+            Used GPU Memory               : 200 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2620
+            Type                          : G
+            Name                          : /usr/bin/Xwayland
+            Used GPU Memory               : 4 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2954
+            Type                          : G
+            Name                          : /usr/bin/plasmashell
+            Used GPU Memory               : 120 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 3527
+            Type                          : G
+            Name                          : /usr/bin/xwaylandvideobridge
+            Used GPU Memory               : 3 MiB
+    Capabilities
+        EGM                                            : disabled
+
+
+
+################################################################################
+# idle :: query-gpu (csv, what the exporter parses)
+# $ nvidia-smi --query-gpu=timestamp,driver_version,kmd_version,vgpu_driver_capability.heterogenous_multivGPU,count,name,serial,uuid,pci.bus_id,pci.domain,pci.bus,pci.device,pci.baseClass,pci.subClass,pci.device_id,pci.sub_device_id,vgpu_device_capability.fractional_multiVgpu,vgpu_device_capability.heterogeneous_timeSlice_profile,vgpu_device_capability.heterogeneous_timeSlice_sizes,vgpu_device_capability.homogeneous_placements,vgpu_device_capability.mig_timeSlicing,vgpu_device_capability.mig_timeSlicing_mode,pcie.link.gen.current,pcie.link.gen.gpucurrent,pcie.link.gen.max,pcie.link.gen.gpumax,pcie.link.gen.hostmax,pcie.link.width.current,pcie.link.width.max,index,display_mode,display_attached,display_active,persistence_mode,addressing_mode,accounting.mode,accounting.buffer_size,driver_model.current,driver_model.pending,vbios_version,inforom.img,inforom.oem,inforom.ecc,inforom.pwr,inforom.checksum_validation,gpu_recovery_action,gom.current,gom.pending,fan.speed,pstate,clocks_event_reasons.supported,clocks_event_reasons.active,clocks_event_reasons.gpu_idle,clocks_event_reasons.applications_clocks_setting,clocks_event_reasons.sw_power_cap,clocks_event_reasons.hw_slowdown,clocks_event_reasons.hw_thermal_slowdown,clocks_event_reasons.hw_power_brake_slowdown,clocks_event_reasons.sw_thermal_slowdown,clocks_event_reasons.sync_boost,clocks_event_reasons_counters.sw_power_cap,clocks_event_reasons_counters.sync_boost,clocks_event_reasons_counters.sw_thermal_slowdown,clocks_event_reasons_counters.hw_thermal_slowdown,clocks_event_reasons_counters.hw_power_brake_slowdown,memory.total,memory.reserved,memory.used,memory.free,compute_mode,compute_cap,utilization.gpu,utilization.memory,utilization.encoder,utilization.decoder,utilization.jpeg,utilization.ofa,encoder.stats.sessionCount,encoder.stats.averageFps,encoder.stats.averageLatency,dramEncryption.mode.current,dramEncryption.mode.pending,ecc.mode.current,ecc.mode.pending,ecc.errors.corrected.volatile.device_memory,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.volatile.register_file,ecc.errors.corrected.volatile.l1_cache,ecc.errors.corrected.volatile.l2_cache,ecc.errors.corrected.volatile.texture_memory,ecc.errors.corrected.volatile.cbu,ecc.errors.corrected.volatile.sram,ecc.errors.corrected.volatile.total,ecc.errors.corrected.aggregate.device_memory,ecc.errors.corrected.aggregate.dram,ecc.errors.corrected.aggregate.register_file,ecc.errors.corrected.aggregate.l1_cache,ecc.errors.corrected.aggregate.l2_cache,ecc.errors.corrected.aggregate.texture_memory,ecc.errors.corrected.aggregate.cbu,ecc.errors.corrected.aggregate.sram,ecc.errors.corrected.aggregate.total,ecc.errors.uncorrected.volatile.device_memory,ecc.errors.uncorrected.volatile.dram,ecc.errors.uncorrected.volatile.register_file,ecc.errors.uncorrected.volatile.l1_cache,ecc.errors.uncorrected.volatile.l2_cache,ecc.errors.uncorrected.volatile.texture_memory,ecc.errors.uncorrected.volatile.cbu,ecc.errors.uncorrected.volatile.sram,ecc.errors.uncorrected.volatile.total,ecc.errors.uncorrected.aggregate.device_memory,ecc.errors.uncorrected.aggregate.dram,ecc.errors.uncorrected.aggregate.register_file,ecc.errors.uncorrected.aggregate.l1_cache,ecc.errors.uncorrected.aggregate.l2_cache,ecc.errors.uncorrected.aggregate.texture_memory,ecc.errors.uncorrected.aggregate.cbu,ecc.errors.uncorrected.aggregate.sram,ecc.errors.uncorrected.aggregate.total,ecc.errors.uncorrected.volatile.sram.parity,ecc.errors.uncorrected.volatile.sram.secded,ecc.errors.uncorrected.aggregate.sram.parity,ecc.errors.uncorrected.aggregate.sram.secded,ecc.errors.uncorrected.aggregate.sram.thresholdExceeded,ecc.errors.uncorrected.aggregate.sram.l2,ecc.errors.uncorrected.aggregate.sram.sm,ecc.errors.uncorrected.aggregate.sram.mcu,ecc.errors.uncorrected.aggregate.sram.pcie,ecc.errors.uncorrected.aggregate.sram.other,retired_pages.single_bit_ecc.count,retired_pages.double_bit.count,retired_pages.pending,remapped_rows.correctable,remapped_rows.correctable_inactive,remapped_rows.uncorrectable,remapped_rows.uncorrectable_inactive,remapped_rows.pending,remapped_rows.failure,remapped_rows.histogram.max,remapped_rows.histogram.high,remapped_rows.histogram.partial,remapped_rows.histogram.low,remapped_rows.histogram.none,temperature.gpu,temperature.gpu.tlimit,temperature.memory,power.management,power.draw,power.draw.average,power.draw.instant,power.limit,enforced.power.limit,power.default_limit,power.min_limit,power.max_limit,module.power.draw.average,module.power.draw.instant,module.power.limit,module.enforced.power.limit,module.power.default_limit,module.power.min_limit,module.power.max_limit,edpp_multiplier,clocks.current.graphics,clocks.current.sm,clocks.current.memory,clocks.current.video,clocks.applications.graphics,clocks.applications.memory,clocks.default_applications.graphics,clocks.default_applications.memory,clocks.max.graphics,clocks.max.sm,clocks.max.memory,mig.mode.current,mig.mode.pending,gsp.mode.current,gsp.mode.default,c2c.mode,protected_memory.total,protected_memory.used,protected_memory.free,fabric.state,fabric.status,fabric.cliqueId,fabric.clusterUuid,fabric.health.summary,fabric.health.bandwidth,fabric.health.route_recovery_in_progress,fabric.health.route_unhealthy,fabric.health.access_timeout_recovery,fabric.health.incorrect_configuration,fabric.health.partition_assigned,platform.chassis_serial_number,platform.slot_number,platform.tray_index,platform.host_id,platform.peer_type,platform.module_id,platform.gpu_fabric_guid,hostname --format=csv
+################################################################################
+timestamp, driver_version, kmd_version, vgpu_driver_capability.heterogenous_multivGPU, count, name, serial, uuid, pci.bus_id, pci.domain, pci.bus, pci.device, pci.baseClass, pci.subClass, pci.device_id, pci.sub_device_id, vgpu_device_capability.fractional_multiVgpu, vgpu_device_capability.heterogeneous_timeSlice_profile, vgpu_device_capability.heterogeneous_timeSlice_sizes, vgpu_device_capability.homogeneous_placements, vgpu_device_capability.mig_timeSlicing, vgpu_device_capability.mig_timeSlicing_mode, pcie.link.gen.current, pcie.link.gen.gpucurrent, pcie.link.gen.max, pcie.link.gen.gpumax, pcie.link.gen.hostmax, pcie.link.width.current, pcie.link.width.max, index, display_mode, display_attached, display_active, persistence_mode, addressing_mode, accounting.mode, accounting.buffer_size, driver_model.current, driver_model.pending, vbios_version, inforom.img, inforom.oem, inforom.ecc, inforom.pwr, inforom.checksum_validation, gpu_recovery_action, gom.current, gom.pending, fan.speed [%], pstate, clocks_event_reasons.supported, clocks_event_reasons.active, clocks_event_reasons.gpu_idle, clocks_event_reasons.applications_clocks_setting, clocks_event_reasons.sw_power_cap, clocks_event_reasons.hw_slowdown, clocks_event_reasons.hw_thermal_slowdown, clocks_event_reasons.hw_power_brake_slowdown, clocks_event_reasons.sw_thermal_slowdown, clocks_event_reasons.sync_boost, clocks_event_reasons_counters.sw_power_cap [us], clocks_event_reasons_counters.sync_boost [us], clocks_event_reasons_counters.sw_thermal_slowdown [us], clocks_event_reasons_counters.hw_thermal_slowdown [us], clocks_event_reasons_counters.hw_power_brake_slowdown [us], memory.total [MiB], memory.reserved [MiB], memory.used [MiB], memory.free [MiB], compute_mode, compute_cap, utilization.gpu [%], utilization.memory [%], utilization.encoder [%], utilization.decoder [%], utilization.jpeg [%], utilization.ofa [%], encoder.stats.sessionCount, encoder.stats.averageFps, encoder.stats.averageLatency, dramEncryption.mode.current, dramEncryption.mode.pending, ecc.mode.current, ecc.mode.pending, ecc.errors.corrected.volatile.device_memory, ecc.errors.corrected.volatile.dram, ecc.errors.corrected.volatile.register_file, ecc.errors.corrected.volatile.l1_cache, ecc.errors.corrected.volatile.l2_cache, ecc.errors.corrected.volatile.texture_memory, ecc.errors.corrected.volatile.cbu, ecc.errors.corrected.volatile.sram, ecc.errors.corrected.volatile.total, ecc.errors.corrected.aggregate.device_memory, ecc.errors.corrected.aggregate.dram, ecc.errors.corrected.aggregate.register_file, ecc.errors.corrected.aggregate.l1_cache, ecc.errors.corrected.aggregate.l2_cache, ecc.errors.corrected.aggregate.texture_memory, ecc.errors.corrected.aggregate.cbu, ecc.errors.corrected.aggregate.sram, ecc.errors.corrected.aggregate.total, ecc.errors.uncorrected.volatile.device_memory, ecc.errors.uncorrected.volatile.dram, ecc.errors.uncorrected.volatile.register_file, ecc.errors.uncorrected.volatile.l1_cache, ecc.errors.uncorrected.volatile.l2_cache, ecc.errors.uncorrected.volatile.texture_memory, ecc.errors.uncorrected.volatile.cbu, ecc.errors.uncorrected.volatile.sram, ecc.errors.uncorrected.volatile.total, ecc.errors.uncorrected.aggregate.device_memory, ecc.errors.uncorrected.aggregate.dram, ecc.errors.uncorrected.aggregate.register_file, ecc.errors.uncorrected.aggregate.l1_cache, ecc.errors.uncorrected.aggregate.l2_cache, ecc.errors.uncorrected.aggregate.texture_memory, ecc.errors.uncorrected.aggregate.cbu, ecc.errors.uncorrected.aggregate.sram, ecc.errors.uncorrected.aggregate.total, ecc.errors.uncorrected.volatile.sram.parity, ecc.errors.uncorrected.volatile.sram.secded, ecc.errors.uncorrected.aggregate.sram.parity, ecc.errors.uncorrected.aggregate.sram.secded, ecc.errors.uncorrected.aggregate.sram.thresholdExceeded, ecc.errors.uncorrected.aggregate.sram.l2, ecc.errors.uncorrected.aggregate.sram.sm, ecc.errors.uncorrected.aggregate.sram.mcu, ecc.errors.uncorrected.aggregate.sram.pcie, ecc.errors.uncorrected.aggregate.sram.other, retired_pages.single_bit_ecc.count, retired_pages.double_bit.count, retired_pages.pending, remapped_rows.correctable, remapped_rows.correctable_inactive, remapped_rows.uncorrectable, remapped_rows.uncorrectable_inactive, remapped_rows.pending, remapped_rows.failure, remapped_rows.histogram.max, remapped_rows.histogram.high, remapped_rows.histogram.partial, remapped_rows.histogram.low, remapped_rows.histogram.none, temperature.gpu, temperature.gpu.tlimit, temperature.memory, power.management, power.draw [W], power.draw.average [W], power.draw.instant [W], power.limit [W], enforced.power.limit [W], power.default_limit [W], power.min_limit [W], power.max_limit [W], module.power.draw.average [W], module.power.draw.instant [W], module.power.limit [W], module.enforced.power.limit [W], module.power.default_limit [W], module.power.min_limit [W], module.power.max_limit [W], edpp_multiplier [%], clocks.current.graphics [MHz], clocks.current.sm [MHz], clocks.current.memory [MHz], clocks.current.video [MHz], clocks.applications.graphics [MHz], clocks.applications.memory [MHz], clocks.default_applications.graphics [MHz], clocks.default_applications.memory [MHz], clocks.max.graphics [MHz], clocks.max.sm [MHz], clocks.max.memory [MHz], mig.mode.current, mig.mode.pending, gsp.mode.current, gsp.mode.default, c2c.mode, protected_memory.total [MiB], protected_memory.used [MiB], protected_memory.free [MiB], fabric.state, fabric.status, fabric.cliqueId, fabric.clusterUuid, fabric.health.summary, fabric.health.bandwidth, fabric.health.route_recovery_in_progress, fabric.health.route_unhealthy, fabric.health.access_timeout_recovery, fabric.health.incorrect_configuration, fabric.health.partition_assigned, platform.chassis_serial_number, platform.slot_number, platform.tray_index, platform.host_id, platform.peer_type, platform.module_id, platform.gpu_fabric_guid, hostname
+2026/06/26 11:59:44.226, 595.71.05, 595.71.05, [N/A], 1, NVIDIA GeForce RTX 4080 SUPER, [N/A], GPU-00000000-0000-0000-0000-000000000000, 00000000:01:00.0, 0x0000, 0x01, 0x00, 0x3, 0x0, 0x270210DE, 0x51101462, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 1, 1, 4, 4, 5, 16, 16, 0, [Requested functionality has been deprecated], Yes, Enabled, Disabled, HMM, Disabled, 4000, [N/A], [N/A], 95.03.44.00.B2, G002.0000.00.03, 2.0, [N/A], [N/A], valid, None, [N/A], [N/A], 0 %, P8, 0x00000000000001FF, 0x0000000000000001, Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, 0 us, 0 us, 0 us, 0 us, 0 us, 16376 MiB, 434 MiB, 596 MiB, 15348 MiB, Default, 8.9, 0 %, 23 %, 0 %, 0 %, 0 %, 0 %, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, No, 0, 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 43, [N/A], N/A, [Requested functionality has been deprecated], 26.20 W, 26.20 W, 28.77 W, 320.00 W, 320.00 W, 320.00 W, 150.00 W, 400.00 W, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 210 MHz, 210 MHz, 405 MHz, 1185 MHz, [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], 3165 MHz, 3165 MHz, 11501 MHz, [N/A], [N/A], Enabled, Enabled, [N/A], 0 MiB, 0 MiB, 0 MiB, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, , 0, 0, 1, Direct Connected, 1, 0x0000000000000000, [N/A]
+
+
+################################################################################
+# idle :: query-compute-apps (per-process)
+# $ nvidia-smi --query-compute-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,process_name,used_gpu_memory --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, process_name, used_gpu_memory [MiB]
+2026/06/26 11:59:44.371, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, 2165, /usr/bin/kwin_wayland, 25 MiB
+
+
+################################################################################
+# idle :: query-accounted-apps
+# $ nvidia-smi --query-accounted-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,gpu_util,mem_util,max_memory_usage,time --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, gpu_utilization [%], mem_utilization [%], max_memory_usage [MiB], time [ms]
+
+
+################################################################################
+# idle :: query-retired-pages
+# $ nvidia-smi --query-retired-pages=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,retired_pages.address,retired_pages.timestamp,retired_pages.cause --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, retired_pages.address, retired_pages.timestamp, retired_pages.cause
+2026/06/26 11:59:44.410, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Single Bit ECC
+2026/06/26 11:59:44.410, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Double Bit ECC
+
+
+################################################################################
+# idle :: pmon (per-process monitor)
+# $ nvidia-smi pmon -c 5
+################################################################################
+# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
+# Idx           #    C/G      %      %      %      %      %      %    name 
+    0       2165   C+G      -      -      -      -      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       2165   C+G      -      -      -      -      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       2165   C+G      -      -      -      -      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       2165   C+G      -      -      -      -      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       2165   C+G      -      -      -      -      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+
+
+################################################################################
+# idle :: dmon (per-device monitor, incl. PCIe rx/tx)
+# $ nvidia-smi dmon -c 5
+################################################################################
+# gpu    pwr  gtemp  mtemp     sm    mem    enc    dec    jpg    ofa   mclk   pclk 
+# Idx      W      C      C      %      %      %      %      %      %    MHz    MHz 
+    0     27     43      -      0     16      0      0      0      0    405    210 
+    0     26     43      -      0     25      0      0      0      0    405    210 
+    0     25     43      -      0     26      0      0      0      0    405    210 
+    0     26     43      -      0     32      0      0      0      0    405    210 
+    0     26     43      -      0     32      0      0      0      0    405    210 
+
+
+################################################################################
+# load :: nvidia-smi (default table)
+# $ nvidia-smi 
+################################################################################
+Fri Jun 26 11:59:58 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 595.71.05              Driver Version: 595.71.05      CUDA Version: 13.2     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 4080 ...    Off |   00000000:01:00.0  On |                  N/A |
+|  0%   45C    P2             83W /  320W |    1474MiB /  16376MiB |      7%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            2165    C+G   /usr/bin/kwin_wayland                    25MiB |
+|    0   N/A  N/A            2496      G   /usr/bin/plasma-keyboard                200MiB |
+|    0   N/A  N/A            2620      G   /usr/bin/Xwayland                         4MiB |
+|    0   N/A  N/A            2954      G   /usr/bin/plasmashell                    120MiB |
+|    0   N/A  N/A            3527      G   /usr/bin/xwaylandvideobridge              3MiB |
+|    0   N/A  N/A            5021      C   ffmpeg                                  360MiB |
+|    0   N/A  N/A            5022      C   ffmpeg                                  503MiB |
++-----------------------------------------------------------------------------------------+
+
+
+################################################################################
+# load :: query (-q)
+# $ nvidia-smi -q
+################################################################################
+
+==============NVSMI LOG==============
+
+Timestamp                                              : Fri Jun 26 11:59:58 2026
+Driver Version                                         : 595.71.05
+CUDA Version                                           : 13.2
+
+Attached GPUs                                          : 1
+GPU 00000000:01:00.0
+    Product Name                                       : NVIDIA GeForce RTX 4080 SUPER
+    Product Brand                                      : GeForce
+    Product Architecture                               : Ada Lovelace
+    Display Mode                                       : Requested functionality has been deprecated
+    Display Attached                                   : Yes
+    Display Active                                     : Enabled
+    Persistence Mode                                   : Disabled
+    Addressing Mode                                    : HMM
+    MIG Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    Accounting Mode                                    : Disabled
+    Accounting Mode Buffer Size                        : 4000
+    Driver Model
+        Current                                        : N/A
+        Pending                                        : N/A
+    Serial Number                                      : N/A
+    GPU UUID                                           : GPU-00000000-0000-0000-0000-000000000000
+    GPU PDI                                            : 0x427f47bdf3c96203
+    Minor Number                                       : 0
+    VBIOS Version                                      : 95.03.44.00.B2
+    MultiGPU Board                                     : No
+    Board ID                                           : 0x100
+    Board Part Number                                  : N/A
+    GPU Part Number                                    : 2702-400-A1
+    FRU Part Number                                    : N/A
+    Platform Info
+        Chassis Serial Number                          : N/A
+        Slot Number                                    : N/A
+        Tray Index                                     : N/A
+        Host ID                                        : N/A
+        Peer Type                                      : N/A
+        Module Id                                      : 1
+        GPU Fabric GUID                                : N/A
+    Inforom Version
+        Image Version                                  : G002.0000.00.03
+        OEM Object                                     : 2.0
+        ECC Object                                     : N/A
+        Power Management Object                        : N/A
+    Inforom BBX Object Flush
+        Latest Timestamp                               : N/A
+        Latest Duration                                : N/A
+    GPU Operation Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    GPU C2C Mode                                       : N/A
+    GPU Virtualization Mode
+        Virtualization Mode                            : None
+        Host VGPU Mode                                 : N/A
+        vGPU Heterogeneous Mode                        : N/A
+    GPU Recovery Action                                : None
+    GSP Firmware Version                               : 595.71.05
+    IBMNPU
+        Relaxed Ordering Mode                          : N/A
+    PCI
+        Bus                                            : 0x01
+        Device                                         : 0x00
+        Domain                                         : 0x0000
+        Base Classcode                                 : 0x3
+        Sub Classcode                                  : 0x0
+        Device Id                                      : 0x270210DE
+        Bus Id                                         : 00000000:01:00.0
+        Sub System Id                                  : 0x51101462
+        GPU Link Info
+            PCIe Generation
+                Max                                    : 4
+                Current                                : 4
+                Device Current                         : 4
+                Device Max                             : 4
+                Host Max                               : 5
+            Link Width
+                Max                                    : 16x
+                Current                                : 16x
+        Bridge Chip
+            Type                                       : N/A
+            Firmware                                   : N/A
+        Replays Since Reset                            : 0
+        Replay Number Rollovers                        : 0
+        Tx Throughput                                  : 174169 KB/s
+        Rx Throughput                                  : 1436230 KB/s
+        Atomic Caps Outbound                           : N/A
+        Atomic Caps Inbound                            : N/A
+    Fan Speed                                          : 0 %
+    Performance State                                  : P2
+    Clocks Event Reasons
+        Idle                                           : Not Active
+        Applications Clocks Setting                    : Not Active
+        SW Power Cap                                   : Not Active
+        HW Slowdown                                    : Not Active
+            HW Thermal Slowdown                        : Not Active
+            HW Power Brake Slowdown                    : Not Active
+        Sync Boost                                     : Not Active
+        SW Thermal Slowdown                            : Not Active
+        Display Clock Setting                          : Not Active
+    Clocks Event Reasons Counters
+        SW Power Capping                               : 0 us
+        Sync Boost                                     : 0 us
+        SW Thermal Slowdown                            : 0 us
+        HW Thermal Slowdown                            : 0 us
+        HW Power Braking                               : 0 us
+    Sparse Operation Mode                              : N/A
+    FB Memory Usage
+        Total                                          : 16376 MiB
+        Reserved                                       : 434 MiB
+        Used                                           : 1474 MiB
+        Free                                           : 14470 MiB
+    BAR1 Memory Usage
+        Total                                          : 16384 MiB
+        Used                                           : 35 MiB
+        Free                                           : 16349 MiB
+    Conf Compute Protected Memory Usage
+        Total                                          : 0 MiB
+        Used                                           : 0 MiB
+        Free                                           : 0 MiB
+    Compute Mode                                       : Default
+    Utilization
+        GPU                                            : 7 %
+        Memory                                         : 2 %
+        Encoder                                        : 72 %
+        Decoder                                        : 0 %
+        JPEG                                           : 0 %
+        OFA                                            : 0 %
+    Encoder Stats
+        Active Sessions                                : 2
+        Average FPS                                    : 184
+        Average Latency                                : 62844
+    FBC Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    DRAM Encryption Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    ECC Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    ECC Errors
+        Volatile
+            SRAM Correctable                           : N/A
+            SRAM Uncorrectable Parity                  : N/A
+            SRAM Uncorrectable SEC-DED                 : N/A
+            DRAM Correctable                           : N/A
+            DRAM Uncorrectable                         : N/A
+        Aggregate
+            SRAM Correctable                           : N/A
+            SRAM Uncorrectable Parity                  : N/A
+            SRAM Uncorrectable SEC-DED                 : N/A
+            DRAM Correctable                           : N/A
+            DRAM Uncorrectable                         : N/A
+            SRAM Threshold Exceeded                    : N/A
+        Aggregate Uncorrectable SRAM Sources
+            SRAM L2                                    : N/A
+            SRAM SM                                    : N/A
+            SRAM Microcontroller                       : N/A
+            SRAM PCIE                                  : N/A
+            SRAM Other                                 : N/A
+        Channel Repair Pending                         : No
+        TPC Repair Pending                             : No
+        Unrepairable Memory                            : N/A
+    Retired Pages
+        Single Bit ECC                                 : N/A
+        Double Bit ECC                                 : N/A
+        Pending Page Blacklist                         : N/A
+    Remapped Rows                                      : N/A
+    Temperature
+        GPU Current Temp                               : 45 C
+        GPU T.Limit Temp                               : N/A
+        GPU Shutdown Temp                              : 101 C
+        GPU Slowdown Temp                              : 96 C
+        GPU Max Operating Temp                         : 90 C
+        GPU Target Temperature                         : 84 C
+        Memory Current Temp                            : N/A
+        Memory Max Operating Temp                      : N/A
+    GPU Power Readings
+        Average Power Draw                             : 84.03 W
+        Instantaneous Power Draw                       : 86.41 W
+        Current Power Limit                            : 320.00 W
+        Requested Power Limit                          : 320.00 W
+        Default Power Limit                            : 320.00 W
+        Min Power Limit                                : 150.00 W
+        Max Power Limit                                : 400.00 W
+    GPU Memory Power Readings 
+        Average Power Draw                             : N/A
+        Instantaneous Power Draw                       : N/A
+    Module Power Readings
+        Average Power Draw                             : N/A
+        Instantaneous Power Draw                       : N/A
+        Current Power Limit                            : N/A
+        Requested Power Limit                          : N/A
+        Default Power Limit                            : N/A
+        Min Power Limit                                : N/A
+        Max Power Limit                                : N/A
+    Power Smoothing                                    : N/A
+    Workload Power Profiles
+        Requested Profiles                             : N/A
+        Enforced Profiles                              : N/A
+    EDPp Multiplier                                    : N/A
+    Clocks
+        Graphics                                       : 2805 MHz
+        SM                                             : 2805 MHz
+        Memory                                         : 11251 MHz
+        Video                                          : 2145 MHz
+    Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Default Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Deferred Clocks
+        Memory                                         : N/A
+    Max Clocks
+        Graphics                                       : 3165 MHz
+        SM                                             : 3165 MHz
+        Memory                                         : 11501 MHz
+        Video                                          : 2415 MHz
+    Max Customer Boost Clocks
+        Graphics                                       : N/A
+    Clock Policy
+        Auto Boost                                     : N/A
+        Auto Boost Default                             : N/A
+    Fabric
+        State                                          : N/A
+        Status                                         : N/A
+        CliqueId                                       : N/A
+        ClusterUUID                                    : N/A
+        Health
+            Summary                                    : N/A
+            Bandwidth                                  : N/A
+            Route Recovery in progress                 : N/A
+            Route Unhealthy                            : N/A
+            Access Timeout Recovery                    : N/A
+            Incorrect Configuration                    : N/A
+            Partition Assigned                         : N/A
+    Processes
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2165
+            Type                          : C+G
+            Name                          : /usr/bin/kwin_wayland
+            Used GPU Memory               : 25 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2496
+            Type                          : G
+            Name                          : /usr/bin/plasma-keyboard
+            Used GPU Memory               : 200 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2620
+            Type                          : G
+            Name                          : /usr/bin/Xwayland
+            Used GPU Memory               : 4 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 2954
+            Type                          : G
+            Name                          : /usr/bin/plasmashell
+            Used GPU Memory               : 120 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 3527
+            Type                          : G
+            Name                          : /usr/bin/xwaylandvideobridge
+            Used GPU Memory               : 3 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 5021
+            Type                          : C
+            Name                          : ffmpeg
+            Used GPU Memory               : 360 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 5022
+            Type                          : C
+            Name                          : ffmpeg
+            Used GPU Memory               : 503 MiB
+    Capabilities
+        EGM                                            : disabled
+
+
+
+################################################################################
+# load :: query-gpu (csv, what the exporter parses)
+# $ nvidia-smi --query-gpu=timestamp,driver_version,kmd_version,vgpu_driver_capability.heterogenous_multivGPU,count,name,serial,uuid,pci.bus_id,pci.domain,pci.bus,pci.device,pci.baseClass,pci.subClass,pci.device_id,pci.sub_device_id,vgpu_device_capability.fractional_multiVgpu,vgpu_device_capability.heterogeneous_timeSlice_profile,vgpu_device_capability.heterogeneous_timeSlice_sizes,vgpu_device_capability.homogeneous_placements,vgpu_device_capability.mig_timeSlicing,vgpu_device_capability.mig_timeSlicing_mode,pcie.link.gen.current,pcie.link.gen.gpucurrent,pcie.link.gen.max,pcie.link.gen.gpumax,pcie.link.gen.hostmax,pcie.link.width.current,pcie.link.width.max,index,display_mode,display_attached,display_active,persistence_mode,addressing_mode,accounting.mode,accounting.buffer_size,driver_model.current,driver_model.pending,vbios_version,inforom.img,inforom.oem,inforom.ecc,inforom.pwr,inforom.checksum_validation,gpu_recovery_action,gom.current,gom.pending,fan.speed,pstate,clocks_event_reasons.supported,clocks_event_reasons.active,clocks_event_reasons.gpu_idle,clocks_event_reasons.applications_clocks_setting,clocks_event_reasons.sw_power_cap,clocks_event_reasons.hw_slowdown,clocks_event_reasons.hw_thermal_slowdown,clocks_event_reasons.hw_power_brake_slowdown,clocks_event_reasons.sw_thermal_slowdown,clocks_event_reasons.sync_boost,clocks_event_reasons_counters.sw_power_cap,clocks_event_reasons_counters.sync_boost,clocks_event_reasons_counters.sw_thermal_slowdown,clocks_event_reasons_counters.hw_thermal_slowdown,clocks_event_reasons_counters.hw_power_brake_slowdown,memory.total,memory.reserved,memory.used,memory.free,compute_mode,compute_cap,utilization.gpu,utilization.memory,utilization.encoder,utilization.decoder,utilization.jpeg,utilization.ofa,encoder.stats.sessionCount,encoder.stats.averageFps,encoder.stats.averageLatency,dramEncryption.mode.current,dramEncryption.mode.pending,ecc.mode.current,ecc.mode.pending,ecc.errors.corrected.volatile.device_memory,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.volatile.register_file,ecc.errors.corrected.volatile.l1_cache,ecc.errors.corrected.volatile.l2_cache,ecc.errors.corrected.volatile.texture_memory,ecc.errors.corrected.volatile.cbu,ecc.errors.corrected.volatile.sram,ecc.errors.corrected.volatile.total,ecc.errors.corrected.aggregate.device_memory,ecc.errors.corrected.aggregate.dram,ecc.errors.corrected.aggregate.register_file,ecc.errors.corrected.aggregate.l1_cache,ecc.errors.corrected.aggregate.l2_cache,ecc.errors.corrected.aggregate.texture_memory,ecc.errors.corrected.aggregate.cbu,ecc.errors.corrected.aggregate.sram,ecc.errors.corrected.aggregate.total,ecc.errors.uncorrected.volatile.device_memory,ecc.errors.uncorrected.volatile.dram,ecc.errors.uncorrected.volatile.register_file,ecc.errors.uncorrected.volatile.l1_cache,ecc.errors.uncorrected.volatile.l2_cache,ecc.errors.uncorrected.volatile.texture_memory,ecc.errors.uncorrected.volatile.cbu,ecc.errors.uncorrected.volatile.sram,ecc.errors.uncorrected.volatile.total,ecc.errors.uncorrected.aggregate.device_memory,ecc.errors.uncorrected.aggregate.dram,ecc.errors.uncorrected.aggregate.register_file,ecc.errors.uncorrected.aggregate.l1_cache,ecc.errors.uncorrected.aggregate.l2_cache,ecc.errors.uncorrected.aggregate.texture_memory,ecc.errors.uncorrected.aggregate.cbu,ecc.errors.uncorrected.aggregate.sram,ecc.errors.uncorrected.aggregate.total,ecc.errors.uncorrected.volatile.sram.parity,ecc.errors.uncorrected.volatile.sram.secded,ecc.errors.uncorrected.aggregate.sram.parity,ecc.errors.uncorrected.aggregate.sram.secded,ecc.errors.uncorrected.aggregate.sram.thresholdExceeded,ecc.errors.uncorrected.aggregate.sram.l2,ecc.errors.uncorrected.aggregate.sram.sm,ecc.errors.uncorrected.aggregate.sram.mcu,ecc.errors.uncorrected.aggregate.sram.pcie,ecc.errors.uncorrected.aggregate.sram.other,retired_pages.single_bit_ecc.count,retired_pages.double_bit.count,retired_pages.pending,remapped_rows.correctable,remapped_rows.correctable_inactive,remapped_rows.uncorrectable,remapped_rows.uncorrectable_inactive,remapped_rows.pending,remapped_rows.failure,remapped_rows.histogram.max,remapped_rows.histogram.high,remapped_rows.histogram.partial,remapped_rows.histogram.low,remapped_rows.histogram.none,temperature.gpu,temperature.gpu.tlimit,temperature.memory,power.management,power.draw,power.draw.average,power.draw.instant,power.limit,enforced.power.limit,power.default_limit,power.min_limit,power.max_limit,module.power.draw.average,module.power.draw.instant,module.power.limit,module.enforced.power.limit,module.power.default_limit,module.power.min_limit,module.power.max_limit,edpp_multiplier,clocks.current.graphics,clocks.current.sm,clocks.current.memory,clocks.current.video,clocks.applications.graphics,clocks.applications.memory,clocks.default_applications.graphics,clocks.default_applications.memory,clocks.max.graphics,clocks.max.sm,clocks.max.memory,mig.mode.current,mig.mode.pending,gsp.mode.current,gsp.mode.default,c2c.mode,protected_memory.total,protected_memory.used,protected_memory.free,fabric.state,fabric.status,fabric.cliqueId,fabric.clusterUuid,fabric.health.summary,fabric.health.bandwidth,fabric.health.route_recovery_in_progress,fabric.health.route_unhealthy,fabric.health.access_timeout_recovery,fabric.health.incorrect_configuration,fabric.health.partition_assigned,platform.chassis_serial_number,platform.slot_number,platform.tray_index,platform.host_id,platform.peer_type,platform.module_id,platform.gpu_fabric_guid,hostname --format=csv
+################################################################################
+timestamp, driver_version, kmd_version, vgpu_driver_capability.heterogenous_multivGPU, count, name, serial, uuid, pci.bus_id, pci.domain, pci.bus, pci.device, pci.baseClass, pci.subClass, pci.device_id, pci.sub_device_id, vgpu_device_capability.fractional_multiVgpu, vgpu_device_capability.heterogeneous_timeSlice_profile, vgpu_device_capability.heterogeneous_timeSlice_sizes, vgpu_device_capability.homogeneous_placements, vgpu_device_capability.mig_timeSlicing, vgpu_device_capability.mig_timeSlicing_mode, pcie.link.gen.current, pcie.link.gen.gpucurrent, pcie.link.gen.max, pcie.link.gen.gpumax, pcie.link.gen.hostmax, pcie.link.width.current, pcie.link.width.max, index, display_mode, display_attached, display_active, persistence_mode, addressing_mode, accounting.mode, accounting.buffer_size, driver_model.current, driver_model.pending, vbios_version, inforom.img, inforom.oem, inforom.ecc, inforom.pwr, inforom.checksum_validation, gpu_recovery_action, gom.current, gom.pending, fan.speed [%], pstate, clocks_event_reasons.supported, clocks_event_reasons.active, clocks_event_reasons.gpu_idle, clocks_event_reasons.applications_clocks_setting, clocks_event_reasons.sw_power_cap, clocks_event_reasons.hw_slowdown, clocks_event_reasons.hw_thermal_slowdown, clocks_event_reasons.hw_power_brake_slowdown, clocks_event_reasons.sw_thermal_slowdown, clocks_event_reasons.sync_boost, clocks_event_reasons_counters.sw_power_cap [us], clocks_event_reasons_counters.sync_boost [us], clocks_event_reasons_counters.sw_thermal_slowdown [us], clocks_event_reasons_counters.hw_thermal_slowdown [us], clocks_event_reasons_counters.hw_power_brake_slowdown [us], memory.total [MiB], memory.reserved [MiB], memory.used [MiB], memory.free [MiB], compute_mode, compute_cap, utilization.gpu [%], utilization.memory [%], utilization.encoder [%], utilization.decoder [%], utilization.jpeg [%], utilization.ofa [%], encoder.stats.sessionCount, encoder.stats.averageFps, encoder.stats.averageLatency, dramEncryption.mode.current, dramEncryption.mode.pending, ecc.mode.current, ecc.mode.pending, ecc.errors.corrected.volatile.device_memory, ecc.errors.corrected.volatile.dram, ecc.errors.corrected.volatile.register_file, ecc.errors.corrected.volatile.l1_cache, ecc.errors.corrected.volatile.l2_cache, ecc.errors.corrected.volatile.texture_memory, ecc.errors.corrected.volatile.cbu, ecc.errors.corrected.volatile.sram, ecc.errors.corrected.volatile.total, ecc.errors.corrected.aggregate.device_memory, ecc.errors.corrected.aggregate.dram, ecc.errors.corrected.aggregate.register_file, ecc.errors.corrected.aggregate.l1_cache, ecc.errors.corrected.aggregate.l2_cache, ecc.errors.corrected.aggregate.texture_memory, ecc.errors.corrected.aggregate.cbu, ecc.errors.corrected.aggregate.sram, ecc.errors.corrected.aggregate.total, ecc.errors.uncorrected.volatile.device_memory, ecc.errors.uncorrected.volatile.dram, ecc.errors.uncorrected.volatile.register_file, ecc.errors.uncorrected.volatile.l1_cache, ecc.errors.uncorrected.volatile.l2_cache, ecc.errors.uncorrected.volatile.texture_memory, ecc.errors.uncorrected.volatile.cbu, ecc.errors.uncorrected.volatile.sram, ecc.errors.uncorrected.volatile.total, ecc.errors.uncorrected.aggregate.device_memory, ecc.errors.uncorrected.aggregate.dram, ecc.errors.uncorrected.aggregate.register_file, ecc.errors.uncorrected.aggregate.l1_cache, ecc.errors.uncorrected.aggregate.l2_cache, ecc.errors.uncorrected.aggregate.texture_memory, ecc.errors.uncorrected.aggregate.cbu, ecc.errors.uncorrected.aggregate.sram, ecc.errors.uncorrected.aggregate.total, ecc.errors.uncorrected.volatile.sram.parity, ecc.errors.uncorrected.volatile.sram.secded, ecc.errors.uncorrected.aggregate.sram.parity, ecc.errors.uncorrected.aggregate.sram.secded, ecc.errors.uncorrected.aggregate.sram.thresholdExceeded, ecc.errors.uncorrected.aggregate.sram.l2, ecc.errors.uncorrected.aggregate.sram.sm, ecc.errors.uncorrected.aggregate.sram.mcu, ecc.errors.uncorrected.aggregate.sram.pcie, ecc.errors.uncorrected.aggregate.sram.other, retired_pages.single_bit_ecc.count, retired_pages.double_bit.count, retired_pages.pending, remapped_rows.correctable, remapped_rows.correctable_inactive, remapped_rows.uncorrectable, remapped_rows.uncorrectable_inactive, remapped_rows.pending, remapped_rows.failure, remapped_rows.histogram.max, remapped_rows.histogram.high, remapped_rows.histogram.partial, remapped_rows.histogram.low, remapped_rows.histogram.none, temperature.gpu, temperature.gpu.tlimit, temperature.memory, power.management, power.draw [W], power.draw.average [W], power.draw.instant [W], power.limit [W], enforced.power.limit [W], power.default_limit [W], power.min_limit [W], power.max_limit [W], module.power.draw.average [W], module.power.draw.instant [W], module.power.limit [W], module.enforced.power.limit [W], module.power.default_limit [W], module.power.min_limit [W], module.power.max_limit [W], edpp_multiplier [%], clocks.current.graphics [MHz], clocks.current.sm [MHz], clocks.current.memory [MHz], clocks.current.video [MHz], clocks.applications.graphics [MHz], clocks.applications.memory [MHz], clocks.default_applications.graphics [MHz], clocks.default_applications.memory [MHz], clocks.max.graphics [MHz], clocks.max.sm [MHz], clocks.max.memory [MHz], mig.mode.current, mig.mode.pending, gsp.mode.current, gsp.mode.default, c2c.mode, protected_memory.total [MiB], protected_memory.used [MiB], protected_memory.free [MiB], fabric.state, fabric.status, fabric.cliqueId, fabric.clusterUuid, fabric.health.summary, fabric.health.bandwidth, fabric.health.route_recovery_in_progress, fabric.health.route_unhealthy, fabric.health.access_timeout_recovery, fabric.health.incorrect_configuration, fabric.health.partition_assigned, platform.chassis_serial_number, platform.slot_number, platform.tray_index, platform.host_id, platform.peer_type, platform.module_id, platform.gpu_fabric_guid, hostname
+2026/06/26 11:59:58.761, 595.71.05, 595.71.05, [N/A], 1, NVIDIA GeForce RTX 4080 SUPER, [N/A], GPU-00000000-0000-0000-0000-000000000000, 00000000:01:00.0, 0x0000, 0x01, 0x00, 0x3, 0x0, 0x270210DE, 0x51101462, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 4, 4, 4, 4, 5, 16, 16, 0, [Requested functionality has been deprecated], Yes, Enabled, Disabled, HMM, Disabled, 4000, [N/A], [N/A], 95.03.44.00.B2, G002.0000.00.03, 2.0, [N/A], [N/A], valid, None, [N/A], [N/A], 0 %, P2, 0x00000000000001FF, 0x0000000000000000, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, 0 us, 0 us, 0 us, 0 us, 0 us, 16376 MiB, 434 MiB, 1474 MiB, 14470 MiB, Default, 8.9, 7 %, 2 %, 72 %, 0 %, 0 %, 0 %, 2, 184, 62844, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, No, 0, 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 46, [N/A], N/A, [Requested functionality has been deprecated], 84.24 W, 84.24 W, 86.41 W, 320.00 W, 320.00 W, 320.00 W, 150.00 W, 400.00 W, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 2805 MHz, 2805 MHz, 11251 MHz, 2145 MHz, [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], 3165 MHz, 3165 MHz, 11501 MHz, [N/A], [N/A], Enabled, Enabled, [N/A], 0 MiB, 0 MiB, 0 MiB, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, N/A, , 0, 0, 1, Direct Connected, 1, 0x0000000000000000, [N/A]
+
+
+################################################################################
+# load :: query-compute-apps (per-process)
+# $ nvidia-smi --query-compute-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,process_name,used_gpu_memory --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, process_name, used_gpu_memory [MiB]
+2026/06/26 11:59:58.909, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, 2165, /usr/bin/kwin_wayland, 25 MiB
+2026/06/26 11:59:58.909, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, 5022, ffmpeg, 503 MiB
+2026/06/26 11:59:58.909, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, 5021, ffmpeg, 360 MiB
+
+
+################################################################################
+# load :: query-accounted-apps
+# $ nvidia-smi --query-accounted-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,gpu_util,mem_util,max_memory_usage,time --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, gpu_utilization [%], mem_utilization [%], max_memory_usage [MiB], time [ms]
+
+
+################################################################################
+# load :: query-retired-pages
+# $ nvidia-smi --query-retired-pages=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,retired_pages.address,retired_pages.timestamp,retired_pages.cause --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, retired_pages.address, retired_pages.timestamp, retired_pages.cause
+2026/06/26 11:59:58.947, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Single Bit ECC
+2026/06/26 11:59:58.947, NVIDIA GeForce RTX 4080 SUPER, 00000000:01:00.0, [N/A], GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Double Bit ECC
+
+
+################################################################################
+# load :: pmon (per-process monitor)
+# $ nvidia-smi pmon -c 5
+################################################################################
+# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
+# Idx           #    C/G      %      %      %      %      %      %    name 
+    0       2165   C+G      -      -      -      0      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       5021     C      0      0     15      -      -      -    ffmpeg         
+    0       5022     C      5      1     54      -      -      -    ffmpeg         
+    0       2165   C+G      -      -      -      0      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       5021     C      1      0     28      -      -      -    ffmpeg         
+    0       5022     C      4      1     42      -      -      -    ffmpeg         
+    0       2165   C+G      -      -      -      0      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       5021     C      -      -     42      -      -      -    ffmpeg         
+    0       5022     C      6      2     27      -      -      -    ffmpeg         
+    0       2165   C+G      -      -      -      0      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       5021     C      3      1     42      -      -      -    ffmpeg         
+    0       5022     C      2      0     28      -      -      -    ffmpeg         
+    0       2165   C+G      -      -      -      0      -      -    kwin_wayland   
+    0       2496     G      -      -      -      -      -      -    plasma-keyboard
+    0       2620     G      -      -      -      -      -      -    Xwayland       
+    0       2954     G      -      -      -      -      -      -    plasmashell    
+    0       3527     G      -      -      -      -      -      -    xwaylandvideobr
+    0       5021     C      2      0     14      -      -      -    ffmpeg         
+    0       5022     C      3      1     55      -      -      -    ffmpeg         
+
+
+################################################################################
+# load :: dmon (per-device monitor, incl. PCIe rx/tx)
+# $ nvidia-smi dmon -c 5
+################################################################################
+# gpu    pwr  gtemp  mtemp     sm    mem    enc    dec    jpg    ofa   mclk   pclk 
+# Idx      W      C      C      %      %      %      %      %      %    MHz    MHz 
+    0     83     46      -      7      2     69      0      0      0  11251   2805 
+    0     84     46      -      7      2     68      0      0      0  11251   2805 
+    0     84     46      -      7      2     71      0      0      0  11251   2805 
+    0     84     46      -      7      2     70      0      0      0  11251   2805 
+    0     84     46      -      6      2     70      0      0      0  11251   2805 

--- a/internal/demodata/linux-x86_64__nvidia-h200__590.48.01.txt
+++ b/internal/demodata/linux-x86_64__nvidia-h200__590.48.01.txt
@@ -1,0 +1,2167 @@
+################################################################################
+# nvidia_gpu_exporter GPU capture
+# https://github.com/utkuozdemir/nvidia_gpu_exporter - see internal/captures/README.md
+################################################################################
+# The GPU model and driver are in the filename. Every other nvidia-smi
+# value is in the raw sections below, not re-parsed here. This header only
+# carries what nvidia-smi does not report: collection time, mask status,
+# host OS (from uname), and the synthetic load used.
+collected_at:   2026-07-03T22:10:45Z
+masked:         yes
+os:             linux (Ubuntu 22.04.5 LTS)
+kernel:         5.15.0-171-generic
+arch:           x86_64
+load:           gpu-burn (CUDA, 20% mem) + 2x CUDA memhog
+
+
+################################################################################
+# capabilities :: version
+# $ nvidia-smi --version
+################################################################################
+NVIDIA-SMI version  : 590.48.01
+NVML version        : 590.48
+DRIVER version      : 590.48.01
+CUDA Version        : 13.1
+
+
+################################################################################
+# capabilities :: help (-h)
+# $ nvidia-smi -h
+################################################################################
+NVIDIA System Management Interface -- v590.48.01
+
+NVSMI provides monitoring information for Tesla and select Quadro devices.
+The data is presented in either a plain text or an XML format, via stdout or a file.
+NVSMI also provides several management operations for changing the device state.
+
+Note that the functionality of NVSMI is exposed through the NVML C-based
+library. See the NVIDIA developer website for more information about NVML.
+Python wrappers to NVML are also available.  The output of NVSMI is
+not guaranteed to be backwards compatible; NVML and the bindings are backwards
+compatible.
+
+http://developer.nvidia.com/nvidia-management-library-nvml/
+http://pypi.python.org/pypi/nvidia-ml-py/
+Supported products:
+- Full Support
+    - All Tesla products, starting with the Kepler architecture
+    - All Quadro products, starting with the Kepler architecture
+    - All GRID products, starting with the Kepler architecture
+    - GeForce Titan products, starting with the Kepler architecture
+- Limited Support
+    - All Geforce products, starting with the Kepler architecture
+nvidia-smi [OPTION1 [ARG1]] [OPTION2 [ARG2]] ...
+
+    -h,   --help                Print usage information and exit.
+
+          --version             Print version information and exit.
+
+  LIST OPTIONS:
+
+    -L,   --list-gpus           Display a list of GPUs connected to the system.
+
+    -B,   --list-excluded-gpus  Display a list of excluded GPUs in the system.
+
+  SUMMARY OPTIONS:
+
+    <no arguments>              Show a summary of GPUs connected to the system.
+
+    -col, --columns             Show a summary of GPUs connected to the system in multi-column format.
+
+    [plus any of]
+
+    -i,   --id=                 Target a specific GPU.
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -l,   --loop=               Probe until Ctrl+C at specified second interval.
+
+  QUERY OPTIONS:
+
+    -q,   --query               Display GPU or Unit info.
+
+    [plus any of]
+
+    -u,   --unit                Show unit, rather than GPU, attributes.
+    -i,   --id=                 Target a specific GPU or Unit.
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -x,   --xml-format          Produce XML output.
+          --dtd                 When showing xml output, embed DTD.
+    -d,   --display=            Display only selected information: MEMORY,
+                                    UTILIZATION, ECC, TEMPERATURE, POWER, CLOCK,
+                                    COMPUTE, PIDS, PERFORMANCE, SUPPORTED_CLOCKS,
+                                    PAGE_RETIREMENT, ACCOUNTING, ENCODER_STATS,
+                                    SUPPORTED_GPU_TARGET_TEMP, VOLTAGE, FBC_STATS
+                                    ROW_REMAPPER, GSP_FIRMWARE_VERSION
+                                    POWER_SMOOTHING, POWER_PROFILES
+                                Flags can be combined with comma e.g. ECC,POWER.
+                                Sampling data with max/min/avg is also returned 
+                                for POWER, UTILIZATION and CLOCK display types.
+                                Doesn't work with -u or -x flags.
+    -l,   --loop=               Probe until Ctrl+C at specified second interval.
+
+    -lms, --loop-ms=            Probe until Ctrl+C at specified millisecond interval.
+
+  SELECTIVE QUERY OPTIONS:
+
+    Allows the caller to pass an explicit list of properties to query.
+
+    [one of]
+
+    --query-gpu                 Information about GPU.
+                                Call --help-query-gpu for more info.
+    --query-supported-clocks    List of supported clocks.
+                                Call --help-query-supported-clocks for more info.
+    --query-compute-apps        List of currently active compute processes.
+                                Call --help-query-compute-apps for more info.
+    --query-accounted-apps      List of accounted compute processes.
+                                Call --help-query-accounted-apps for more info.
+                                This query is not supported on vGPU host.
+    --query-retired-pages       List of device memory pages that have been retired.
+                                Call --help-query-retired-pages for more info.
+    --query-remapped-rows       Information about remapped rows.
+                                Call --help-query-remapped-rows for more info.
+
+    [mandatory]
+
+    --format=                   Comma separated list of format options:
+                                  csv - comma separated values (MANDATORY)
+                                  noheader - skip the first line with column headers
+                                  nounits - don't print units for numerical
+                                             values
+
+    [plus any of]
+
+    -i,   --id=                 Target a specific GPU or Unit.
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -l,   --loop=               Probe until Ctrl+C at specified second interval.
+    -lms, --loop-ms=            Probe until Ctrl+C at specified millisecond interval.
+
+  DEVICE MODIFICATION OPTIONS:
+
+    [any one of]
+
+    -pm,  --persistence-mode=   Set persistence mode: 0/DISABLED, 1/ENABLED
+    -e,   --ecc-config=         Toggle ECC support: 0/DISABLED, 1/ENABLED
+    -p,   --reset-ecc-errors=   Reset ECC error counts: 0/VOLATILE, 1/AGGREGATE
+    -c,   --compute-mode=       Set MODE for compute applications:
+                                0/DEFAULT, 1/EXCLUSIVE_THREAD (DEPRECATED),
+                                2/PROHIBITED, 3/EXCLUSIVE_PROCESS
+          --gom=                Set GPU Operation Mode:
+                                    0/ALL_ON, 1/COMPUTE, 2/LOW_DP
+    -r    --gpu-reset           Trigger reset of the GPU.
+                                Can be used to reset the GPU HW state in situations
+                                that would otherwise require a machine reboot.
+                                Typically useful if a double bit ECC error has
+                                occurred.
+                                Reset operations are not guaranteed to work in
+                                all cases and should be used with caution.
+                                Reset triggered without extra arguments, will be a.
+                                default Function Level Reset (FLR). To issue a
+                                Bus Reset, use -r bus.
+    -vm   --virt-mode=          Switch GPU Virtualization Mode:
+                                Sets GPU virtualization mode to 3/VGPU or 4/VSGA
+                                Virtualization mode of a GPU can only be set when
+                                it is running on a hypervisor.
+    -lgc  --lock-gpu-clocks=    Specifies <minGpuClock,maxGpuClock> clocks as a
+                                    pair (e.g. 1500,1500) that defines the range 
+                                    of desired locked GPU clock speed in MHz.
+                                    Setting this will supersede application clocks
+                                    and take effect regardless if an app is running.
+                                    Input can also be a singular desired clock value
+                                    (e.g. <GpuClockValue>). Optionally, --mode can be
+                                    specified to indicate a special mode.
+    -m    --mode=               Specifies the mode for --lock-gpu-clocks.
+                                    Valid modes: 0, 1
+    -rgc  --reset-gpu-clocks
+                                Resets the GPU clocks to the default values.
+    -lmc  --lock-memory-clocks=  Specifies <minMemClock,maxMemClock> clocks as a
+                                    pair (e.g. 5100,5100) that defines the range 
+                                    of desired locked Memory clock speed in MHz.
+                                    Input can also be a singular desired clock value
+                                    (e.g. <MemClockValue>).
+    -rmc  --reset-memory-clocks
+                                Resets the Memory clocks to the default values.
+    -lmcd --lock-memory-clocks-deferred=
+                                    Specifies memClock clock to lock. This limit is
+                                    applied the next time GPU is initialized.
+                                    This is guaranteed by unloading and reloading the kernel module.
+                                    Requires root.
+    -rmcd --reset-memory-clocks-deferred
+                                Resets the deferred Memory clocks applied.
+    -ac   --applications-clocks= Specifies <memory,graphics> clocks as a
+                                    pair (e.g. 2000,800) that defines GPU's
+                                    speed in MHz while running applications on a GPU.
+    -rac  --reset-applications-clocks
+                                Resets the applications clocks to the default values.
+    -pl   --power-limit=        Specifies maximum power management limit in watts.
+                                Takes an optional argument --scope.
+    -sc   --scope=              Specifies the device type for --scope: 0/GPU, 1/TOTAL_MODULE (Grace Hopper Only)
+    -cc   --cuda-clocks=        Overrides or restores default CUDA clocks.
+                                In override mode, GPU clocks higher frequencies when running CUDA applications.
+                                Only on supported devices starting from the Volta series.
+                                Requires administrator privileges.
+                                0/RESTORE_DEFAULT, 1/OVERRIDE
+    -am   --accounting-mode=    Enable or disable Accounting Mode: 0/DISABLED, 1/ENABLED
+    -caa  --clear-accounted-apps
+                                Clears all the accounted PIDs in the buffer.
+          --auto-boost-default= Set the default auto boost policy to 0/DISABLED
+                                or 1/ENABLED, enforcing the change only after the
+                                last boost client has exited.
+          --auto-boost-permission=
+                                Allow non-admin/root control over auto boost mode:
+                                0/UNRESTRICTED, 1/RESTRICTED
+    -mig  --multi-instance-gpu= Enable or disable Multi Instance GPU: 0/DISABLED, 1/ENABLED
+                                Requires root.
+    -gtt  --gpu-target-temp=    Set GPU Target Temperature for a GPU in degree celsius.
+                                Requires administrator privileges
+    -den, --dram-encryption=    Toggle DRAM Encryption support: 0/DISABLED, 1/ENABLED
+                                Requires root.
+           --set-hostname=      Set the hostname associated with the GPU.
+                                Requires root.
+           --get-hostname       Get the hostname associated with the GPU.
+
+   [plus optional]
+
+    -i,   --id=                 Target a specific GPU.
+    -eow, --error-on-warning    Return a non-zero error for warnings.
+
+  UNIT MODIFICATION OPTIONS:
+
+    -t,   --toggle-led=         Set Unit LED state: 0/GREEN, 1/AMBER
+
+   [plus optional]
+
+    -i,   --id=                 Target a specific Unit.
+
+  SHOW DTD OPTIONS:
+
+          --dtd                 Print device DTD and exit.
+
+     [plus optional]
+
+    -f,   --filename=           Log to a specified file, rather than to stdout.
+    -u,   --unit                Show unit, rather than device, DTD.
+
+    --debug=                    Log encrypted debug information to a specified file. 
+
+ Device Monitoring:
+    dmon                        Displays device stats in scrolling format.
+                                "nvidia-smi dmon -h" for more information.
+
+    daemon                      Runs in background and monitor devices as a daemon process.
+                                This is an experimental feature. Not supported on Windows baremetal
+                                "nvidia-smi daemon -h" for more information.
+
+    replay                      Used to replay/extract the persistent stats generated by daemon.
+                                This is an experimental feature.
+                                "nvidia-smi replay -h" for more information.
+
+ Process Monitoring:
+    pmon                        Displays process stats in scrolling format.
+                                "nvidia-smi pmon -h" for more information.
+
+ TOPOLOGY:
+    topo                        Displays device/system topology. "nvidia-smi topo -h" for more information.
+
+ DRAIN STATES:
+    drain                       Displays/modifies GPU drain states for power idling. "nvidia-smi drain -h" for more information.
+
+ NVLINK:
+    nvlink                      Displays device nvlink information. "nvidia-smi nvlink -h" for more information.
+
+ C2C:
+    c2c                         Displays device C2C information. "nvidia-smi c2c -h" for more information.
+
+ CLOCKS:
+    clocks                      Control and query clock information. "nvidia-smi clocks -h" for more information.
+
+ ENCODER SESSIONS:
+    encodersessions             Displays device encoder sessions information. "nvidia-smi encodersessions -h" for more information.
+
+ FBC SESSIONS:
+    fbcsessions                 Displays device FBC sessions information. "nvidia-smi fbcsessions -h" for more information.
+
+ GRID vGPU:
+    vgpu                        Displays vGPU information. "nvidia-smi vgpu -h" for more information.
+
+ MIG:
+    mig                         Provides controls for MIG management. "nvidia-smi mig -h" for more information.
+
+ COMPUTE POLICY:
+    compute-policy              Control and query compute policies. "nvidia-smi compute-policy -h" for more information. 
+
+ BOOST SLIDER:
+    boost-slider                Control and query boost sliders. "nvidia-smi boost-slider -h" for more information. 
+
+ POWER HINT:    power-hint                  Estimates GPU power usage. "nvidia-smi power-hint -h" for more information. 
+
+ BASE CLOCKS:    base-clocks                 Query GPU base clocks. "nvidia-smi base-clocks -h" for more information. 
+
+ CONFIDENTIAL COMPUTE:
+    conf-compute                Control and query confidential compute. "nvidia-smi conf-compute -h" for more information. 
+
+ GPU PERFORMANCE MONITORING: 
+    gpm                         Control and query GPU performance monitoring unit. "nvidia-smi gpm -h" for more information. 
+
+ PCI:
+    pci                         Display device PCI information. "nvidia-smi pci -h" for more information.
+
+ Power Smoothing:
+    power-smoothing             Control and query power smoothing information. "nvidia-smi power-smoothing -h" for more information.
+
+ Power Profiles:
+    power-profiles              Control and query workload power profiles information. "nvidia-smi power-profiles -h" for more information.
+
+ RUSD:
+    rusd                         Set RUSD (read only shared data buffer) settings. "nvidia-smi rusd -h" for more information.
+
+ PRM:
+    prm                         Query GPU PRM registers. "nvidia-smi prm -h" for more information.
+
+ SOC:
+    soc                          Query system on chip metrics. "nvidia-smi soc -h" for more information.
+
+Please see the nvidia-smi(1) manual page for more detailed information.
+
+
+################################################################################
+# capabilities :: help-query-gpu
+# $ nvidia-smi --help-query-gpu
+################################################################################
+List of valid properties to query for the switch "--query-gpu":
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"driver_version"
+The version of the installed NVIDIA display driver. This is an alphanumeric string.
+
+Section about vgpu_driver_capability properties
+Retrieves information about driver level caps.
+
+"vgpu_driver_capability.heterogenous_multivGPU"
+Whether heterogeneuos multi-vGPU is supported by driver.
+
+"count"
+The number of NVIDIA GPUs in the system.
+
+"name" or "gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"serial" or "gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"uuid" or "gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"pci.bus_id" or "gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"pci.domain"
+PCI domain number, in hex.
+
+"pci.bus"
+PCI bus number, in hex.
+
+"pci.device"
+PCI device number, in hex.
+
+"pci.baseClass"
+PCI Base Classcode, in hex.
+
+"pci.subClass"
+PCI Sub Classcode, in hex.
+
+"pci.device_id"
+PCI vendor device id, in hex
+
+"pci.sub_device_id"
+PCI Sub System id, in hex
+
+Section about vgpu_device_capability properties
+Retrieves information about device level caps.
+
+"vgpu_device_capability.fractional_multiVgpu"
+Fractional vGPU profiles on this GPU can be used in multi-vGPU configurations.
+
+"vgpu_device_capability.heterogeneous_timeSlice_profile"
+Supports concurrent execution of timesliced vGPU profiles of differing types.
+
+"vgpu_device_capability.heterogeneous_timeSlice_sizes"
+Supports concurrent execution of timesliced vGPU profiles of differing framebuffer sizes.
+
+"vgpu_device_capability.homogeneous_placements"
+Supports reporting of placements of timesliced vGPU profiles of identical framebuffer sizes.
+
+"vgpu_device_capability.mig_timeSlicing"
+Reports whether GPU supports timesliced vGPU on MIG.
+
+"vgpu_device_capability.mig_timeSlicing_mode"
+Reports whether MIG timesliced mode is enabled or not.
+
+"pcie.link.gen.current"
+The current PCI-E link generation. These may be reduced when the GPU is not in use. Deprecated, use pcie.link.gen.gpucurrent instead.
+
+"pcie.link.gen.gpucurrent"
+The current PCI-E link generation. These may be reduced when the GPU is not in use.
+
+"pcie.link.gen.max"
+The maximum PCI-E link generation possible with this GPU and system configuration. For example, if the GPU supports a higher PCIe generation than the system supports then this reports the system PCIe generation.
+
+"pcie.link.gen.gpumax"
+The maximum PCI-E link generation supported by this GPU.
+
+"pcie.link.gen.hostmax"
+The maximum PCI-E link generation supported by the root port corresponding to this GPU.
+
+"pcie.link.width.current"
+The current PCI-E link width. These may be reduced when the GPU is not in use.
+
+"pcie.link.width.max"
+The maximum PCI-E link width possible with this GPU and system configuration. For example, if the GPU supports a higher PCIe generation than the system supports then this reports the system PCIe generation.
+
+"index"
+Zero based index of the GPU. Can change at each boot.
+
+"display_mode"
+Deprecated, do not use.
+
+"display_attached"
+A flag that indicates whether a physical display (e.g. monitor) is currently connected to any of the GPU's connectors. "Yes" indicates an attached display. "No" indicates otherwise.
+
+"display_active"
+A flag that indicates whether a display is initialized on the GPU's (e.g. memory is allocated on the device for display). Display can be active even when no monitor is physically attached. "Enabled" indicates an active display. "Disabled" indicates otherwise.
+
+"persistence_mode"
+A flag that indicates whether persistence mode is enabled for the GPU. Value is either "Enabled" or "Disabled". When persistence mode is enabled the NVIDIA driver remains loaded even when no active clients, such as X11 or nvidia-smi, exist. This minimizes the driver load latency associated with running dependent apps, such as CUDA programs. Linux only.
+
+"addressing_mode"
+A flag that indicates the type of addressing mode enabled for the GPU. Value is either "HMM" or "ATS" or "None". When the mode is HMM, system allocated memory (malloc, mmap) is addressable from the device (GPU), via software-based mirroring of the CPU's page tables, on the GPU. When the mode is ATS, system allocated memory (malloc, mmap) is addressable from the device (GPU), via Address Translation Services. This means that there is (effectively) a single set of page tables, and the CPU and GPU both use them. The mode is None when neither HMM nor ATS is active. Linux only.
+
+"accounting.mode"
+A flag that indicates whether accounting mode is enabled for the GPU. Value is either "Enabled" or "Disabled". When accounting is enabled statistics are calculated for each compute process running on the GPU.Statistics can be queried during the lifetime or after termination of the process.The execution time of process is reported as 0 while the process is in running state and updated to actualexecution time after the process has terminated. See --help-query-accounted-apps for more info.
+
+"accounting.buffer_size"
+The size of the circular buffer that holds list of processes that can be queried for accounting stats. This is the maximum number of processes that accounting information will be stored for before information about oldest processes will get overwritten by information about new processes.
+
+Section about driver_model properties
+On Windows, the TCC, WDDM and MCDM driver models are supported. The driver model can be changed with the (-dm) or (-fdm) flags. The TCC and MCDM driver models are optimized for compute applications. I.E. kernel launch times will be quicker. The WDDM driver model is designed for graphics applications and is not recommended for compute applications. Linux does not support multiple driver models, and will always have the value of "N/A". Only for selected products. Please see feature matrix in NVML documentation.
+
+"driver_model.current"
+The driver model currently in use. Always "N/A" on Linux.
+
+"driver_model.pending"
+The driver model that will be used on the next reboot. Always "N/A" on Linux.
+
+"vbios_version"
+The BIOS of the GPU board.
+
+Section about inforom properties
+Version numbers for each object in the GPU board's inforom storage. The inforom is a small, persistent store of configuration and state data for the GPU. All inforom version fields are numerical. It can be useful to know these version numbers because some GPU features are only available with inforoms of a certain version or higher.
+
+"inforom.img" or "inforom.image"
+Global version of the infoROM image. Image version just like VBIOS version uniquely describes the exact version of the infoROM flashed on the board in contrast to infoROM object version which is only an indicator of supported features.
+
+"inforom.oem"
+Version for the OEM configuration data.
+
+"inforom.ecc"
+Version for the ECC recording data.
+
+"inforom.pwr" or "inforom.power"
+Version for the power management data.
+
+"inforom.checksum_validation"
+Inforom Checksum Validation information.
+
+"gpu_recovery_action"
+GPU recovery action information. Reports the GPU Recovery action recommended to recover from a bad state. 'N/A' indicates that the field is not supported on the current device or device configuration. An error message indicates that retrieving the field failed.
+
+Section about gom properties
+GOM allows to reduce power usage and optimize GPU throughput by disabling GPU features. Each GOM is designed to meet specific user needs.
+In "All On" mode everything is enabled and running at full speed.
+The "Compute" mode is designed for running only compute tasks. Graphics operations are not allowed.
+The "Low Double Precision" mode is designed for running graphics applications that don't require high bandwidth double precision.
+GOM can be changed with the (--gom) flag.
+
+"gom.current" or "gpu_operation_mode.current"
+The GOM currently in use.
+
+"gom.pending" or "gpu_operation_mode.pending"
+The GOM that will be used on the next reboot.
+
+"fan.speed"
+The fan speed value is the percent of the product's maximum noise tolerance fan speed that the device's fan is currently intended to run at. This value may exceed 100% in certain cases. Note: The reported speed is the intended fan speed. If the fan is physically blocked and unable to spin, this output will not match the actual fan speed. Many parts do not report fan speeds because they rely on cooling via fans in the surrounding enclosure.
+
+"pstate"
+The current performance state for the GPU. States range from P0 (maximum performance) to P12 (minimum performance).
+
+Section about clocks_event_reasons properties
+Retrieves information about factors that are reducing the frequency of clocks. If all event reasons are returned as "Not Active" it means that clocks are running as high as possible.
+
+"clocks_event_reasons.supported" or "clocks_throttle_reasons.supported"
+Bitmask of supported clock event reasons. See nvml.h for more details.
+
+"clocks_event_reasons.active" or "clocks_throttle_reasons.active"
+Bitmask of active clock event reasons. See nvml.h for more details.
+
+"clocks_event_reasons.gpu_idle" or "clocks_throttle_reasons.gpu_idle"
+Nothing is running on the GPU and the clocks are dropping to Idle state. This limiter may be removed in a later release.
+
+"clocks_event_reasons.applications_clocks_setting" or "clocks_throttle_reasons.applications_clocks_setting"
+GPU clocks are limited by applications clocks setting. E.g. can be changed by nvidia-smi --applications-clocks=
+
+"clocks_event_reasons.sw_power_cap" or "clocks_throttle_reasons.sw_power_cap"
+SW Power Scaling algorithm is reducing the clocks below requested clocks because the GPU is consuming too much power. E.g. SW power cap limit can be changed with nvidia-smi --power-limit=
+
+"clocks_event_reasons.hw_slowdown" or "clocks_throttle_reasons.hw_slowdown"
+HW Slowdown (reducing the core clocks by a factor of 2 or more) is engaged. This is an indicator of:
+ HW Thermal Slowdown: temperature being too high
+ HW Power Brake Slowdown: External Power Brake Assertion is triggered (e.g. by the system power supply)
+ * Power draw is too high and Fast Trigger protection is reducing the clocks
+ * May be also reported during PState or clock change
+ * This behavior may be removed in a later release
+
+"clocks_event_reasons.hw_thermal_slowdown" or "clocks_throttle_reasons.hw_thermal_slowdown"
+HW Thermal Slowdown (reducing the core clocks by a factor of 2 or more) is engaged. This is an indicator of temperature being too high
+
+"clocks_event_reasons.hw_power_brake_slowdown" or "clocks_throttle_reasons.hw_power_brake_slowdown"
+HW Power Brake Slowdown (reducing the core clocks by a factor of 2 or more) is engaged. This is an indicator of External Power Brake Assertion being triggered (e.g. by the system power supply)
+
+"clocks_event_reasons.sw_thermal_slowdown" or "clocks_throttle_reasons.sw_thermal_slowdown"
+SW Thermal capping algorithm is reducing clocks below requested clocks because GPU temperature is higher than Max Operating Temp.
+
+"clocks_event_reasons.sync_boost" or "clocks_throttle_reasons.sync_boost"
+Sync Boost This GPU has been added to a Sync boost group with nvidia-smi or DCGM in
+ * order to maximize performance per watt. All GPUs in the sync boost group
+ * will boost to the minimum possible clocks across the entire group. Look at
+ * the event reasons for other GPUs in the system to see why those GPUs are
+ * holding this one at lower clocks.
+
+Section about clocks_event_reasons_counters properties
+Retrieves counters in microseconds for events which have reduced the frequency of clocks.
+
+"clocks_event_reasons_counters.sw_power_cap"
+Amount of time SW Power Scaling algorithm has reduced the clocks below requested clocks because the GPU was consuming too much power.
+
+"clocks_event_reasons_counters.sync_boost"
+Amount of time the clock frequency of this GPU was reduced to match the minimum possible clock across the sync boost group.
+
+"clocks_event_reasons_counters.sw_thermal_slowdown"
+Amount of time SW Thermal capping algorithm has reduced clocks below requested clocks because GPU temperature was higher than Max Operating Temp.
+
+"clocks_event_reasons_counters.hw_thermal_slowdown"
+Amount of time HW Thermal Slowdown was engaged, reducing the core clocks by a factor of 2 or more, due to temperature being too high.
+
+"clocks_event_reasons_counters.hw_power_brake_slowdown"
+Amount of time External Power Brake Assertion was triggered (e.g. by the system power supply).
+
+Section about memory properties
+On-board memory information. Reported total memory is affected by ECC state. If ECC is enabled the total available memory is decreased by several percent, due to the requisite parity bits. The driver may also reserve a small amount of memory for internal use, even without active work on the GPU.
+
+"memory.total"
+Total installed GPU memory.
+
+"memory.reserved"
+Total memory reserved by the NVIDIA driver and firmware.
+
+"memory.used"
+Total memory allocated by active contexts.
+
+"memory.free"
+Total free memory.
+
+"compute_mode"
+The compute mode flag indicates whether individual or multiple compute applications may run on the GPU.
+"0: Default" means multiple contexts are allowed per device.
+"1: Exclusive_Thread", deprecated, use Exclusive_Process instead
+"2: Prohibited" means no contexts are allowed per device (no compute apps).
+"3: Exclusive_Process" means only one context is allowed per device, usable from multiple threads at a time.
+
+"compute_cap"
+The CUDA Compute Capability, represented as Major DOT Minor.
+
+Section about utilization properties
+Utilization rates report how busy each GPU is over time, and can be used to determine how much an application is using the GPUs in the system.
+Note: On MIG-enabled GPUs, querying the utilization of encoder, decoder, jpeg, ofa, gpu, and memory is not currently supported.
+
+"utilization.gpu"
+Percent of time over the past sample period during which one or more kernels was executing on the GPU.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.memory"
+Percent of time over the past sample period during which global (device) memory was being read or written.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.encoder"
+Percent of time over the past sample period during which one or more kernels was executing on the Encoder Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.decoder"
+Percent of time over the past sample period during which one or more kernels was executing on the Decoder Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.jpeg"
+Percent of time over the past sample period during which one or more kernels was executing on the Jpeg Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+"utilization.ofa"
+Percent of time over the past sample period during which one or more kernels was executing on the Optical Flow Accelerator Engine.
+The sample period may be between 1 second and 1/6 second depending on the product.
+
+Section about encoder.stats properties
+Encoder stats report number of encoder sessions, average FPS and average latency in us for given GPUs in the system.
+
+"encoder.stats.sessionCount"
+Number of encoder sessions running on the GPU.
+
+"encoder.stats.averageFps"
+Average FPS of all sessions running on the GPU.
+
+"encoder.stats.averageLatency"
+Average latency in microseconds of all sessions running on the GPU.
+
+Section about dramEncryption.mode properties
+A flag that indicates whether DRAM Encryption support is enabled. May be either "Enabled" or "Disabled". Changes to DRAM Encryption mode require a reboot. Requires Inforom DRAM Encryption object version 1.0 or higher.
+
+"dramEncryption.mode.current"
+The DRAM Encryption mode that the GPU is currently operating under.
+
+"dramEncryption.mode.pending"
+The DRAM Encryption mode that the GPU will operate under after the next reboot.
+
+Section about ecc.mode properties
+A flag that indicates whether ECC support is enabled. May be either "Enabled" or "Disabled". Changes to ECC mode require a reboot. Requires Inforom ECC object version 1.0 or higher.
+
+"ecc.mode.current"
+The ECC mode that the GPU is currently operating under.
+
+"ecc.mode.pending"
+The ECC mode that the GPU will operate under after the next reboot.
+
+Section about ecc.errors properties
+NVIDIA GPUs can provide error counts for various types of ECC errors. Some ECC errors are either single or double bit, where single bit errors are corrected and double bit errors are uncorrectable. Texture memory errors may be correctable via resend or uncorrectable if the resend fails. These errors are available across two timescales (volatile and aggregate). Single bit ECC errors are automatically corrected by the HW and do not result in data corruption. Double bit errors are detected but not corrected. Please see the ECC documents on the web for information on compute application behavior when double bit errors occur. Volatile error counters track the number of errors detected since the last driver load. Aggregate error counts persist indefinitely and thus act as a lifetime counter.
+
+"ecc.errors.corrected.volatile.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.volatile.dram"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.volatile.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.corrected.volatile.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.corrected.volatile.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.corrected.volatile.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.corrected.volatile.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.corrected.volatile.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.corrected.volatile.total"
+Total errors detected across entire chip.
+
+"ecc.errors.corrected.aggregate.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.aggregate.dram"
+Errors detected in global device memory.
+
+"ecc.errors.corrected.aggregate.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.corrected.aggregate.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.corrected.aggregate.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.corrected.aggregate.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.corrected.aggregate.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.corrected.aggregate.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.corrected.aggregate.total"
+Total errors detected across entire chip.
+
+"ecc.errors.uncorrected.volatile.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.volatile.dram"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.volatile.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.uncorrected.volatile.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.uncorrected.volatile.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.uncorrected.volatile.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.uncorrected.volatile.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.uncorrected.volatile.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.uncorrected.volatile.total"
+Total errors detected across entire chip.
+
+"ecc.errors.uncorrected.aggregate.device_memory"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.aggregate.dram"
+Errors detected in global device memory.
+
+"ecc.errors.uncorrected.aggregate.register_file"
+Errors detected in register file memory.
+
+"ecc.errors.uncorrected.aggregate.l1_cache"
+Errors detected in the L1 cache.
+
+"ecc.errors.uncorrected.aggregate.l2_cache"
+Errors detected in the L2 cache.
+
+"ecc.errors.uncorrected.aggregate.texture_memory"
+Parity errors detected in texture memory.
+
+"ecc.errors.uncorrected.aggregate.cbu"
+Parity errors detected in CBU.
+
+"ecc.errors.uncorrected.aggregate.sram"
+Errors detected in global SRAMs.
+
+"ecc.errors.uncorrected.aggregate.total"
+Total errors detected across entire chip.
+
+"ecc.errors.uncorrected.volatile.sram.parity"
+Unique volatile parity errors detected in SRAM
+
+"ecc.errors.uncorrected.volatile.sram.secded"
+Unique volatile SEC-DED errors detected in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.parity"
+Unique aggregate parity errors detected in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.secded"
+Unique aggregate SEC-DED errors detected in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.thresholdExceeded"
+Unique aggregate error threshold exceeded flag in SRAM
+
+"ecc.errors.uncorrected.aggregate.sram.l2"
+Unique aggregate errors detected in L2 cache
+
+"ecc.errors.uncorrected.aggregate.sram.sm"
+Unique aggregate errors detected in SM
+
+"ecc.errors.uncorrected.aggregate.sram.mcu"
+Unique aggregate errors detected in microcontrollers
+
+"ecc.errors.uncorrected.aggregate.sram.pcie"
+Aggregate errors detected in PCIe
+
+"ecc.errors.uncorrected.aggregate.sram.other"
+Unique aggregate SRAM errors detected not in L2 cache, SM, microcontrollers and PCIe
+
+Section about retired_pages properties
+NVIDIA GPUs can retire pages of GPU device memory when they become unreliable. This can happen when multiple single bit ECC errors occur for the same page, or on a double bit ECC error. When a page is retired, the NVIDIA driver will hide it such that no driver, or application memory allocations can access it.
+
+"retired_pages.single_bit_ecc.count" or "retired_pages.sbe"
+The number of GPU device memory pages that have been retired due to multiple single bit ECC errors.
+
+"retired_pages.double_bit.count" or "retired_pages.dbe"
+The number of GPU device memory pages that have been retired due to a double bit ECC error.
+
+"retired_pages.pending"
+Checks if any GPU device memory pages are pending retirement on the next reboot. Pages that are pending retirement can still be allocated, and may cause further reliability issues.
+
+Section about remapped_rows properties
+NVIDIA GPUs can remap bank rows of GPU device memory when they become unreliable. This can happen when multiple single bit ECC errors occur for the same row, or on a double bit ECC error. When a pending row remapping happens, GPU reset is required to complete row remapping.
+
+"remapped_rows.correctable" or "remapped_rows.sbe"
+The number of rows that have been remapped due to multiple single bit ECC errors.
+
+"remapped_rows.uncorrectable" or "remapped_rows.dbe"
+The number of rows that have been remapped due to a double bit ECC error.
+
+"remapped_rows.pending"
+Checks if any row remapping are pending on the next reboot.
+
+"remapped_rows.failure"
+Checks if any row remapping failure happens in the GPU lifespan.
+
+Section about remapped_rows.histogram properties
+The histogram of bank remap availability.
+
+"remapped_rows.histogram.max"
+The number of banks with full remap availability.
+
+"remapped_rows.histogram.high"
+The number of banks with high remap availability.
+
+"remapped_rows.histogram.partial"
+The number of banks with partial remap availability.
+
+"remapped_rows.histogram.low"
+The number of banks with low remap availability.
+
+"remapped_rows.histogram.none"
+The number of banks without remap availability.
+
+"temperature.gpu"
+ Core GPU temperature. in degrees C.
+
+"temperature.gpu.tlimit"
+ GPU T.Limit temperature. in degrees C.
+
+"temperature.memory"
+ HBM memory temperature. in degrees C.
+
+"power.management"
+A flag that indicates whether power management is enabled. Either "Supported" or "[Not Supported]". Requires Inforom PWR object version 3.0 or higher or Kepler device.
+
+"power.draw"
+The last measured power draw for the entire board, in watts. On Ampere or newer devices, returns average power draw over 1 sec. On older devices, returns instantaneous power draw. Only available if power management is supported. This reading is accurate to within +/- 5 watts.
+
+"power.draw.average" or "gpu.power.draw.average"
+The last measured average power draw for the entire board, in watts. Only available if power management is supported and Ampere (except GA100) or newer devices. This reading is accurate to within +/- 5 watts.
+
+"power.draw.instant" or "gpu.power.draw.instant"
+The last measured instant power draw for the entire board, in watts. Only available if power management is supported. This reading is accurate to within +/- 5 watts.
+
+"power.limit" or "gpu.power.requested_limit"
+The software power limit in watts. Set by software like nvidia-smi. On Kepler devices Power Limit can be adjusted using [-pl | --power-limit=] switches.
+
+"enforced.power.limit" or "gpu.power.current_limit"
+The power management algorithm's power ceiling, in watts. Total board power draw is manipulated by the power management algorithm such that it stays under this value. This value is the minimum of various power limiters.
+
+"power.default_limit" or "gpu.power.default_limit"
+The default power management algorithm's power ceiling, in watts. Power Limit will be set back to Default Power Limit after driver unload.
+
+"power.min_limit" or "gpu.power.min_limit"
+The minimum value in watts that power limit can be set to.
+
+"power.max_limit" or "gpu.power.max_limit"
+The maximum value in watts that power limit can be set to.
+
+"module.power.draw.average"
+The last measured average power draw for the entire module, in watts. This reading is accurate to within +/- 5 watts.
+
+"module.power.draw.instant"
+The last measured instant power draw for the entire module, in watts. This reading is accurate to within +/- 5 watts.
+
+"module.power.limit" or "module.power.requested_limit"
+The software power limit in watts for the entire module.
+
+"module.enforced.power.limit" or "module.power.current_limit"
+The power management algorithm's power ceiling for the entire module, in watts. This value is the minimum of various power limiters.
+
+"module.power.default_limit"
+The default power management algorithm's power ceiling for the entire module, in watts. Power Limit will be set back to Default Power Limit after driver unload.
+
+"module.power.min_limit"
+The minimum value in watts that module power limit can be set to.
+
+"module.power.max_limit"
+The maximum value in watts that module power limit can be set to.
+
+"power_smoothing.delayed_power_smoothing_supported"
+Indicates whether delayed power smoothing is supported (Yes/No).
+
+"power_smoothing.primary_power_floor"
+Current primary Power floor value in watts for power smoothing.
+
+"power_smoothing.secondary_power_floor"
+Current secondary Power floor value in watts for power smoothing.
+
+"power_smoothing.min_primary_floor_activation_offset"
+Minimum primary floor activation offset value in watts for power smoothing.
+
+"power_smoothing.min_primary_floor_activation_point"
+Minimum primary floor activation point value in watts for power smoothing.
+
+"power_smoothing.window_multiplier"
+The window multiplier value in ms for power smoothing.
+
+"power_smoothing.curr_profile.secondary_power_floor"
+Current profile secondary power floor value in watts.
+
+"power_smoothing.curr_profile.primary_floor_act_window_multiplier"
+Current profile primary floor activation window multiplier value.
+
+"power_smoothing.curr_profile.primary_floor_tar_window_multiplier"
+Current profile primary floor target window multiplier value.
+
+"power_smoothing.curr_profile.primary_floor_act_offset"
+Current profile primary floor activation offset value in watts.
+
+"power_smoothing.admin_override.secondary_power_floor"
+Admin override for secondary power floor value in watts, if set.
+
+"power_smoothing.admin_override.primary_floor_act_window_multiplier"
+Admin override for primary floor activation window multiplier value, if set.
+
+"power_smoothing.admin_override.primary_floor_tar_window_multiplier"
+Admin override for primary floor target window multiplier value, if set.
+
+"power_smoothing.admin_override.primary_floor_act_offset"
+Admin override for primary floor activation offset value in watts, if set.
+
+"edpp_multiplier"
+The EDPp multiplier expressed as a percentage.
+
+"clocks.current.graphics" or "clocks.gr"
+Current frequency of graphics (shader) clock.
+
+"clocks.current.sm" or "clocks.sm"
+Current frequency of SM (Streaming Multiprocessor) clock.
+
+"clocks.current.memory" or "clocks.mem"
+Current frequency of memory clock.
+
+"clocks.current.video" or "clocks.video"
+Current frequency of video encoder/decoder clock.
+
+Section about clocks.applications properties
+User specified frequency at which applications will be running at. Can be changed with [-ac | --applications-clocks] switches.
+
+"clocks.applications.graphics" or "clocks.applications.gr"
+User specified frequency of graphics (shader) clock.
+
+"clocks.applications.memory" or "clocks.applications.mem"
+User specified frequency of memory clock.
+
+Section about clocks.default_applications properties
+Default frequency at which applications will be running at. Application clocks can be changed with [-ac | --applications-clocks] switches. Application clocks can be set to default using [-rac | --reset-applications-clocks] switches.
+
+"clocks.default_applications.graphics" or "clocks.default_applications.gr"
+Default frequency of applications graphics (shader) clock.
+
+"clocks.default_applications.memory" or "clocks.default_applications.mem"
+Default frequency of applications memory clock.
+
+Section about clocks.max properties
+Maximum frequency at which parts of the GPU are design to run.
+
+"clocks.max.graphics" or "clocks.max.gr"
+Maximum frequency of graphics (shader) clock.
+
+"clocks.max.sm" or "clocks.max.sm"
+Maximum frequency of SM (Streaming Multiprocessor) clock.
+
+"clocks.max.memory" or "clocks.max.mem"
+Maximum frequency of memory clock.
+
+Section about mig.mode properties
+A flag that indicates whether MIG mode is enabled. May be either "Enabled" or "Disabled". Changes to MIG mode require a GPU reset.
+
+"mig.mode.current"
+The MIG mode that the GPU is currently operating under.
+
+"mig.mode.pending"
+The MIG mode that the GPU will operate under after reset.
+
+Section about gsp.mode properties
+A flag that indicates whether GSP firmware is enabled.May be either "Enabled" or "Disabled".
+
+"gsp.mode.current"
+The current status of GSP firmware.
+
+"gsp.mode.default"
+The default status of GSP firmware.
+
+"c2c.mode"
+A flag the indicates whether the device is in C2C mode, if supported.May be either "Enabled" or "Disabled".
+
+Section about protected_memory properties
+On-board protected memory information.
+
+"protected_memory.total"
+Total installed GPU conf compute protected memory.
+
+"protected_memory.used"
+Total conf compute protected memory allocated by active contexts.
+
+"protected_memory.free"
+Total free conf compute protected memory.
+
+"fabric.state"
+Current state of GPU fabric registration process.
+
+"fabric.status"
+Error status, valid only if gpu fabric registration state is "completed"
+
+"fabric.cliqueId"
+ID of the fabric clique to which this GPU belongs
+
+"fabric.clusterUuid"
+Uuid of the cluster to which this GPU belongs
+
+"fabric.health.summary"
+Fabric Health summary
+
+"fabric.health.bandwidth"
+Fabric Degraded bandwidth
+
+"fabric.health.route_recovery_in_progress"
+Fabric Route Recovery
+
+"fabric.health.route_unhealthy"
+Fabric Route Unhealthy
+
+"fabric.health.access_timeout_recovery"
+Fabric Access Timeout Recovery
+
+"fabric.health.incorrect_configuration"
+Fabric Incorrect Configuration
+
+Section about platform properties
+Platform Information.
+
+"platform.chassis_serial_number"
+Serial number of the chassis containing this GPU.
+
+"platform.slot_number"
+The slot number in the chassis containing this GPU (includes switches).
+
+"platform.tray_index"
+The tray index within the compute slots in the chassis containing this GPU (does not include switches).
+
+"platform.host_id"
+Index of the node within the slot containing this GPU.
+
+"platform.peer_type"
+Platform indicated NVLink-peer type (e.g. switch present or not).
+
+"platform.module_id"
+ID of this GPU within the node.
+
+"platform.gpu_fabric_guid"
+Fabric ID for this GPU.
+
+"hostname"
+Hostname associated with the GPU.
+
+
+
+################################################################################
+# capabilities :: help-query-compute-apps
+# $ nvidia-smi --help-query-compute-apps
+################################################################################
+List of valid properties to query for the switch "--query-compute-apps":
+
+Section about Active Compute Processes properties
+List of processes having compute context on the device.
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"pid"
+Process ID of the compute application
+
+"process_name" or "name"
+Process Name
+
+"used_gpu_memory" or "used_memory"
+Amount memory used on the device by the context. Not available on Windows when running in WDDM mode because Windows KMD manages all the memory not NVIDIA driver.
+
+
+
+################################################################################
+# capabilities :: help-query-accounted-apps
+# $ nvidia-smi --help-query-accounted-apps
+################################################################################
+List of valid properties to query for the switch "--query-accounted-apps":
+
+Section about Accounted Graphics/Compute Processes properties
+List of accounted processes having had a graphics/compute context on the device.
+
+Format options and one or more properties to be queried need to be provided as comma separated values for this switch.
+For example:
+nvidia-smi --query-accounted-apps=gpu_name,pid,time,gpu_util,mem_util,max_memory_usage --format=csv
+
+List of properties that can be queried are:
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"vgpu_instance"
+vGPU instance
+
+"pid"
+Process ID of the compute application
+
+"gpu_utilization" or "gpu_util"
+GPU Utilization
+
+"mem_utilization" or "mem_util"
+Percentage of GPU memory utilized on the device by the context.
+
+"max_memory_usage"
+Maximum amount memory used on the device by the context.
+
+"time"
+Amount of time in ms during which the compute context was active.
+
+
+
+################################################################################
+# capabilities :: help-query-retired-pages
+# $ nvidia-smi --help-query-retired-pages
+################################################################################
+List of valid properties to query for the switch "--query-retired-pages":
+
+"timestamp"
+The timestamp of when the query was made in format "YYYY/MM/DD HH:MM:SS.msec".
+
+"gpu_name"
+The official product name of the GPU. This is an alphanumeric string. For all products.
+
+"gpu_bus_id"
+PCI bus id as "domain:bus:device.function", in hex.
+
+"gpu_serial"
+This number matches the serial number physically printed on each board. It is a globally unique immutable alphanumeric value.
+
+"gpu_uuid"
+This value is the globally unique immutable alphanumeric identifier of the GPU. It does not correspond to any physical label on the board.
+
+"retired_pages.address"
+Address of a retired page. Address might be different when ECC is Enabled or Disabled.
+
+"retired_pages.timestamp"
+Timestamp at which the page was retired.
+
+"retired_pages.cause"
+Reason that describes why the page was retired. Can take one of two values: 
+ - Double Bit ECC - The number of GPU device memory pages that have been retired due to a double bit ECC error.
+ - Single Bit ECC - The number of GPU device memory pages that have been retired due to multiple single bit ECC errors.
+
+
+
+################################################################################
+# capabilities :: list (-L)
+# $ nvidia-smi -L
+################################################################################
+GPU 0: NVIDIA H200 (UUID: GPU-00000000-0000-0000-0000-000000000000)
+
+
+################################################################################
+# capabilities :: topo -m
+# $ nvidia-smi topo -m
+################################################################################
+	[4mGPU0	CPU Affinity	NUMA Affinity	GPU NUMA ID[0m
+GPU0	 X 	0-23	0		N/A
+
+Legend:
+
+  X    = Self
+  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
+  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
+  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
+  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
+  PIX  = Connection traversing at most a single PCIe bridge
+  NV#  = Connection traversing a bonded set of # NVLinks
+
+
+################################################################################
+# capabilities :: nvlink -s
+# $ nvidia-smi nvlink -s
+################################################################################
+GPU 0: NVIDIA H200 (UUID: GPU-00000000-0000-0000-0000-000000000000)
+	 Link 0: 26.562 GB/s
+	 Link 1: 26.562 GB/s
+	 Link 2: 26.562 GB/s
+	 Link 3: 26.562 GB/s
+	 Link 4: 26.562 GB/s
+	 Link 5: 26.562 GB/s
+	 Link 6: 26.562 GB/s
+	 Link 7: 26.562 GB/s
+	 Link 8: 26.562 GB/s
+	 Link 9: 26.562 GB/s
+	 Link 10: 26.562 GB/s
+	 Link 11: 26.562 GB/s
+	 Link 12: 26.562 GB/s
+	 Link 13: 26.562 GB/s
+	 Link 14: 26.562 GB/s
+	 Link 15: 26.562 GB/s
+	 Link 16: 26.562 GB/s
+	 Link 17: 26.562 GB/s
+
+
+################################################################################
+# capabilities :: query-gpu field list (derived, used for query-gpu above)
+################################################################################
+timestamp
+driver_version
+vgpu_driver_capability.heterogenous_multivGPU
+count
+name
+serial
+uuid
+pci.bus_id
+pci.domain
+pci.bus
+pci.device
+pci.baseClass
+pci.subClass
+pci.device_id
+pci.sub_device_id
+vgpu_device_capability.fractional_multiVgpu
+vgpu_device_capability.heterogeneous_timeSlice_profile
+vgpu_device_capability.heterogeneous_timeSlice_sizes
+vgpu_device_capability.homogeneous_placements
+vgpu_device_capability.mig_timeSlicing
+vgpu_device_capability.mig_timeSlicing_mode
+pcie.link.gen.current
+pcie.link.gen.gpucurrent
+pcie.link.gen.max
+pcie.link.gen.gpumax
+pcie.link.gen.hostmax
+pcie.link.width.current
+pcie.link.width.max
+index
+display_mode
+display_attached
+display_active
+persistence_mode
+addressing_mode
+accounting.mode
+accounting.buffer_size
+driver_model.current
+driver_model.pending
+vbios_version
+inforom.img
+inforom.oem
+inforom.ecc
+inforom.pwr
+inforom.checksum_validation
+gpu_recovery_action
+gom.current
+gom.pending
+fan.speed
+pstate
+clocks_event_reasons.supported
+clocks_event_reasons.active
+clocks_event_reasons.gpu_idle
+clocks_event_reasons.applications_clocks_setting
+clocks_event_reasons.sw_power_cap
+clocks_event_reasons.hw_slowdown
+clocks_event_reasons.hw_thermal_slowdown
+clocks_event_reasons.hw_power_brake_slowdown
+clocks_event_reasons.sw_thermal_slowdown
+clocks_event_reasons.sync_boost
+clocks_event_reasons_counters.sw_power_cap
+clocks_event_reasons_counters.sync_boost
+clocks_event_reasons_counters.sw_thermal_slowdown
+clocks_event_reasons_counters.hw_thermal_slowdown
+clocks_event_reasons_counters.hw_power_brake_slowdown
+memory.total
+memory.reserved
+memory.used
+memory.free
+compute_mode
+compute_cap
+utilization.gpu
+utilization.memory
+utilization.encoder
+utilization.decoder
+utilization.jpeg
+utilization.ofa
+encoder.stats.sessionCount
+encoder.stats.averageFps
+encoder.stats.averageLatency
+dramEncryption.mode.current
+dramEncryption.mode.pending
+ecc.mode.current
+ecc.mode.pending
+ecc.errors.corrected.volatile.device_memory
+ecc.errors.corrected.volatile.dram
+ecc.errors.corrected.volatile.register_file
+ecc.errors.corrected.volatile.l1_cache
+ecc.errors.corrected.volatile.l2_cache
+ecc.errors.corrected.volatile.texture_memory
+ecc.errors.corrected.volatile.cbu
+ecc.errors.corrected.volatile.sram
+ecc.errors.corrected.volatile.total
+ecc.errors.corrected.aggregate.device_memory
+ecc.errors.corrected.aggregate.dram
+ecc.errors.corrected.aggregate.register_file
+ecc.errors.corrected.aggregate.l1_cache
+ecc.errors.corrected.aggregate.l2_cache
+ecc.errors.corrected.aggregate.texture_memory
+ecc.errors.corrected.aggregate.cbu
+ecc.errors.corrected.aggregate.sram
+ecc.errors.corrected.aggregate.total
+ecc.errors.uncorrected.volatile.device_memory
+ecc.errors.uncorrected.volatile.dram
+ecc.errors.uncorrected.volatile.register_file
+ecc.errors.uncorrected.volatile.l1_cache
+ecc.errors.uncorrected.volatile.l2_cache
+ecc.errors.uncorrected.volatile.texture_memory
+ecc.errors.uncorrected.volatile.cbu
+ecc.errors.uncorrected.volatile.sram
+ecc.errors.uncorrected.volatile.total
+ecc.errors.uncorrected.aggregate.device_memory
+ecc.errors.uncorrected.aggregate.dram
+ecc.errors.uncorrected.aggregate.register_file
+ecc.errors.uncorrected.aggregate.l1_cache
+ecc.errors.uncorrected.aggregate.l2_cache
+ecc.errors.uncorrected.aggregate.texture_memory
+ecc.errors.uncorrected.aggregate.cbu
+ecc.errors.uncorrected.aggregate.sram
+ecc.errors.uncorrected.aggregate.total
+ecc.errors.uncorrected.volatile.sram.parity
+ecc.errors.uncorrected.volatile.sram.secded
+ecc.errors.uncorrected.aggregate.sram.parity
+ecc.errors.uncorrected.aggregate.sram.secded
+ecc.errors.uncorrected.aggregate.sram.thresholdExceeded
+ecc.errors.uncorrected.aggregate.sram.l2
+ecc.errors.uncorrected.aggregate.sram.sm
+ecc.errors.uncorrected.aggregate.sram.mcu
+ecc.errors.uncorrected.aggregate.sram.pcie
+ecc.errors.uncorrected.aggregate.sram.other
+retired_pages.single_bit_ecc.count
+retired_pages.double_bit.count
+retired_pages.pending
+remapped_rows.correctable
+remapped_rows.uncorrectable
+remapped_rows.pending
+remapped_rows.failure
+remapped_rows.histogram.max
+remapped_rows.histogram.high
+remapped_rows.histogram.partial
+remapped_rows.histogram.low
+remapped_rows.histogram.none
+temperature.gpu
+temperature.gpu.tlimit
+temperature.memory
+power.management
+power.draw
+power.draw.average
+power.draw.instant
+power.limit
+enforced.power.limit
+power.default_limit
+power.min_limit
+power.max_limit
+module.power.draw.average
+module.power.draw.instant
+module.power.limit
+module.enforced.power.limit
+module.power.default_limit
+module.power.min_limit
+module.power.max_limit
+power_smoothing.delayed_power_smoothing_supported
+power_smoothing.primary_power_floor
+power_smoothing.secondary_power_floor
+power_smoothing.min_primary_floor_activation_offset
+power_smoothing.min_primary_floor_activation_point
+power_smoothing.window_multiplier
+power_smoothing.curr_profile.secondary_power_floor
+power_smoothing.curr_profile.primary_floor_act_window_multiplier
+power_smoothing.curr_profile.primary_floor_tar_window_multiplier
+power_smoothing.curr_profile.primary_floor_act_offset
+power_smoothing.admin_override.secondary_power_floor
+power_smoothing.admin_override.primary_floor_act_window_multiplier
+power_smoothing.admin_override.primary_floor_tar_window_multiplier
+power_smoothing.admin_override.primary_floor_act_offset
+edpp_multiplier
+clocks.current.graphics
+clocks.current.sm
+clocks.current.memory
+clocks.current.video
+clocks.applications.graphics
+clocks.applications.memory
+clocks.default_applications.graphics
+clocks.default_applications.memory
+clocks.max.graphics
+clocks.max.sm
+clocks.max.memory
+mig.mode.current
+mig.mode.pending
+gsp.mode.current
+gsp.mode.default
+c2c.mode
+protected_memory.total
+protected_memory.used
+protected_memory.free
+fabric.state
+fabric.status
+fabric.cliqueId
+fabric.clusterUuid
+fabric.health.summary
+fabric.health.bandwidth
+fabric.health.route_recovery_in_progress
+fabric.health.route_unhealthy
+fabric.health.access_timeout_recovery
+fabric.health.incorrect_configuration
+platform.chassis_serial_number
+platform.slot_number
+platform.tray_index
+platform.host_id
+platform.peer_type
+platform.module_id
+platform.gpu_fabric_guid
+hostname
+
+
+################################################################################
+# idle :: nvidia-smi (default table)
+# $ nvidia-smi 
+################################################################################
+Fri Jul  3 22:10:45 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 590.48.01              Driver Version: 590.48.01      CUDA Version: 13.1     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H200                    On  |   00000000:83:00.0 Off |                    0 |
+| N/A   28C    P0             77W /  700W |       0MiB / 143771MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|  No running processes found                                                             |
++-----------------------------------------------------------------------------------------+
+
+
+################################################################################
+# idle :: query (-q)
+# $ nvidia-smi -q
+################################################################################
+
+==============NVSMI LOG==============
+
+Timestamp                                              : Fri Jul  3 22:10:45 2026
+Driver Version                                         : 590.48.01
+CUDA Version                                           : 13.1
+
+Attached GPUs                                          : 1
+GPU 00000000:83:00.0
+    Product Name                                       : NVIDIA H200
+    Product Brand                                      : NVIDIA
+    Product Architecture                               : Hopper
+    Display Mode                                       : Requested functionality has been deprecated
+    Display Attached                                   : Yes
+    Display Active                                     : Disabled
+    Persistence Mode                                   : Enabled
+    Addressing Mode                                    : None
+    MIG Mode
+        Current                                        : Disabled
+        Pending                                        : Disabled
+    Accounting Mode                                    : Disabled
+    Accounting Mode Buffer Size                        : 4000
+    Driver Model
+        Current                                        : N/A
+        Pending                                        : N/A
+    Serial Number                                      : 0000000000000
+    GPU UUID                                           : GPU-00000000-0000-0000-0000-000000000000
+    GPU PDI                                            : 0x737bb8d09327f7d9
+    Minor Number                                       : 0
+    VBIOS Version                                      : 96.00.A5.00.03
+    MultiGPU Board                                     : No
+    Board ID                                           : 0x8300
+    Board Part Number                                  : 695-2G520-0280-001
+    GPU Part Number                                    : 2335-895-A1
+    FRU Part Number                                    : N/A
+    Platform Info
+        Chassis Serial Number                          : N/A
+        Slot Number                                    : N/A
+        Tray Index                                     : N/A
+        Host ID                                        : N/A
+        Peer Type                                      : N/A
+        Module Id                                      : 1
+        GPU Fabric GUID                                : N/A
+    Inforom Version
+        Image Version                                  : G520.0280.02.02
+        OEM Object                                     : 2.1
+        ECC Object                                     : 7.16
+        Power Management Object                        : N/A
+    Inforom BBX Object Flush
+        Latest Timestamp                               : N/A
+        Latest Duration                                : N/A
+    GPU Operation Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    GPU C2C Mode                                       : Disabled
+    GPU Virtualization Mode
+        Virtualization Mode                            : Pass-Through
+        Host VGPU Mode                                 : N/A
+        vGPU Heterogeneous Mode                        : N/A
+    GPU Recovery Action                                : None
+    GSP Firmware Version                               : 590.48.01
+    IBMNPU
+        Relaxed Ordering Mode                          : N/A
+    PCI
+        Bus                                            : 0x83
+        Device                                         : 0x00
+        Domain                                         : 0x0000
+        Base Classcode                                 : 0x3
+        Sub Classcode                                  : 0x2
+        Device Id                                      : 0x233510DE
+        Bus Id                                         : 00000000:83:00.0
+        Sub System Id                                  : 0x18BE10DE
+        GPU Link Info
+            PCIe Generation
+                Max                                    : 5
+                Current                                : 5
+                Device Current                         : 5
+                Device Max                             : 5
+                Host Max                               : N/A
+            Link Width
+                Max                                    : 16x
+                Current                                : 16x
+        Bridge Chip
+            Type                                       : N/A
+            Firmware                                   : N/A
+        Replays Since Reset                            : 0
+        Replay Number Rollovers                        : 0
+        Tx Throughput                                  : 371 KB/s
+        Rx Throughput                                  : 337 KB/s
+        Atomic Caps Outbound                           : N/A
+        Atomic Caps Inbound                            : N/A
+    Fan Speed                                          : N/A
+    Performance State                                  : P0
+    Clocks Event Reasons
+        Idle                                           : Active
+        Applications Clocks Setting                    : Not Active
+        SW Power Cap                                   : Not Active
+        HW Slowdown                                    : Not Active
+            HW Thermal Slowdown                        : Not Active
+            HW Power Brake Slowdown                    : Not Active
+        Sync Boost                                     : Not Active
+        SW Thermal Slowdown                            : Not Active
+        Display Clock Setting                          : Not Active
+    Clocks Event Reasons Counters
+        SW Power Capping                               : 0 us
+        Sync Boost                                     : 0 us
+        SW Thermal Slowdown                            : 0 us
+        HW Thermal Slowdown                            : 0 us
+        HW Power Braking                               : 0 us
+    Sparse Operation Mode                              : Disabled
+    FB Memory Usage
+        Total                                          : 143771 MiB
+        Reserved                                       : 614 MiB
+        Used                                           : 0 MiB
+        Free                                           : 143158 MiB
+    BAR1 Memory Usage
+        Total                                          : 262144 MiB
+        Used                                           : 1 MiB
+        Free                                           : 262143 MiB
+    Conf Compute Protected Memory Usage
+        Total                                          : 0 MiB
+        Used                                           : 0 MiB
+        Free                                           : 0 MiB
+    Compute Mode                                       : Default
+    Utilization
+        GPU                                            : 0 %
+        Memory                                         : 0 %
+        Encoder                                        : 0 %
+        Decoder                                        : 0 %
+        JPEG                                           : 0 %
+        OFA                                            : 0 %
+    Encoder Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    FBC Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    DRAM Encryption Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    ECC Mode
+        Current                                        : Enabled
+        Pending                                        : Enabled
+    ECC Errors
+        Volatile
+            SRAM Correctable                           : 0
+            SRAM Uncorrectable Parity                  : 0
+            SRAM Uncorrectable SEC-DED                 : 0
+            DRAM Correctable                           : 0
+            DRAM Uncorrectable                         : 0
+        Aggregate
+            SRAM Correctable                           : 0
+            SRAM Uncorrectable Parity                  : 0
+            SRAM Uncorrectable SEC-DED                 : 0
+            DRAM Correctable                           : 0
+            DRAM Uncorrectable                         : 0
+            SRAM Threshold Exceeded                    : No
+        Aggregate Uncorrectable SRAM Sources
+            SRAM L2                                    : 0
+            SRAM SM                                    : 0
+            SRAM Microcontroller                       : 0
+            SRAM PCIE                                  : 0
+            SRAM Other                                 : 0
+        Channel Repair Pending                         : No
+        TPC Repair Pending                             : No
+        Unrepairable Memory                            : No
+    Retired Pages
+        Single Bit ECC                                 : N/A
+        Double Bit ECC                                 : N/A
+        Pending Page Blacklist                         : N/A
+    Remapped Rows
+        Correctable Error                              : 0
+        Uncorrectable Error                            : 0
+        Pending                                        : No
+        Remapping Failure Occurred                     : No
+        Bank Remap Availability Histogram
+            Max                                        : 3072 bank(s)
+            High                                       : 0 bank(s)
+            Partial                                    : 0 bank(s)
+            Low                                        : 0 bank(s)
+            None                                       : 0 bank(s)
+    Temperature
+        GPU Current Temp                               : 28 C
+        GPU T.Limit Temp                               : 59 C
+        GPU Shutdown T.Limit Temp                      : -8 C
+        GPU Slowdown T.Limit Temp                      : -2 C
+        GPU Max Operating T.Limit Temp                 : 0 C
+        GPU Target Temperature                         : N/A
+        Memory Current Temp                            : 32 C
+        Memory Max Operating T.Limit Temp              : 0 C
+    GPU Power Readings
+        Average Power Draw                             : 77.67 W
+        Instantaneous Power Draw                       : 77.88 W
+        Current Power Limit                            : 700.00 W
+        Requested Power Limit                          : 700.00 W
+        Default Power Limit                            : 700.00 W
+        Min Power Limit                                : 200.00 W
+        Max Power Limit                                : 700.00 W
+    GPU Memory Power Readings 
+        Average Power Draw                             : 46.56 W
+        Instantaneous Power Draw                       : N/A
+    Module Power Readings
+        Average Power Draw                             : N/A
+        Instantaneous Power Draw                       : N/A
+        Current Power Limit                            : N/A
+        Requested Power Limit                          : N/A
+        Default Power Limit                            : N/A
+        Min Power Limit                                : N/A
+        Max Power Limit                                : N/A
+    Power Smoothing                                    : N/A
+    Workload Power Profiles
+        Requested Profiles                             : N/A
+        Enforced Profiles                              : N/A
+    EDPp Multiplier                                    : 100.00%
+    Clocks
+        Graphics                                       : 345 MHz
+        SM                                             : 345 MHz
+        Memory                                         : 3201 MHz
+        Video                                          : 765 MHz
+    Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Default Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Deferred Clocks
+        Memory                                         : N/A
+    Max Clocks
+        Graphics                                       : 1980 MHz
+        SM                                             : 1980 MHz
+        Memory                                         : 3201 MHz
+        Video                                          : 1545 MHz
+    Max Customer Boost Clocks
+        Graphics                                       : 1980 MHz
+    Clock Policy
+        Auto Boost                                     : N/A
+        Auto Boost Default                             : N/A
+    Fabric
+        State                                          : Completed
+        Status                                         : Success
+        CliqueId                                       : 0
+        ClusterUUID                                    : 00000000-0000-0000-0000-000000000000
+        Health
+            Summary                                    : N/A
+            Bandwidth                                  : N/A
+            Route Recovery in progress                 : N/A
+            Route Unhealthy                            : N/A
+            Access Timeout Recovery                    : N/A
+            Incorrect Configuration                    : N/A
+    Processes                                          : None
+    Capabilities
+        EGM                                            : disabled
+
+
+
+################################################################################
+# idle :: query-gpu (csv, what the exporter parses)
+# $ nvidia-smi --query-gpu=timestamp,driver_version,vgpu_driver_capability.heterogenous_multivGPU,count,name,serial,uuid,pci.bus_id,pci.domain,pci.bus,pci.device,pci.baseClass,pci.subClass,pci.device_id,pci.sub_device_id,vgpu_device_capability.fractional_multiVgpu,vgpu_device_capability.heterogeneous_timeSlice_profile,vgpu_device_capability.heterogeneous_timeSlice_sizes,vgpu_device_capability.homogeneous_placements,vgpu_device_capability.mig_timeSlicing,vgpu_device_capability.mig_timeSlicing_mode,pcie.link.gen.current,pcie.link.gen.gpucurrent,pcie.link.gen.max,pcie.link.gen.gpumax,pcie.link.gen.hostmax,pcie.link.width.current,pcie.link.width.max,index,display_mode,display_attached,display_active,persistence_mode,addressing_mode,accounting.mode,accounting.buffer_size,driver_model.current,driver_model.pending,vbios_version,inforom.img,inforom.oem,inforom.ecc,inforom.pwr,inforom.checksum_validation,gpu_recovery_action,gom.current,gom.pending,fan.speed,pstate,clocks_event_reasons.supported,clocks_event_reasons.active,clocks_event_reasons.gpu_idle,clocks_event_reasons.applications_clocks_setting,clocks_event_reasons.sw_power_cap,clocks_event_reasons.hw_slowdown,clocks_event_reasons.hw_thermal_slowdown,clocks_event_reasons.hw_power_brake_slowdown,clocks_event_reasons.sw_thermal_slowdown,clocks_event_reasons.sync_boost,clocks_event_reasons_counters.sw_power_cap,clocks_event_reasons_counters.sync_boost,clocks_event_reasons_counters.sw_thermal_slowdown,clocks_event_reasons_counters.hw_thermal_slowdown,clocks_event_reasons_counters.hw_power_brake_slowdown,memory.total,memory.reserved,memory.used,memory.free,compute_mode,compute_cap,utilization.gpu,utilization.memory,utilization.encoder,utilization.decoder,utilization.jpeg,utilization.ofa,encoder.stats.sessionCount,encoder.stats.averageFps,encoder.stats.averageLatency,dramEncryption.mode.current,dramEncryption.mode.pending,ecc.mode.current,ecc.mode.pending,ecc.errors.corrected.volatile.device_memory,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.volatile.register_file,ecc.errors.corrected.volatile.l1_cache,ecc.errors.corrected.volatile.l2_cache,ecc.errors.corrected.volatile.texture_memory,ecc.errors.corrected.volatile.cbu,ecc.errors.corrected.volatile.sram,ecc.errors.corrected.volatile.total,ecc.errors.corrected.aggregate.device_memory,ecc.errors.corrected.aggregate.dram,ecc.errors.corrected.aggregate.register_file,ecc.errors.corrected.aggregate.l1_cache,ecc.errors.corrected.aggregate.l2_cache,ecc.errors.corrected.aggregate.texture_memory,ecc.errors.corrected.aggregate.cbu,ecc.errors.corrected.aggregate.sram,ecc.errors.corrected.aggregate.total,ecc.errors.uncorrected.volatile.device_memory,ecc.errors.uncorrected.volatile.dram,ecc.errors.uncorrected.volatile.register_file,ecc.errors.uncorrected.volatile.l1_cache,ecc.errors.uncorrected.volatile.l2_cache,ecc.errors.uncorrected.volatile.texture_memory,ecc.errors.uncorrected.volatile.cbu,ecc.errors.uncorrected.volatile.sram,ecc.errors.uncorrected.volatile.total,ecc.errors.uncorrected.aggregate.device_memory,ecc.errors.uncorrected.aggregate.dram,ecc.errors.uncorrected.aggregate.register_file,ecc.errors.uncorrected.aggregate.l1_cache,ecc.errors.uncorrected.aggregate.l2_cache,ecc.errors.uncorrected.aggregate.texture_memory,ecc.errors.uncorrected.aggregate.cbu,ecc.errors.uncorrected.aggregate.sram,ecc.errors.uncorrected.aggregate.total,ecc.errors.uncorrected.volatile.sram.parity,ecc.errors.uncorrected.volatile.sram.secded,ecc.errors.uncorrected.aggregate.sram.parity,ecc.errors.uncorrected.aggregate.sram.secded,ecc.errors.uncorrected.aggregate.sram.thresholdExceeded,ecc.errors.uncorrected.aggregate.sram.l2,ecc.errors.uncorrected.aggregate.sram.sm,ecc.errors.uncorrected.aggregate.sram.mcu,ecc.errors.uncorrected.aggregate.sram.pcie,ecc.errors.uncorrected.aggregate.sram.other,retired_pages.single_bit_ecc.count,retired_pages.double_bit.count,retired_pages.pending,remapped_rows.correctable,remapped_rows.uncorrectable,remapped_rows.pending,remapped_rows.failure,remapped_rows.histogram.max,remapped_rows.histogram.high,remapped_rows.histogram.partial,remapped_rows.histogram.low,remapped_rows.histogram.none,temperature.gpu,temperature.gpu.tlimit,temperature.memory,power.management,power.draw,power.draw.average,power.draw.instant,power.limit,enforced.power.limit,power.default_limit,power.min_limit,power.max_limit,module.power.draw.average,module.power.draw.instant,module.power.limit,module.enforced.power.limit,module.power.default_limit,module.power.min_limit,module.power.max_limit,power_smoothing.delayed_power_smoothing_supported,power_smoothing.primary_power_floor,power_smoothing.secondary_power_floor,power_smoothing.min_primary_floor_activation_offset,power_smoothing.min_primary_floor_activation_point,power_smoothing.window_multiplier,power_smoothing.curr_profile.secondary_power_floor,power_smoothing.curr_profile.primary_floor_act_window_multiplier,power_smoothing.curr_profile.primary_floor_tar_window_multiplier,power_smoothing.curr_profile.primary_floor_act_offset,power_smoothing.admin_override.secondary_power_floor,power_smoothing.admin_override.primary_floor_act_window_multiplier,power_smoothing.admin_override.primary_floor_tar_window_multiplier,power_smoothing.admin_override.primary_floor_act_offset,edpp_multiplier,clocks.current.graphics,clocks.current.sm,clocks.current.memory,clocks.current.video,clocks.applications.graphics,clocks.applications.memory,clocks.default_applications.graphics,clocks.default_applications.memory,clocks.max.graphics,clocks.max.sm,clocks.max.memory,mig.mode.current,mig.mode.pending,gsp.mode.current,gsp.mode.default,c2c.mode,protected_memory.total,protected_memory.used,protected_memory.free,fabric.state,fabric.status,fabric.cliqueId,fabric.clusterUuid,fabric.health.summary,fabric.health.bandwidth,fabric.health.route_recovery_in_progress,fabric.health.route_unhealthy,fabric.health.access_timeout_recovery,fabric.health.incorrect_configuration,platform.chassis_serial_number,platform.slot_number,platform.tray_index,platform.host_id,platform.peer_type,platform.module_id,platform.gpu_fabric_guid,hostname --format=csv
+################################################################################
+timestamp, driver_version, vgpu_driver_capability.heterogenous_multivGPU, count, name, serial, uuid, pci.bus_id, pci.domain, pci.bus, pci.device, pci.baseClass, pci.subClass, pci.device_id, pci.sub_device_id, vgpu_device_capability.fractional_multiVgpu, vgpu_device_capability.heterogeneous_timeSlice_profile, vgpu_device_capability.heterogeneous_timeSlice_sizes, vgpu_device_capability.homogeneous_placements, vgpu_device_capability.mig_timeSlicing, vgpu_device_capability.mig_timeSlicing_mode, pcie.link.gen.current, pcie.link.gen.gpucurrent, pcie.link.gen.max, pcie.link.gen.gpumax, pcie.link.gen.hostmax, pcie.link.width.current, pcie.link.width.max, index, display_mode, display_attached, display_active, persistence_mode, addressing_mode, accounting.mode, accounting.buffer_size, driver_model.current, driver_model.pending, vbios_version, inforom.img, inforom.oem, inforom.ecc, inforom.pwr, inforom.checksum_validation, gpu_recovery_action, gom.current, gom.pending, fan.speed [%], pstate, clocks_event_reasons.supported, clocks_event_reasons.active, clocks_event_reasons.gpu_idle, clocks_event_reasons.applications_clocks_setting, clocks_event_reasons.sw_power_cap, clocks_event_reasons.hw_slowdown, clocks_event_reasons.hw_thermal_slowdown, clocks_event_reasons.hw_power_brake_slowdown, clocks_event_reasons.sw_thermal_slowdown, clocks_event_reasons.sync_boost, clocks_event_reasons_counters.sw_power_cap [us], clocks_event_reasons_counters.sync_boost [us], clocks_event_reasons_counters.sw_thermal_slowdown [us], clocks_event_reasons_counters.hw_thermal_slowdown [us], clocks_event_reasons_counters.hw_power_brake_slowdown [us], memory.total [MiB], memory.reserved [MiB], memory.used [MiB], memory.free [MiB], compute_mode, compute_cap, utilization.gpu [%], utilization.memory [%], utilization.encoder [%], utilization.decoder [%], utilization.jpeg [%], utilization.ofa [%], encoder.stats.sessionCount, encoder.stats.averageFps, encoder.stats.averageLatency, dramEncryption.mode.current, dramEncryption.mode.pending, ecc.mode.current, ecc.mode.pending, ecc.errors.corrected.volatile.device_memory, ecc.errors.corrected.volatile.dram, ecc.errors.corrected.volatile.register_file, ecc.errors.corrected.volatile.l1_cache, ecc.errors.corrected.volatile.l2_cache, ecc.errors.corrected.volatile.texture_memory, ecc.errors.corrected.volatile.cbu, ecc.errors.corrected.volatile.sram, ecc.errors.corrected.volatile.total, ecc.errors.corrected.aggregate.device_memory, ecc.errors.corrected.aggregate.dram, ecc.errors.corrected.aggregate.register_file, ecc.errors.corrected.aggregate.l1_cache, ecc.errors.corrected.aggregate.l2_cache, ecc.errors.corrected.aggregate.texture_memory, ecc.errors.corrected.aggregate.cbu, ecc.errors.corrected.aggregate.sram, ecc.errors.corrected.aggregate.total, ecc.errors.uncorrected.volatile.device_memory, ecc.errors.uncorrected.volatile.dram, ecc.errors.uncorrected.volatile.register_file, ecc.errors.uncorrected.volatile.l1_cache, ecc.errors.uncorrected.volatile.l2_cache, ecc.errors.uncorrected.volatile.texture_memory, ecc.errors.uncorrected.volatile.cbu, ecc.errors.uncorrected.volatile.sram, ecc.errors.uncorrected.volatile.total, ecc.errors.uncorrected.aggregate.device_memory, ecc.errors.uncorrected.aggregate.dram, ecc.errors.uncorrected.aggregate.register_file, ecc.errors.uncorrected.aggregate.l1_cache, ecc.errors.uncorrected.aggregate.l2_cache, ecc.errors.uncorrected.aggregate.texture_memory, ecc.errors.uncorrected.aggregate.cbu, ecc.errors.uncorrected.aggregate.sram, ecc.errors.uncorrected.aggregate.total, ecc.errors.uncorrected.volatile.sram.parity, ecc.errors.uncorrected.volatile.sram.secded, ecc.errors.uncorrected.aggregate.sram.parity, ecc.errors.uncorrected.aggregate.sram.secded, ecc.errors.uncorrected.aggregate.sram.thresholdExceeded, ecc.errors.uncorrected.aggregate.sram.l2, ecc.errors.uncorrected.aggregate.sram.sm, ecc.errors.uncorrected.aggregate.sram.mcu, ecc.errors.uncorrected.aggregate.sram.pcie, ecc.errors.uncorrected.aggregate.sram.other, retired_pages.single_bit_ecc.count, retired_pages.double_bit.count, retired_pages.pending, remapped_rows.correctable, remapped_rows.uncorrectable, remapped_rows.pending, remapped_rows.failure, remapped_rows.histogram.max, remapped_rows.histogram.high, remapped_rows.histogram.partial, remapped_rows.histogram.low, remapped_rows.histogram.none, temperature.gpu, temperature.gpu.tlimit, temperature.memory, power.management, power.draw [W], power.draw.average [W], power.draw.instant [W], power.limit [W], enforced.power.limit [W], power.default_limit [W], power.min_limit [W], power.max_limit [W], module.power.draw.average [W], module.power.draw.instant [W], module.power.limit [W], module.enforced.power.limit [W], module.power.default_limit [W], module.power.min_limit [W], module.power.max_limit [W], power_smoothing.delayed_power_smoothing_supported, power_smoothing.primary_power_floor [W], power_smoothing.secondary_power_floor [W], power_smoothing.min_primary_floor_activation_offset [W], power_smoothing.min_primary_floor_activation_point [W], power_smoothing.window_multiplier [ms], power_smoothing.curr_profile.secondary_power_floor [W], power_smoothing.curr_profile.primary_floor_act_window_multiplier, power_smoothing.curr_profile.primary_floor_tar_window_multiplier, power_smoothing.curr_profile.primary_floor_act_offset [W], power_smoothing.admin_override.secondary_power_floor [W], power_smoothing.admin_override.primary_floor_act_window_multiplier, power_smoothing.admin_override.primary_floor_tar_window_multiplier, power_smoothing.admin_override.primary_floor_act_offset [W], edpp_multiplier [%], clocks.current.graphics [MHz], clocks.current.sm [MHz], clocks.current.memory [MHz], clocks.current.video [MHz], clocks.applications.graphics [MHz], clocks.applications.memory [MHz], clocks.default_applications.graphics [MHz], clocks.default_applications.memory [MHz], clocks.max.graphics [MHz], clocks.max.sm [MHz], clocks.max.memory [MHz], mig.mode.current, mig.mode.pending, gsp.mode.current, gsp.mode.default, c2c.mode, protected_memory.total [MiB], protected_memory.used [MiB], protected_memory.free [MiB], fabric.state, fabric.status, fabric.cliqueId, fabric.clusterUuid, fabric.health.summary, fabric.health.bandwidth, fabric.health.route_recovery_in_progress, fabric.health.route_unhealthy, fabric.health.access_timeout_recovery, fabric.health.incorrect_configuration, platform.chassis_serial_number, platform.slot_number, platform.tray_index, platform.host_id, platform.peer_type, platform.module_id, platform.gpu_fabric_guid, hostname
+2026/07/03 22:10:46.109, 590.48.01, [N/A], 1, NVIDIA H200, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, 00000000:83:00.0, 0x0000, 0x83, 0x00, 0x3, 0x2, 0x233510DE, 0x18BE10DE, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 5, 5, 5, 5, [N/A], 16, 16, 0, [Requested functionality has been deprecated], Yes, Disabled, Enabled, None, Disabled, 4000, [N/A], [N/A], 96.00.A5.00.03, G520.0280.02.02, 2.1, 7.16, [N/A], valid, None, [N/A], [N/A], [N/A], P0, 0x00000000000001FF, 0x0000000000000001, Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, 0 us, 0 us, 0 us, 0 us, 0 us, 143771 MiB, 614 MiB, 0 MiB, 143158 MiB, Default, 9.0, 0 %, 0 %, 0 %, 0 %, 0 %, 0 %, 0, 0, 0, [N/A], [N/A], Enabled, Enabled, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, 0, 0, No, 0, 0, 0, 0, 0, [N/A], [N/A], [N/A], 0, 0, No, No, 3072, 0, 0, 0, 0, 28, 59, 32, [Requested functionality has been deprecated], 77.71 W, 77.71 W, 78.21 W, 700.00 W, 700.00 W, 700.00 W, 200.00 W, 700.00 W, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 100.00 %, 345 MHz, 345 MHz, 3201 MHz, 765 MHz, [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], 1980 MHz, 1980 MHz, 3201 MHz, Disabled, Disabled, Enabled, Enabled, Disabled, 0 MiB, 0 MiB, 0 MiB, Completed, Success, 0, 00000000-0000-0000-0000-000000000000, N/A, N/A, N/A, N/A, N/A, N/A, , 0, 0, 1, Direct Connected, 1, 0x0000000000000000, [N/A]
+
+
+################################################################################
+# idle :: query-compute-apps (per-process)
+# $ nvidia-smi --query-compute-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,process_name,used_gpu_memory --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, process_name, used_gpu_memory [MiB]
+
+
+################################################################################
+# idle :: query-accounted-apps
+# $ nvidia-smi --query-accounted-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,gpu_util,mem_util,max_memory_usage,time --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, gpu_utilization [%], mem_utilization [%], max_memory_usage [MiB], time [ms]
+
+
+################################################################################
+# idle :: query-retired-pages
+# $ nvidia-smi --query-retired-pages=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,retired_pages.address,retired_pages.timestamp,retired_pages.cause --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, retired_pages.address, retired_pages.timestamp, retired_pages.cause
+2026/07/03 22:10:46.307, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Single Bit ECC
+2026/07/03 22:10:46.307, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Double Bit ECC
+
+
+################################################################################
+# idle :: pmon (per-process monitor)
+# $ nvidia-smi pmon -c 5
+################################################################################
+# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
+# Idx           #    C/G      %      %      %      %      %      %    name 
+    0          -     -      -      -      -      -      -      -    -              
+    0          -     -      -      -      -      -      -      -    -              
+    0          -     -      -      -      -      -      -      -    -              
+    0          -     -      -      -      -      -      -      -    -              
+    0          -     -      -      -      -      -      -      -    -              
+
+
+################################################################################
+# idle :: dmon (per-device monitor, incl. PCIe rx/tx)
+# $ nvidia-smi dmon -c 5
+################################################################################
+# gpu    pwr  gtemp  mtemp     sm    mem    enc    dec    jpg    ofa   mclk   pclk 
+# Idx      W      C      C      %      %      %      %      %      %    MHz    MHz 
+    0     77     28     31      0      0      0      0      0      0   3201    345 
+    0     77     28     32      0      0      0      0      0      0   3201    345 
+    0     77     28     32      0      0      0      0      0      0   3201    345 
+    0     77     28     32      0      0      0      0      0      0   3201    345 
+    0     77     28     32      0      0      0      0      0      0   3201    345 
+
+
+################################################################################
+# load :: nvidia-smi (default table)
+# $ nvidia-smi 
+################################################################################
+Fri Jul  3 22:11:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 590.48.01              Driver Version: 590.48.01      CUDA Version: 13.1     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H200                    On  |   00000000:83:00.0 Off |                    0 |
+| N/A   52C    P0            628W /  700W |   32362MiB / 143771MiB |    100%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           10291      C   /root/tools/memhog                     2566MiB |
+|    0   N/A  N/A           10293      C   /root/tools/memhog                     1542MiB |
+|    0   N/A  N/A           10309      C   ./gpu_burn                            28234MiB |
++-----------------------------------------------------------------------------------------+
+
+
+################################################################################
+# load :: query (-q)
+# $ nvidia-smi -q
+################################################################################
+
+==============NVSMI LOG==============
+
+Timestamp                                              : Fri Jul  3 22:11:09 2026
+Driver Version                                         : 590.48.01
+CUDA Version                                           : 13.1
+
+Attached GPUs                                          : 1
+GPU 00000000:83:00.0
+    Product Name                                       : NVIDIA H200
+    Product Brand                                      : NVIDIA
+    Product Architecture                               : Hopper
+    Display Mode                                       : Requested functionality has been deprecated
+    Display Attached                                   : Yes
+    Display Active                                     : Disabled
+    Persistence Mode                                   : Enabled
+    Addressing Mode                                    : None
+    MIG Mode
+        Current                                        : Disabled
+        Pending                                        : Disabled
+    Accounting Mode                                    : Disabled
+    Accounting Mode Buffer Size                        : 4000
+    Driver Model
+        Current                                        : N/A
+        Pending                                        : N/A
+    Serial Number                                      : 0000000000000
+    GPU UUID                                           : GPU-00000000-0000-0000-0000-000000000000
+    GPU PDI                                            : 0x737bb8d09327f7d9
+    Minor Number                                       : 0
+    VBIOS Version                                      : 96.00.A5.00.03
+    MultiGPU Board                                     : No
+    Board ID                                           : 0x8300
+    Board Part Number                                  : 695-2G520-0280-001
+    GPU Part Number                                    : 2335-895-A1
+    FRU Part Number                                    : N/A
+    Platform Info
+        Chassis Serial Number                          : N/A
+        Slot Number                                    : N/A
+        Tray Index                                     : N/A
+        Host ID                                        : N/A
+        Peer Type                                      : N/A
+        Module Id                                      : 1
+        GPU Fabric GUID                                : N/A
+    Inforom Version
+        Image Version                                  : G520.0280.02.02
+        OEM Object                                     : 2.1
+        ECC Object                                     : 7.16
+        Power Management Object                        : N/A
+    Inforom BBX Object Flush
+        Latest Timestamp                               : N/A
+        Latest Duration                                : N/A
+    GPU Operation Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    GPU C2C Mode                                       : Disabled
+    GPU Virtualization Mode
+        Virtualization Mode                            : Pass-Through
+        Host VGPU Mode                                 : N/A
+        vGPU Heterogeneous Mode                        : N/A
+    GPU Recovery Action                                : None
+    GSP Firmware Version                               : 590.48.01
+    IBMNPU
+        Relaxed Ordering Mode                          : N/A
+    PCI
+        Bus                                            : 0x83
+        Device                                         : 0x00
+        Domain                                         : 0x0000
+        Base Classcode                                 : 0x3
+        Sub Classcode                                  : 0x2
+        Device Id                                      : 0x233510DE
+        Bus Id                                         : 00000000:83:00.0
+        Sub System Id                                  : 0x18BE10DE
+        GPU Link Info
+            PCIe Generation
+                Max                                    : 5
+                Current                                : 5
+                Device Current                         : 5
+                Device Max                             : 5
+                Host Max                               : N/A
+            Link Width
+                Max                                    : 16x
+                Current                                : 16x
+        Bridge Chip
+            Type                                       : N/A
+            Firmware                                   : N/A
+        Replays Since Reset                            : 0
+        Replay Number Rollovers                        : 0
+        Tx Throughput                                  : 4217 KB/s
+        Rx Throughput                                  : 8691 KB/s
+        Atomic Caps Outbound                           : N/A
+        Atomic Caps Inbound                            : N/A
+    Fan Speed                                          : N/A
+    Performance State                                  : P0
+    Clocks Event Reasons
+        Idle                                           : Not Active
+        Applications Clocks Setting                    : Not Active
+        SW Power Cap                                   : Not Active
+        HW Slowdown                                    : Not Active
+            HW Thermal Slowdown                        : Not Active
+            HW Power Brake Slowdown                    : Not Active
+        Sync Boost                                     : Not Active
+        SW Thermal Slowdown                            : Not Active
+        Display Clock Setting                          : Not Active
+    Clocks Event Reasons Counters
+        SW Power Capping                               : 0 us
+        Sync Boost                                     : 0 us
+        SW Thermal Slowdown                            : 0 us
+        HW Thermal Slowdown                            : 0 us
+        HW Power Braking                               : 0 us
+    Sparse Operation Mode                              : Disabled
+    FB Memory Usage
+        Total                                          : 143771 MiB
+        Reserved                                       : 614 MiB
+        Used                                           : 32362 MiB
+        Free                                           : 110796 MiB
+    BAR1 Memory Usage
+        Total                                          : 262144 MiB
+        Used                                           : 32363 MiB
+        Free                                           : 229781 MiB
+    Conf Compute Protected Memory Usage
+        Total                                          : 0 MiB
+        Used                                           : 0 MiB
+        Free                                           : 0 MiB
+    Compute Mode                                       : Default
+    Utilization
+        GPU                                            : 100 %
+        Memory                                         : 7 %
+        Encoder                                        : 0 %
+        Decoder                                        : 0 %
+        JPEG                                           : 0 %
+        OFA                                            : 0 %
+    Encoder Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    FBC Stats
+        Active Sessions                                : 0
+        Average FPS                                    : 0
+        Average Latency                                : 0
+    DRAM Encryption Mode
+        Current                                        : N/A
+        Pending                                        : N/A
+    ECC Mode
+        Current                                        : Enabled
+        Pending                                        : Enabled
+    ECC Errors
+        Volatile
+            SRAM Correctable                           : 0
+            SRAM Uncorrectable Parity                  : 0
+            SRAM Uncorrectable SEC-DED                 : 0
+            DRAM Correctable                           : 0
+            DRAM Uncorrectable                         : 0
+        Aggregate
+            SRAM Correctable                           : 0
+            SRAM Uncorrectable Parity                  : 0
+            SRAM Uncorrectable SEC-DED                 : 0
+            DRAM Correctable                           : 0
+            DRAM Uncorrectable                         : 0
+            SRAM Threshold Exceeded                    : No
+        Aggregate Uncorrectable SRAM Sources
+            SRAM L2                                    : 0
+            SRAM SM                                    : 0
+            SRAM Microcontroller                       : 0
+            SRAM PCIE                                  : 0
+            SRAM Other                                 : 0
+        Channel Repair Pending                         : No
+        TPC Repair Pending                             : No
+        Unrepairable Memory                            : No
+    Retired Pages
+        Single Bit ECC                                 : N/A
+        Double Bit ECC                                 : N/A
+        Pending Page Blacklist                         : N/A
+    Remapped Rows
+        Correctable Error                              : 0
+        Uncorrectable Error                            : 0
+        Pending                                        : No
+        Remapping Failure Occurred                     : No
+        Bank Remap Availability Histogram
+            Max                                        : 3072 bank(s)
+            High                                       : 0 bank(s)
+            Partial                                    : 0 bank(s)
+            Low                                        : 0 bank(s)
+            None                                       : 0 bank(s)
+    Temperature
+        GPU Current Temp                               : 52 C
+        GPU T.Limit Temp                               : 35 C
+        GPU Shutdown T.Limit Temp                      : -8 C
+        GPU Slowdown T.Limit Temp                      : -2 C
+        GPU Max Operating T.Limit Temp                 : 0 C
+        GPU Target Temperature                         : N/A
+        Memory Current Temp                            : 41 C
+        Memory Max Operating T.Limit Temp              : 0 C
+    GPU Power Readings
+        Average Power Draw                             : 627.32 W
+        Instantaneous Power Draw                       : 625.24 W
+        Current Power Limit                            : 700.00 W
+        Requested Power Limit                          : 700.00 W
+        Default Power Limit                            : 700.00 W
+        Min Power Limit                                : 200.00 W
+        Max Power Limit                                : 700.00 W
+    GPU Memory Power Readings 
+        Average Power Draw                             : 97.69 W
+        Instantaneous Power Draw                       : N/A
+    Module Power Readings
+        Average Power Draw                             : N/A
+        Instantaneous Power Draw                       : N/A
+        Current Power Limit                            : N/A
+        Requested Power Limit                          : N/A
+        Default Power Limit                            : N/A
+        Min Power Limit                                : N/A
+        Max Power Limit                                : N/A
+    Power Smoothing                                    : N/A
+    Workload Power Profiles
+        Requested Profiles                             : N/A
+        Enforced Profiles                              : N/A
+    EDPp Multiplier                                    : 100.00%
+    Clocks
+        Graphics                                       : 1980 MHz
+        SM                                             : 1980 MHz
+        Memory                                         : 3201 MHz
+        Video                                          : 1545 MHz
+    Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Default Applications Clocks
+        Graphics                                       : Requested functionality has been deprecated
+        Memory                                         : Requested functionality has been deprecated
+    Deferred Clocks
+        Memory                                         : N/A
+    Max Clocks
+        Graphics                                       : 1980 MHz
+        SM                                             : 1980 MHz
+        Memory                                         : 3201 MHz
+        Video                                          : 1545 MHz
+    Max Customer Boost Clocks
+        Graphics                                       : 1980 MHz
+    Clock Policy
+        Auto Boost                                     : N/A
+        Auto Boost Default                             : N/A
+    Fabric
+        State                                          : Completed
+        Status                                         : Success
+        CliqueId                                       : 0
+        ClusterUUID                                    : 00000000-0000-0000-0000-000000000000
+        Health
+            Summary                                    : N/A
+            Bandwidth                                  : N/A
+            Route Recovery in progress                 : N/A
+            Route Unhealthy                            : N/A
+            Access Timeout Recovery                    : N/A
+            Incorrect Configuration                    : N/A
+    Processes
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 10291
+            Type                          : C
+            Name                          : /root/tools/memhog
+            Used GPU Memory               : 2566 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 10293
+            Type                          : C
+            Name                          : /root/tools/memhog
+            Used GPU Memory               : 1542 MiB
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 10309
+            Type                          : C
+            Name                          : ./gpu_burn
+            Used GPU Memory               : 28234 MiB
+    Capabilities
+        EGM                                            : disabled
+
+
+
+################################################################################
+# load :: query-gpu (csv, what the exporter parses)
+# $ nvidia-smi --query-gpu=timestamp,driver_version,vgpu_driver_capability.heterogenous_multivGPU,count,name,serial,uuid,pci.bus_id,pci.domain,pci.bus,pci.device,pci.baseClass,pci.subClass,pci.device_id,pci.sub_device_id,vgpu_device_capability.fractional_multiVgpu,vgpu_device_capability.heterogeneous_timeSlice_profile,vgpu_device_capability.heterogeneous_timeSlice_sizes,vgpu_device_capability.homogeneous_placements,vgpu_device_capability.mig_timeSlicing,vgpu_device_capability.mig_timeSlicing_mode,pcie.link.gen.current,pcie.link.gen.gpucurrent,pcie.link.gen.max,pcie.link.gen.gpumax,pcie.link.gen.hostmax,pcie.link.width.current,pcie.link.width.max,index,display_mode,display_attached,display_active,persistence_mode,addressing_mode,accounting.mode,accounting.buffer_size,driver_model.current,driver_model.pending,vbios_version,inforom.img,inforom.oem,inforom.ecc,inforom.pwr,inforom.checksum_validation,gpu_recovery_action,gom.current,gom.pending,fan.speed,pstate,clocks_event_reasons.supported,clocks_event_reasons.active,clocks_event_reasons.gpu_idle,clocks_event_reasons.applications_clocks_setting,clocks_event_reasons.sw_power_cap,clocks_event_reasons.hw_slowdown,clocks_event_reasons.hw_thermal_slowdown,clocks_event_reasons.hw_power_brake_slowdown,clocks_event_reasons.sw_thermal_slowdown,clocks_event_reasons.sync_boost,clocks_event_reasons_counters.sw_power_cap,clocks_event_reasons_counters.sync_boost,clocks_event_reasons_counters.sw_thermal_slowdown,clocks_event_reasons_counters.hw_thermal_slowdown,clocks_event_reasons_counters.hw_power_brake_slowdown,memory.total,memory.reserved,memory.used,memory.free,compute_mode,compute_cap,utilization.gpu,utilization.memory,utilization.encoder,utilization.decoder,utilization.jpeg,utilization.ofa,encoder.stats.sessionCount,encoder.stats.averageFps,encoder.stats.averageLatency,dramEncryption.mode.current,dramEncryption.mode.pending,ecc.mode.current,ecc.mode.pending,ecc.errors.corrected.volatile.device_memory,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.volatile.register_file,ecc.errors.corrected.volatile.l1_cache,ecc.errors.corrected.volatile.l2_cache,ecc.errors.corrected.volatile.texture_memory,ecc.errors.corrected.volatile.cbu,ecc.errors.corrected.volatile.sram,ecc.errors.corrected.volatile.total,ecc.errors.corrected.aggregate.device_memory,ecc.errors.corrected.aggregate.dram,ecc.errors.corrected.aggregate.register_file,ecc.errors.corrected.aggregate.l1_cache,ecc.errors.corrected.aggregate.l2_cache,ecc.errors.corrected.aggregate.texture_memory,ecc.errors.corrected.aggregate.cbu,ecc.errors.corrected.aggregate.sram,ecc.errors.corrected.aggregate.total,ecc.errors.uncorrected.volatile.device_memory,ecc.errors.uncorrected.volatile.dram,ecc.errors.uncorrected.volatile.register_file,ecc.errors.uncorrected.volatile.l1_cache,ecc.errors.uncorrected.volatile.l2_cache,ecc.errors.uncorrected.volatile.texture_memory,ecc.errors.uncorrected.volatile.cbu,ecc.errors.uncorrected.volatile.sram,ecc.errors.uncorrected.volatile.total,ecc.errors.uncorrected.aggregate.device_memory,ecc.errors.uncorrected.aggregate.dram,ecc.errors.uncorrected.aggregate.register_file,ecc.errors.uncorrected.aggregate.l1_cache,ecc.errors.uncorrected.aggregate.l2_cache,ecc.errors.uncorrected.aggregate.texture_memory,ecc.errors.uncorrected.aggregate.cbu,ecc.errors.uncorrected.aggregate.sram,ecc.errors.uncorrected.aggregate.total,ecc.errors.uncorrected.volatile.sram.parity,ecc.errors.uncorrected.volatile.sram.secded,ecc.errors.uncorrected.aggregate.sram.parity,ecc.errors.uncorrected.aggregate.sram.secded,ecc.errors.uncorrected.aggregate.sram.thresholdExceeded,ecc.errors.uncorrected.aggregate.sram.l2,ecc.errors.uncorrected.aggregate.sram.sm,ecc.errors.uncorrected.aggregate.sram.mcu,ecc.errors.uncorrected.aggregate.sram.pcie,ecc.errors.uncorrected.aggregate.sram.other,retired_pages.single_bit_ecc.count,retired_pages.double_bit.count,retired_pages.pending,remapped_rows.correctable,remapped_rows.uncorrectable,remapped_rows.pending,remapped_rows.failure,remapped_rows.histogram.max,remapped_rows.histogram.high,remapped_rows.histogram.partial,remapped_rows.histogram.low,remapped_rows.histogram.none,temperature.gpu,temperature.gpu.tlimit,temperature.memory,power.management,power.draw,power.draw.average,power.draw.instant,power.limit,enforced.power.limit,power.default_limit,power.min_limit,power.max_limit,module.power.draw.average,module.power.draw.instant,module.power.limit,module.enforced.power.limit,module.power.default_limit,module.power.min_limit,module.power.max_limit,power_smoothing.delayed_power_smoothing_supported,power_smoothing.primary_power_floor,power_smoothing.secondary_power_floor,power_smoothing.min_primary_floor_activation_offset,power_smoothing.min_primary_floor_activation_point,power_smoothing.window_multiplier,power_smoothing.curr_profile.secondary_power_floor,power_smoothing.curr_profile.primary_floor_act_window_multiplier,power_smoothing.curr_profile.primary_floor_tar_window_multiplier,power_smoothing.curr_profile.primary_floor_act_offset,power_smoothing.admin_override.secondary_power_floor,power_smoothing.admin_override.primary_floor_act_window_multiplier,power_smoothing.admin_override.primary_floor_tar_window_multiplier,power_smoothing.admin_override.primary_floor_act_offset,edpp_multiplier,clocks.current.graphics,clocks.current.sm,clocks.current.memory,clocks.current.video,clocks.applications.graphics,clocks.applications.memory,clocks.default_applications.graphics,clocks.default_applications.memory,clocks.max.graphics,clocks.max.sm,clocks.max.memory,mig.mode.current,mig.mode.pending,gsp.mode.current,gsp.mode.default,c2c.mode,protected_memory.total,protected_memory.used,protected_memory.free,fabric.state,fabric.status,fabric.cliqueId,fabric.clusterUuid,fabric.health.summary,fabric.health.bandwidth,fabric.health.route_recovery_in_progress,fabric.health.route_unhealthy,fabric.health.access_timeout_recovery,fabric.health.incorrect_configuration,platform.chassis_serial_number,platform.slot_number,platform.tray_index,platform.host_id,platform.peer_type,platform.module_id,platform.gpu_fabric_guid,hostname --format=csv
+################################################################################
+timestamp, driver_version, vgpu_driver_capability.heterogenous_multivGPU, count, name, serial, uuid, pci.bus_id, pci.domain, pci.bus, pci.device, pci.baseClass, pci.subClass, pci.device_id, pci.sub_device_id, vgpu_device_capability.fractional_multiVgpu, vgpu_device_capability.heterogeneous_timeSlice_profile, vgpu_device_capability.heterogeneous_timeSlice_sizes, vgpu_device_capability.homogeneous_placements, vgpu_device_capability.mig_timeSlicing, vgpu_device_capability.mig_timeSlicing_mode, pcie.link.gen.current, pcie.link.gen.gpucurrent, pcie.link.gen.max, pcie.link.gen.gpumax, pcie.link.gen.hostmax, pcie.link.width.current, pcie.link.width.max, index, display_mode, display_attached, display_active, persistence_mode, addressing_mode, accounting.mode, accounting.buffer_size, driver_model.current, driver_model.pending, vbios_version, inforom.img, inforom.oem, inforom.ecc, inforom.pwr, inforom.checksum_validation, gpu_recovery_action, gom.current, gom.pending, fan.speed [%], pstate, clocks_event_reasons.supported, clocks_event_reasons.active, clocks_event_reasons.gpu_idle, clocks_event_reasons.applications_clocks_setting, clocks_event_reasons.sw_power_cap, clocks_event_reasons.hw_slowdown, clocks_event_reasons.hw_thermal_slowdown, clocks_event_reasons.hw_power_brake_slowdown, clocks_event_reasons.sw_thermal_slowdown, clocks_event_reasons.sync_boost, clocks_event_reasons_counters.sw_power_cap [us], clocks_event_reasons_counters.sync_boost [us], clocks_event_reasons_counters.sw_thermal_slowdown [us], clocks_event_reasons_counters.hw_thermal_slowdown [us], clocks_event_reasons_counters.hw_power_brake_slowdown [us], memory.total [MiB], memory.reserved [MiB], memory.used [MiB], memory.free [MiB], compute_mode, compute_cap, utilization.gpu [%], utilization.memory [%], utilization.encoder [%], utilization.decoder [%], utilization.jpeg [%], utilization.ofa [%], encoder.stats.sessionCount, encoder.stats.averageFps, encoder.stats.averageLatency, dramEncryption.mode.current, dramEncryption.mode.pending, ecc.mode.current, ecc.mode.pending, ecc.errors.corrected.volatile.device_memory, ecc.errors.corrected.volatile.dram, ecc.errors.corrected.volatile.register_file, ecc.errors.corrected.volatile.l1_cache, ecc.errors.corrected.volatile.l2_cache, ecc.errors.corrected.volatile.texture_memory, ecc.errors.corrected.volatile.cbu, ecc.errors.corrected.volatile.sram, ecc.errors.corrected.volatile.total, ecc.errors.corrected.aggregate.device_memory, ecc.errors.corrected.aggregate.dram, ecc.errors.corrected.aggregate.register_file, ecc.errors.corrected.aggregate.l1_cache, ecc.errors.corrected.aggregate.l2_cache, ecc.errors.corrected.aggregate.texture_memory, ecc.errors.corrected.aggregate.cbu, ecc.errors.corrected.aggregate.sram, ecc.errors.corrected.aggregate.total, ecc.errors.uncorrected.volatile.device_memory, ecc.errors.uncorrected.volatile.dram, ecc.errors.uncorrected.volatile.register_file, ecc.errors.uncorrected.volatile.l1_cache, ecc.errors.uncorrected.volatile.l2_cache, ecc.errors.uncorrected.volatile.texture_memory, ecc.errors.uncorrected.volatile.cbu, ecc.errors.uncorrected.volatile.sram, ecc.errors.uncorrected.volatile.total, ecc.errors.uncorrected.aggregate.device_memory, ecc.errors.uncorrected.aggregate.dram, ecc.errors.uncorrected.aggregate.register_file, ecc.errors.uncorrected.aggregate.l1_cache, ecc.errors.uncorrected.aggregate.l2_cache, ecc.errors.uncorrected.aggregate.texture_memory, ecc.errors.uncorrected.aggregate.cbu, ecc.errors.uncorrected.aggregate.sram, ecc.errors.uncorrected.aggregate.total, ecc.errors.uncorrected.volatile.sram.parity, ecc.errors.uncorrected.volatile.sram.secded, ecc.errors.uncorrected.aggregate.sram.parity, ecc.errors.uncorrected.aggregate.sram.secded, ecc.errors.uncorrected.aggregate.sram.thresholdExceeded, ecc.errors.uncorrected.aggregate.sram.l2, ecc.errors.uncorrected.aggregate.sram.sm, ecc.errors.uncorrected.aggregate.sram.mcu, ecc.errors.uncorrected.aggregate.sram.pcie, ecc.errors.uncorrected.aggregate.sram.other, retired_pages.single_bit_ecc.count, retired_pages.double_bit.count, retired_pages.pending, remapped_rows.correctable, remapped_rows.uncorrectable, remapped_rows.pending, remapped_rows.failure, remapped_rows.histogram.max, remapped_rows.histogram.high, remapped_rows.histogram.partial, remapped_rows.histogram.low, remapped_rows.histogram.none, temperature.gpu, temperature.gpu.tlimit, temperature.memory, power.management, power.draw [W], power.draw.average [W], power.draw.instant [W], power.limit [W], enforced.power.limit [W], power.default_limit [W], power.min_limit [W], power.max_limit [W], module.power.draw.average [W], module.power.draw.instant [W], module.power.limit [W], module.enforced.power.limit [W], module.power.default_limit [W], module.power.min_limit [W], module.power.max_limit [W], power_smoothing.delayed_power_smoothing_supported, power_smoothing.primary_power_floor [W], power_smoothing.secondary_power_floor [W], power_smoothing.min_primary_floor_activation_offset [W], power_smoothing.min_primary_floor_activation_point [W], power_smoothing.window_multiplier [ms], power_smoothing.curr_profile.secondary_power_floor [W], power_smoothing.curr_profile.primary_floor_act_window_multiplier, power_smoothing.curr_profile.primary_floor_tar_window_multiplier, power_smoothing.curr_profile.primary_floor_act_offset [W], power_smoothing.admin_override.secondary_power_floor [W], power_smoothing.admin_override.primary_floor_act_window_multiplier, power_smoothing.admin_override.primary_floor_tar_window_multiplier, power_smoothing.admin_override.primary_floor_act_offset [W], edpp_multiplier [%], clocks.current.graphics [MHz], clocks.current.sm [MHz], clocks.current.memory [MHz], clocks.current.video [MHz], clocks.applications.graphics [MHz], clocks.applications.memory [MHz], clocks.default_applications.graphics [MHz], clocks.default_applications.memory [MHz], clocks.max.graphics [MHz], clocks.max.sm [MHz], clocks.max.memory [MHz], mig.mode.current, mig.mode.pending, gsp.mode.current, gsp.mode.default, c2c.mode, protected_memory.total [MiB], protected_memory.used [MiB], protected_memory.free [MiB], fabric.state, fabric.status, fabric.cliqueId, fabric.clusterUuid, fabric.health.summary, fabric.health.bandwidth, fabric.health.route_recovery_in_progress, fabric.health.route_unhealthy, fabric.health.access_timeout_recovery, fabric.health.incorrect_configuration, platform.chassis_serial_number, platform.slot_number, platform.tray_index, platform.host_id, platform.peer_type, platform.module_id, platform.gpu_fabric_guid, hostname
+2026/07/03 22:11:09.763, 590.48.01, [N/A], 1, NVIDIA H200, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, 00000000:83:00.0, 0x0000, 0x83, 0x00, 0x3, 0x2, 0x233510DE, 0x18BE10DE, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 5, 5, 5, 5, [N/A], 16, 16, 0, [Requested functionality has been deprecated], Yes, Disabled, Enabled, None, Disabled, 4000, [N/A], [N/A], 96.00.A5.00.03, G520.0280.02.02, 2.1, 7.16, [N/A], valid, None, [N/A], [N/A], [N/A], P0, 0x00000000000001FF, 0x0000000000000000, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, Not Active, 0 us, 0 us, 0 us, 0 us, 0 us, 143771 MiB, 614 MiB, 32362 MiB, 110796 MiB, Default, 9.0, 100 %, 7 %, 0 %, 0 %, 0 %, 0 %, 0, 0, 0, [N/A], [N/A], Enabled, Enabled, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, [N/A], [N/A], [N/A], [N/A], [N/A], 0, 0, 0, 0, 0, 0, No, 0, 0, 0, 0, 0, [N/A], [N/A], [N/A], 0, 0, No, No, 3072, 0, 0, 0, 0, 52, 35, 40, [Requested functionality has been deprecated], 627.40 W, 627.40 W, 626.26 W, 700.00 W, 700.00 W, 700.00 W, 200.00 W, 700.00 W, [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], [N/A], 100.00 %, 1980 MHz, 1980 MHz, 3201 MHz, 1545 MHz, [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], [Requested functionality has been deprecated], 1980 MHz, 1980 MHz, 3201 MHz, Disabled, Disabled, Enabled, Enabled, Disabled, 0 MiB, 0 MiB, 0 MiB, Completed, Success, 0, 00000000-0000-0000-0000-000000000000, N/A, N/A, N/A, N/A, N/A, N/A, , 0, 0, 1, Direct Connected, 1, 0x0000000000000000, [N/A]
+
+
+################################################################################
+# load :: query-compute-apps (per-process)
+# $ nvidia-smi --query-compute-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,process_name,used_gpu_memory --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, process_name, used_gpu_memory [MiB]
+2026/07/03 22:11:09.916, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, 10291, /root/tools/memhog, 2566 MiB
+2026/07/03 22:11:09.916, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, 10293, /root/tools/memhog, 1542 MiB
+2026/07/03 22:11:09.916, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, 10309, ./gpu_burn, 28234 MiB
+
+
+################################################################################
+# load :: query-accounted-apps
+# $ nvidia-smi --query-accounted-apps=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,pid,gpu_util,mem_util,max_memory_usage,time --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, pid, gpu_utilization [%], mem_utilization [%], max_memory_usage [MiB], time [ms]
+
+
+################################################################################
+# load :: query-retired-pages
+# $ nvidia-smi --query-retired-pages=timestamp,gpu_name,gpu_bus_id,gpu_serial,gpu_uuid,retired_pages.address,retired_pages.timestamp,retired_pages.cause --format=csv
+################################################################################
+timestamp, gpu_name, gpu_bus_id, gpu_serial, gpu_uuid, retired_pages.address, retired_pages.timestamp, retired_pages.cause
+2026/07/03 22:11:09.950, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Single Bit ECC
+2026/07/03 22:11:09.950, NVIDIA H200, 00000000:83:00.0, 0000000000000, GPU-00000000-0000-0000-0000-000000000000, [N/A], [N/A], Double Bit ECC
+
+
+################################################################################
+# load :: pmon (per-process monitor)
+# $ nvidia-smi pmon -c 5
+################################################################################
+# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
+# Idx           #    C/G      %      %      %      %      %      %    name 
+    0      10291     C      -      -      -      -      -      -    memhog         
+    0      10293     C      -      -      -      -      -      -    memhog         
+    0      10309     C     99      7      -      -      -      -    gpu_burn       
+    0      10291     C      -      -      -      -      -      -    memhog         
+    0      10293     C      -      -      -      -      -      -    memhog         
+    0      10309     C     99      7      -      -      -      -    gpu_burn       
+    0      10291     C      -      -      -      -      -      -    memhog         
+    0      10293     C      -      -      -      -      -      -    memhog         
+    0      10309     C     99      7      -      -      -      -    gpu_burn       
+    0      10291     C     19      1      -      -      -      -    memhog         
+    0      10293     C      -      -      -      -      -      -    memhog         
+    0      10309     C     79      5      -      -      -      -    gpu_burn       
+    0      10291     C      -      -      -      -      -      -    memhog         
+    0      10293     C      -      -      -      -      -      -    memhog         
+    0      10309     C     99      7      -      -      -      -    gpu_burn       
+
+
+################################################################################
+# load :: dmon (per-device monitor, incl. PCIe rx/tx)
+# $ nvidia-smi dmon -c 5
+################################################################################
+# gpu    pwr  gtemp  mtemp     sm    mem    enc    dec    jpg    ofa   mclk   pclk 
+# Idx      W      C      C      %      %      %      %      %      %    MHz    MHz 
+    0    630     53     41    100      8      0      0      0      0   3201   1980 
+    0    628     53     42    100      8      0      0      0      0   3201   1980 
+    0    629     53     42    100      8      0      0      0      0   3201   1980 
+    0    632     54     42    100      8      0      0      0      0   3201   1980 
+    0    630     54     42    100      8      0      0      0      0   3201   1980 

--- a/internal/fakesmi/config.go
+++ b/internal/fakesmi/config.go
@@ -37,6 +37,10 @@ type fileConfig struct {
 	Delay     string                   `yaml:"delay"`
 	StderrMsg string                   `yaml:"stderr-msg"` //nolint:tagliatelle // matches the --stderr-msg flag
 	FailArg   string                   `yaml:"fail-arg"`   //nolint:tagliatelle // matches the --fail-arg flag
+	// Extras is reserved for the exporter's demo backend, which reads the
+	// same config file: the fake itself ignores the block, and it is
+	// declared here only so the strict decoder accepts shared configs.
+	Extras yaml.Node `yaml:"extras"`
 }
 
 // overrideEntry is one field's override in the config. It is either a fixed
@@ -103,12 +107,17 @@ func loadFileConfig(path string) (*fileConfig, error) {
 		return nil, fmt.Errorf("failed to read config %q: %w", path, err)
 	}
 
+	return parseFileConfig(data, path)
+}
+
+// parseFileConfig strictly decodes a config document.
+func parseFileConfig(data []byte, name string) (*fileConfig, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 
 	var cfg fileConfig
 	if err := dec.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config %q: %w", path, err)
+		return nil, fmt.Errorf("failed to parse config %q: %w", name, err)
 	}
 
 	return &cfg, nil

--- a/internal/fakesmi/fakesmi.go
+++ b/internal/fakesmi/fakesmi.go
@@ -16,12 +16,25 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/capture"
-	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/captures"
 )
 
 // DefaultState is the capture state replayed when none is given.
 const DefaultState = "idle"
+
+// CaptureSource supplies the embedded captures the fake resolves names
+// against. It is injected by the caller so this package pins no capture
+// corpus of its own: the fake-nvidia-smi binary carries the full test
+// corpus, while the exporter's demo backend carries a small curated set
+// (embedding the corpus into the exporter is forbidden by a guard test).
+type CaptureSource struct {
+	// FS holds the embedded capture files.
+	FS fs.FS
+	// Default is the capture name served when none is configured.
+	Default string
+}
 
 // usageExitCode reports a problem with the fake itself (bad flags, unreadable
 // capture, an invocation the capture has no section for), as opposed to a
@@ -56,17 +69,145 @@ type config struct {
 	fluct *fluctuator
 }
 
-// Run executes the fake: it parses the fake's own leading flags, loads the
-// capture, and answers the remaining arguments from it. The returned value is
-// the process exit code.
-func Run(args []string, stdout, stderr io.Writer) int {
-	cfg, rest, err := parseFlags(args)
+// Config is a pre-parsed configuration document, for in-process callers that
+// need one immutable configuration across several invocations of one
+// collection cycle (the exporter's demo backend): re-reading the file per
+// invocation could otherwise interleave an atomic config edit into a cycle.
+type Config struct {
+	fc fileConfig
+}
+
+// LoadConfig reads and strictly parses a config file once.
+func LoadConfig(path string) (*Config, error) {
+	fc, err := loadFileConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{fc: *fc}, nil
+}
+
+// ParseConfig strictly parses a config document from memory (the demo
+// backend's built-in default configuration).
+func ParseConfig(data []byte) (*Config, error) {
+	fc, err := parseFileConfig(data, "<builtin>")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{fc: *fc}, nil
+}
+
+// Extras exposes the raw extras block, which the fake itself ignores: the
+// demo backend decodes it with its own schema.
+func (c *Config) Extras() *yaml.Node {
+	if c.fc.Extras.IsZero() {
+		return nil
+	}
+
+	return &c.fc.Extras
+}
+
+// GPUCount reports how many GPUs the configuration simulates: the gpus
+// setting's count when present, otherwise the capture's single GPU.
+func (c *Config) GPUCount() int {
+	if c.fc.GPUs == nil {
+		return 1
+	}
+
+	if c.fc.GPUs.count > 0 {
+		return c.fc.GPUs.count
+	}
+
+	return len(c.fc.GPUs.entries)
+}
+
+// EnsureFieldOverride sets a fixed override for one field on the simulated
+// GPU at index, unless the configuration already overrides that field
+// (globally or for that GPU): an explicit user choice wins. The demo backend
+// uses this to keep the served table coherent with its synthesized extras
+// (e.g. the MIG mode flag on GPUs carrying a MIG topology). Without
+// multi-GPU simulation there is only GPU 0, and the override is global.
+func (c *Config) EnsureFieldOverride(index int, field, value string) error {
+	if _, exists := c.fc.Overrides[field]; exists {
+		return nil
+	}
+
+	if index < 0 || index >= c.GPUCount() {
+		return fmt.Errorf("gpu index %d is out of range: the config simulates %d GPU(s)", index, c.GPUCount())
+	}
+
+	if c.fc.GPUs == nil {
+		if c.fc.Overrides == nil {
+			c.fc.Overrides = map[string]overrideEntry{}
+		}
+
+		c.fc.Overrides[field] = overrideEntry{fixed: &value}
+
+		return nil
+	}
+
+	// identities are index-derived, so padding with empty entries changes
+	// nothing for the GPUs they describe
+	for len(c.fc.GPUs.entries) <= index {
+		c.fc.GPUs.entries = append(c.fc.GPUs.entries, gpuFileEntry{})
+	}
+
+	entry := &c.fc.GPUs.entries[index]
+	if _, exists := entry.overrides[field]; exists {
+		return nil
+	}
+
+	if entry.overrides == nil {
+		entry.overrides = map[string]overrideEntry{}
+	}
+
+	entry.overrides[field] = overrideEntry{fixed: &value}
+
+	return nil
+}
+
+// StripFailureInjection clears the failure-injection settings (exit code,
+// delay, stderr noise, per-argument failure): they exist to test the
+// exec pipeline's subprocess handling, which the demo backend's in-process
+// path deliberately does not reproduce.
+func (c *Config) StripFailureInjection() {
+	c.fc.Exit = nil
+	c.fc.Delay = ""
+	c.fc.StderrMsg = ""
+	c.fc.FailArg = ""
+}
+
+// RunWith executes one invocation against a pre-parsed configuration, with
+// no leading fake flags: args is the plain nvidia-smi invocation to answer.
+// The returned value is the process exit code equivalent.
+func RunWith(source CaptureSource, cfg *Config, args []string, stdout, stderr io.Writer) int {
+	merged, _, err := resolveMerged(source, rawFlags{}, &cfg.fc, nil)
 	if err != nil {
 		fmt.Fprintf(stderr, "fake-nvidia-smi: %v\n", err)
 
 		return usageExitCode
 	}
 
+	return run(source, merged, args, stdout, stderr)
+}
+
+// Run executes the fake: it parses the fake's own leading flags, loads the
+// capture, and answers the remaining arguments from it. The returned value is
+// the process exit code.
+func Run(source CaptureSource, args []string, stdout, stderr io.Writer) int {
+	cfg, rest, err := parseFlags(source, args)
+	if err != nil {
+		fmt.Fprintf(stderr, "fake-nvidia-smi: %v\n", err)
+
+		return usageExitCode
+	}
+
+	return run(source, cfg, rest, stdout, stderr)
+}
+
+// run answers one resolved invocation.
+func run(source CaptureSource, cfg config, rest []string, stdout, stderr io.Writer) int {
 	if cfg.delay > 0 {
 		time.Sleep(cfg.delay)
 	}
@@ -83,7 +224,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return errorExitCode
 	}
 
-	capt, err := loadCapture(cfg.capturePath)
+	capt, err := loadCapture(source, cfg.capturePath)
 	if err != nil {
 		fmt.Fprintf(stderr, "fake-nvidia-smi: %v\n", err)
 
@@ -95,9 +236,9 @@ func Run(args []string, stdout, stderr io.Writer) int {
 
 // loadCapture resolves the --capture value: a path (anything with a path
 // separator, or naming an existing file) loads from disk, and anything else
-// names an embedded capture from internal/captures, where the .txt suffix
+// names an embedded capture from the injected source, where the .txt suffix
 // may be omitted.
-func loadCapture(value string) (*capture.Capture, error) {
+func loadCapture(source CaptureSource, value string) (*capture.Capture, error) {
 	_, statErr := os.Stat(value)
 
 	if statErr == nil || strings.ContainsRune(value, '/') || strings.ContainsRune(value, os.PathSeparator) {
@@ -114,7 +255,7 @@ func loadCapture(value string) (*capture.Capture, error) {
 		name += ".txt"
 	}
 
-	data, err := fs.ReadFile(captures.FS, name)
+	data, err := fs.ReadFile(source.FS, name)
 	if err != nil {
 		return nil, fmt.Errorf("capture %q is neither a file on disk nor an embedded capture", value)
 	}
@@ -156,7 +297,7 @@ type rawFlags struct {
 // parseFlags consumes the fake's own flags from the front of args, then resolves
 // them against an optional --config base, returning the remaining arguments,
 // which form the nvidia-smi invocation to replay.
-func parseFlags(args []string) (config, []string, error) {
+func parseFlags(source CaptureSource, args []string) (config, []string, error) {
 	var raw rawFlags
 
 	for len(args) > 0 {
@@ -177,7 +318,7 @@ func parseFlags(args []string) (config, []string, error) {
 		case "--capture", "--state", "--stderr-msg", "--fail-arg", "--exit", "--delay",
 			"--set", "--set-range", "--config", "--seed", "--gpus":
 		default:
-			return resolve(raw, args)
+			return resolve(source, raw, args)
 		}
 
 		args = args[1:]
@@ -195,7 +336,7 @@ func parseFlags(args []string) (config, []string, error) {
 		}
 	}
 
-	return resolve(raw, nil)
+	return resolve(source, raw, nil)
 }
 
 // applyFlag records a single parsed flag into raw.
@@ -308,9 +449,7 @@ func applyFluctuateFlag(raw *rawFlags, value string, hasValue bool, rest []strin
 
 // resolve merges the parsed flags with an optional --config base into the final
 // config: the config supplies defaults, and any flag-set value wins per field.
-func resolve(raw rawFlags, rest []string) (config, []string, error) {
-	cfg := config{capturePath: captures.Default, state: DefaultState}
-
+func resolve(source CaptureSource, raw rawFlags, rest []string) (config, []string, error) {
 	var fc *fileConfig
 
 	if raw.configPath != "" {
@@ -321,6 +460,14 @@ func resolve(raw rawFlags, rest []string) (config, []string, error) {
 
 		fc = loaded
 	}
+
+	return resolveMerged(source, raw, fc, rest)
+}
+
+// resolveMerged merges already-loaded settings into the final config, shared
+// by the flag path and the pre-parsed-config path.
+func resolveMerged(source CaptureSource, raw rawFlags, fc *fileConfig, rest []string) (config, []string, error) {
+	cfg := config{capturePath: source.Default, state: DefaultState}
 
 	mergeBaseSettings(&cfg, raw, fc)
 

--- a/internal/fakesmi/fakesmi_test.go
+++ b/internal/fakesmi/fakesmi_test.go
@@ -5,23 +5,28 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/capture"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/captures"
 	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/fakesmi"
 )
 
 const capturesDir = "../captures"
 
-// runFake runs the fake in-process, returning its exit code and outputs.
+// runFake runs the fake in-process with the full corpus as its capture
+// source (matching the fake-nvidia-smi binary), returning its exit code and
+// outputs.
 func runFake(t *testing.T, args ...string) (int, string, string) {
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
 
-	code := fakesmi.Run(args, &stdout, &stderr)
+	source := fakesmi.CaptureSource{FS: captures.FS, Default: captures.Default}
+	code := fakesmi.Run(source, args, &stdout, &stderr)
 
 	return code, stdout.String(), stderr.String()
 }
@@ -384,4 +389,79 @@ func TestErrors(t *testing.T) {
 			assert.NotEmpty(t, stderr)
 		})
 	}
+}
+
+// TestConfigGPUCount pins the simulated-GPU accounting the demo backend's
+// validation relies on.
+func TestConfigGPUCount(t *testing.T) {
+	t.Parallel()
+
+	for doc, want := range map[string]int{
+		"state: idle\n": 1,
+		"gpus: 3\n":     3,
+		"gpus:\n  - uuid: GPU-11111111-1111-4111-8111-111111111111\n  - {}\n": 2,
+	} {
+		cfg, err := fakesmi.ParseConfig([]byte(doc))
+		require.NoError(t, err)
+		assert.Equal(t, want, cfg.GPUCount(), "config: %q", doc)
+	}
+}
+
+// TestConfigEnsureFieldOverride proves the demo backend's table
+// reconciliation seam: the override lands on exactly the addressed GPU, an
+// explicit user override wins, and an unservable index is an error.
+func TestConfigEnsureFieldOverride(t *testing.T) {
+	t.Parallel()
+
+	source := fakesmi.CaptureSource{FS: captures.FS, Default: captures.Default}
+
+	cfg, err := fakesmi.ParseConfig([]byte("gpus: 2\n"))
+	require.NoError(t, err)
+
+	require.NoError(t, cfg.EnsureFieldOverride(1, "temperature.gpu", "99"))
+	require.ErrorContains(t, cfg.EnsureFieldOverride(2, "temperature.gpu", "99"), "out of range")
+
+	var stdout, stderr bytes.Buffer
+
+	code := fakesmi.RunWith(source, cfg, []string{"--query-gpu=temperature.gpu", "--format=csv"}, &stdout, &stderr)
+	require.Zero(t, code, stderr.String())
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	require.Len(t, lines, 3)
+	assert.NotEqual(t, "99", strings.TrimSpace(lines[1]), "GPU 0 keeps the captured value")
+	assert.Equal(t, "99", strings.TrimSpace(lines[2]), "GPU 1 serves the injected override")
+
+	// an explicit user override is never displaced
+	cfg, err = fakesmi.ParseConfig([]byte("overrides:\n  temperature.gpu: \"55\"\n"))
+	require.NoError(t, err)
+	require.NoError(t, cfg.EnsureFieldOverride(0, "temperature.gpu", "99"))
+
+	stdout.Reset()
+
+	code = fakesmi.RunWith(source, cfg, []string{"--query-gpu=temperature.gpu", "--format=csv"}, &stdout, &stderr)
+	require.Zero(t, code, stderr.String())
+	assert.Contains(t, stdout.String(), "55")
+	assert.NotContains(t, stdout.String(), "99")
+}
+
+// TestConfigStripFailureInjection proves the demo backend's in-process path
+// can disarm the subprocess-oriented failure settings.
+func TestConfigStripFailureInjection(t *testing.T) {
+	t.Parallel()
+
+	source := fakesmi.CaptureSource{FS: captures.FS, Default: captures.Default}
+
+	cfg, err := fakesmi.ParseConfig([]byte("exit: 7\ndelay: 10s\n"))
+	require.NoError(t, err)
+
+	cfg.StripFailureInjection()
+
+	var stdout, stderr bytes.Buffer
+
+	start := time.Now()
+	code := fakesmi.RunWith(source, cfg, []string{"--query-gpu=uuid", "--format=csv"}, &stdout, &stderr)
+
+	assert.Zero(t, code, "the exit injection must be gone")
+	assert.Less(t, time.Since(start), 2*time.Second, "the delay must be gone")
+	assert.NotEmpty(t, stdout.String())
 }

--- a/internal/integration/deps_test.go
+++ b/internal/integration/deps_test.go
@@ -24,4 +24,6 @@ func TestExporterDoesNotEmbedCaptures(t *testing.T) {
 
 	assert.NotContains(t, string(output), "internal/captures",
 		"the exporter binary must not import the capture corpus")
+	assert.Contains(t, string(output), "internal/demodata",
+		"the demo backend's curated captures are the one embedded corpus the binary may carry")
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -37,6 +37,7 @@ const startupTimeout = 30 * time.Second
 var wallClockFamilies = map[string]bool{
 	"nvidia_smi_last_collect_duration_seconds":          true,
 	"nvidia_smi_last_collect_success_timestamp_seconds": true,
+	"nvidia_smi_xid_last_timestamp_seconds":             true,
 }
 
 // fakeBin is the fake nvidia-smi binary, built once for the whole suite.
@@ -280,12 +281,51 @@ func TestExpectedMetrics(t *testing.T) {
 	}
 }
 
+// demoExpectedFile holds the expected scrape output of the demo backend
+// driven by the committed deterministic config fixture.
+const demoExpectedFile = "demo__seeded.metrics"
+
+// TestDemoBackendExpectedMetrics runs the demo backend with a fully
+// deterministic config (fixed seed, no fluctuation, initial XID events only)
+// and compares the deterministic part of the scrape against the expected
+// output file, pinning the whole synthesized surface: the extras families,
+// the MIG topology and its deterministic uuids, the per-process MIG
+// attribution, and the seeded XID counts. Run with -update to regenerate.
+func TestDemoBackendExpectedMetrics(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t,
+		"--collect.backend=demo",
+		"--demo-config="+filepath.Join("testdata", "demo-config.yaml"),
+		"--collect.compute-apps",
+		"--collect.compute-apps-mig")
+
+	got := filterDeterministic(scrape(t, baseURL))
+	expectedPath := filepath.Join("testdata", demoExpectedFile)
+
+	if *update {
+		require.NoError(t, os.MkdirAll("testdata", 0o755))
+		require.NoError(t, os.WriteFile(expectedPath, []byte(got), 0o600))
+
+		return
+	}
+
+	want, err := os.ReadFile(expectedPath)
+	require.NoError(
+		t,
+		err,
+		"missing expected output for the demo backend? generate and review it with: go test ./internal/integration/ -update",
+	)
+
+	assert.Equal(t, string(want), got)
+}
+
 // TestNoStaleExpectedFiles fails when a committed expected output file corresponds to no
 // capture/state pair anymore, e.g. after a capture rename or removal.
 func TestNoStaleExpectedFiles(t *testing.T) {
 	t.Parallel()
 
-	expected := make(map[string]bool)
+	expected := map[string]bool{demoExpectedFile: true}
 	for _, testCase := range replayCases(t) {
 		expected[testCase.expectedFile] = true
 	}
@@ -939,6 +979,123 @@ func TestExecBackendRejectsPcieThroughput(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--collect.pcie-throughput requires --collect.backend=nvml")
+}
+
+// TestDemoBackendDefaultConfig proves the zero-config demo mode serves every
+// metric family out of the box: the qfield surface plus all the nvml-superset
+// extras, including the wall-clock XID timestamp the golden test excludes.
+// It also pins two real-hardware behaviors the demo mimics: MIG utilization
+// is absent on the first collection that sees a GPU instance (the real GPM
+// sampling needs a pair), and a GPU carrying a MIG topology reports MIG mode
+// enabled.
+func TestDemoBackendDefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t, "--collect.backend=demo", "--collect.compute-apps")
+
+	first := scrape(t, baseURL)
+	second := scrape(t, baseURL)
+
+	for _, family := range []string{
+		"nvidia_smi_gpu_info",
+		"nvidia_smi_compute_app_info",
+		"nvidia_smi_energy_joules_total",
+		"nvidia_smi_pcie_throughput_tx_bytes_per_second",
+		"nvidia_smi_mig_info",
+		"nvidia_smi_mig_memory_used_bytes",
+		"nvidia_smi_xid_errors_total",
+		"nvidia_smi_xid_last_timestamp_seconds",
+	} {
+		assert.Contains(t, first, family+"{", "family %s must be served by the built-in demo config", family)
+	}
+
+	assert.NotContains(t, first, "nvidia_smi_mig_sm_activity_ratio",
+		"MIG utilization needs a sample pair, like the real backend")
+	assert.Contains(t, second, "nvidia_smi_mig_sm_activity_ratio{",
+		"the second collection must serve MIG utilization")
+
+	assert.Regexp(t, `nvidia_smi_mig_mode_current\{[^}]*\} 1`, first,
+		"a GPU carrying a MIG topology must report the mode on")
+	assert.Regexp(t, `nvidia_smi_gpu_info\{[^}]*cuda_version="[0-9.]+"`, first)
+}
+
+// TestDemoBackendEnergyWithoutPowerField proves the energy counter does not
+// depend on the public field selection: with the power field excluded from
+// the metrics, the counter still integrates a power reading sampled from the
+// same configuration snapshot.
+func TestDemoBackendEnergyWithoutPowerField(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startExporter(t,
+		"--collect.backend=demo",
+		"--query-field-names=uuid,name")
+
+	first := scrape(t, baseURL)
+	assert.NotContains(t, first, "nvidia_smi_power_draw", "the power family must really be excluded")
+	assert.Contains(t, first, "nvidia_smi_energy_joules_total{")
+
+	// the H200 capture draws hundreds of watts; the built-in fallback is
+	// 120W, so a between-scrapes joule gain far above fallback * elapsed
+	// proves the counter integrates the capture's own power reading
+	value := regexp.MustCompile(`nvidia_smi_energy_joules_total\{[^}]*\} ([0-9.e+]+)`)
+
+	match := value.FindStringSubmatch(scrape(t, baseURL))
+	require.NotNil(t, match)
+
+	joules, err := strconv.ParseFloat(match[1], 64)
+	require.NoError(t, err)
+	assert.Positive(t, joules, "the second collection must have integrated real power")
+}
+
+// TestDemoBackendRejectsCustomCommand pins the flag-validation contract: the
+// demo backend runs no external command, so a custom one must fail at startup.
+func TestDemoBackendRejectsCustomCommand(t *testing.T) {
+	t.Parallel()
+
+	err := app.Run(t.Context(), []string{
+		"--web.listen-address=127.0.0.1:0",
+		"--log.level=error",
+		"--collect.backend=demo",
+		"--nvidia-smi-command=" + fakeCommand(defaultCapture(t)),
+	}, app.Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--nvidia-smi-command cannot be combined")
+}
+
+// TestDemoConfigRequiresDemoBackend pins the reverse rule: the demo config
+// flag is meaningless without the demo backend.
+func TestDemoConfigRequiresDemoBackend(t *testing.T) {
+	t.Parallel()
+
+	err := app.Run(t.Context(), []string{
+		"--web.listen-address=127.0.0.1:0",
+		"--log.level=error",
+		"--nvidia-smi-command=" + fakeCommand(defaultCapture(t)),
+		"--demo-config=" + filepath.Join("testdata", "demo-config.yaml"),
+	}, app.Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--demo-config requires --collect.backend=demo")
+}
+
+// TestDemoBackendInvalidConfigFailsStartup proves a broken demo config is a
+// startup error, not a silently-degraded server.
+func TestDemoBackendInvalidConfigFailsStartup(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := filepath.Join(t.TempDir(), "demo.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("extras:\n  mig:\n    - gpu: 0\n"), 0o600))
+
+	err := app.Run(t.Context(), []string{
+		"--web.listen-address=127.0.0.1:0",
+		"--log.level=error",
+		"--collect.backend=demo",
+		"--demo-config=" + cfgPath,
+	}, app.Options{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set up the demo backend")
 }
 
 // TestNVMLBackendStartupFailureWithoutDriver pins the startup behavior on

--- a/internal/integration/testdata/demo-config.yaml
+++ b/internal/integration/testdata/demo-config.yaml
@@ -1,0 +1,22 @@
+# Fully deterministic demo backend config for the golden integration test:
+# fixed seed, no fluctuation, no ongoing XID cadence. Any change to the demo
+# synthesizers shows up as a golden diff.
+capture: linux-x86_64__nvidia-h200__590.48.01.txt
+state: load
+gpus: 2
+extras:
+  seed: 42
+  mig:
+    - gpu: 0
+      instances:
+        - gi: 2
+          profile: 3g.71gb
+          cis: 2
+          busy: true
+        - gi: 7
+          profile: 1g.18gb
+  xids:
+    initial:
+      - gpu: 1
+        xid: 79
+        count: 2

--- a/internal/integration/testdata/demo__seeded.metrics
+++ b/internal/integration/testdata/demo__seeded.metrics
@@ -1,0 +1,580 @@
+# HELP nvidia_smi_accounting_buffer_size accounting.buffer_size
+# TYPE nvidia_smi_accounting_buffer_size gauge
+nvidia_smi_accounting_buffer_size{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 4000
+nvidia_smi_accounting_buffer_size{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 4000
+# HELP nvidia_smi_accounting_mode accounting.mode
+# TYPE nvidia_smi_accounting_mode gauge
+nvidia_smi_accounting_mode{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_accounting_mode{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_c2c_mode c2c.mode
+# TYPE nvidia_smi_c2c_mode gauge
+nvidia_smi_c2c_mode{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_c2c_mode{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_current_graphics_clock_hz clocks.current.graphics [MHz]
+# TYPE nvidia_smi_clocks_current_graphics_clock_hz gauge
+nvidia_smi_clocks_current_graphics_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.98e+09
+nvidia_smi_clocks_current_graphics_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.98e+09
+# HELP nvidia_smi_clocks_current_memory_clock_hz clocks.current.memory [MHz]
+# TYPE nvidia_smi_clocks_current_memory_clock_hz gauge
+nvidia_smi_clocks_current_memory_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3.201e+09
+nvidia_smi_clocks_current_memory_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3.201e+09
+# HELP nvidia_smi_clocks_current_sm_clock_hz clocks.current.sm [MHz]
+# TYPE nvidia_smi_clocks_current_sm_clock_hz gauge
+nvidia_smi_clocks_current_sm_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.98e+09
+nvidia_smi_clocks_current_sm_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.98e+09
+# HELP nvidia_smi_clocks_current_video_clock_hz clocks.current.video [MHz]
+# TYPE nvidia_smi_clocks_current_video_clock_hz gauge
+nvidia_smi_clocks_current_video_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.545e+09
+nvidia_smi_clocks_current_video_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.545e+09
+# HELP nvidia_smi_clocks_event_reasons_active clocks_event_reasons.active
+# TYPE nvidia_smi_clocks_event_reasons_active gauge
+nvidia_smi_clocks_event_reasons_active{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_active{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_applications_clocks_setting clocks_event_reasons.applications_clocks_setting
+# TYPE nvidia_smi_clocks_event_reasons_applications_clocks_setting gauge
+nvidia_smi_clocks_event_reasons_applications_clocks_setting{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_applications_clocks_setting{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_counters_hw_power_brake_slowdown_seconds clocks_event_reasons_counters.hw_power_brake_slowdown [us]
+# TYPE nvidia_smi_clocks_event_reasons_counters_hw_power_brake_slowdown_seconds gauge
+nvidia_smi_clocks_event_reasons_counters_hw_power_brake_slowdown_seconds{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_counters_hw_power_brake_slowdown_seconds{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_counters_hw_thermal_slowdown_seconds clocks_event_reasons_counters.hw_thermal_slowdown [us]
+# TYPE nvidia_smi_clocks_event_reasons_counters_hw_thermal_slowdown_seconds gauge
+nvidia_smi_clocks_event_reasons_counters_hw_thermal_slowdown_seconds{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_counters_hw_thermal_slowdown_seconds{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_counters_sw_power_cap_seconds clocks_event_reasons_counters.sw_power_cap [us]
+# TYPE nvidia_smi_clocks_event_reasons_counters_sw_power_cap_seconds gauge
+nvidia_smi_clocks_event_reasons_counters_sw_power_cap_seconds{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_counters_sw_power_cap_seconds{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_counters_sw_thermal_slowdown_seconds clocks_event_reasons_counters.sw_thermal_slowdown [us]
+# TYPE nvidia_smi_clocks_event_reasons_counters_sw_thermal_slowdown_seconds gauge
+nvidia_smi_clocks_event_reasons_counters_sw_thermal_slowdown_seconds{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_counters_sw_thermal_slowdown_seconds{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_counters_sync_boost_seconds clocks_event_reasons_counters.sync_boost [us]
+# TYPE nvidia_smi_clocks_event_reasons_counters_sync_boost_seconds gauge
+nvidia_smi_clocks_event_reasons_counters_sync_boost_seconds{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_counters_sync_boost_seconds{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_gpu_idle clocks_event_reasons.gpu_idle
+# TYPE nvidia_smi_clocks_event_reasons_gpu_idle gauge
+nvidia_smi_clocks_event_reasons_gpu_idle{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_gpu_idle{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown clocks_event_reasons.hw_power_brake_slowdown
+# TYPE nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown gauge
+nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_hw_slowdown clocks_event_reasons.hw_slowdown
+# TYPE nvidia_smi_clocks_event_reasons_hw_slowdown gauge
+nvidia_smi_clocks_event_reasons_hw_slowdown{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_hw_slowdown{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_hw_thermal_slowdown clocks_event_reasons.hw_thermal_slowdown
+# TYPE nvidia_smi_clocks_event_reasons_hw_thermal_slowdown gauge
+nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_supported clocks_event_reasons.supported
+# TYPE nvidia_smi_clocks_event_reasons_supported gauge
+nvidia_smi_clocks_event_reasons_supported{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 511
+nvidia_smi_clocks_event_reasons_supported{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 511
+# HELP nvidia_smi_clocks_event_reasons_sw_power_cap clocks_event_reasons.sw_power_cap
+# TYPE nvidia_smi_clocks_event_reasons_sw_power_cap gauge
+nvidia_smi_clocks_event_reasons_sw_power_cap{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_sw_power_cap{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_sw_thermal_slowdown clocks_event_reasons.sw_thermal_slowdown
+# TYPE nvidia_smi_clocks_event_reasons_sw_thermal_slowdown gauge
+nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_event_reasons_sync_boost clocks_event_reasons.sync_boost
+# TYPE nvidia_smi_clocks_event_reasons_sync_boost gauge
+nvidia_smi_clocks_event_reasons_sync_boost{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_clocks_event_reasons_sync_boost{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_clocks_max_graphics_clock_hz clocks.max.graphics [MHz]
+# TYPE nvidia_smi_clocks_max_graphics_clock_hz gauge
+nvidia_smi_clocks_max_graphics_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.98e+09
+nvidia_smi_clocks_max_graphics_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.98e+09
+# HELP nvidia_smi_clocks_max_memory_clock_hz clocks.max.memory [MHz]
+# TYPE nvidia_smi_clocks_max_memory_clock_hz gauge
+nvidia_smi_clocks_max_memory_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3.201e+09
+nvidia_smi_clocks_max_memory_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3.201e+09
+# HELP nvidia_smi_clocks_max_sm_clock_hz clocks.max.sm [MHz]
+# TYPE nvidia_smi_clocks_max_sm_clock_hz gauge
+nvidia_smi_clocks_max_sm_clock_hz{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.98e+09
+nvidia_smi_clocks_max_sm_clock_hz{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.98e+09
+# HELP nvidia_smi_compute_app_info A metric with a constant '1' value labeled by the identity of a process with a compute context on a GPU.
+# TYPE nvidia_smi_compute_app_info gauge
+nvidia_smi_compute_app_info{compute_instance_id="",gpu_instance_id="",pid="10291",process_name="/root/tools/memhog",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+nvidia_smi_compute_app_info{compute_instance_id="",gpu_instance_id="",pid="10293",process_name="/root/tools/memhog",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+nvidia_smi_compute_app_info{compute_instance_id="",gpu_instance_id="",pid="10309",process_name="./gpu_burn",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+nvidia_smi_compute_app_info{compute_instance_id="0",gpu_instance_id="7",pid="10291",process_name="/root/tools/memhog",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_compute_app_info{compute_instance_id="1",gpu_instance_id="2",pid="10293",process_name="/root/tools/memhog",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_compute_app_info{compute_instance_id="1",gpu_instance_id="2",pid="10309",process_name="./gpu_burn",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+# HELP nvidia_smi_compute_app_used_memory_bytes GPU memory used by the process. Absent when the driver cannot report it (e.g. Windows WDDM).
+# TYPE nvidia_smi_compute_app_used_memory_bytes gauge
+nvidia_smi_compute_app_used_memory_bytes{compute_instance_id="",gpu_instance_id="",pid="10291",process_name="/root/tools/memhog",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2.690646016e+09
+nvidia_smi_compute_app_used_memory_bytes{compute_instance_id="",gpu_instance_id="",pid="10293",process_name="/root/tools/memhog",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.616904192e+09
+nvidia_smi_compute_app_used_memory_bytes{compute_instance_id="",gpu_instance_id="",pid="10309",process_name="./gpu_burn",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2.9605494784e+10
+nvidia_smi_compute_app_used_memory_bytes{compute_instance_id="0",gpu_instance_id="7",pid="10291",process_name="/root/tools/memhog",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 2.690646016e+09
+nvidia_smi_compute_app_used_memory_bytes{compute_instance_id="1",gpu_instance_id="2",pid="10293",process_name="/root/tools/memhog",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.616904192e+09
+nvidia_smi_compute_app_used_memory_bytes{compute_instance_id="1",gpu_instance_id="2",pid="10309",process_name="./gpu_burn",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 2.9605494784e+10
+# HELP nvidia_smi_compute_apps Number of processes with a compute context on the GPU.
+# TYPE nvidia_smi_compute_apps gauge
+nvidia_smi_compute_apps{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3
+nvidia_smi_compute_apps{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3
+# HELP nvidia_smi_compute_apps_last_collect_success Whether the most recent per-process collection succeeded (1) or not (0)
+# TYPE nvidia_smi_compute_apps_last_collect_success gauge
+nvidia_smi_compute_apps_last_collect_success 1
+# HELP nvidia_smi_compute_cap compute_cap
+# TYPE nvidia_smi_compute_cap gauge
+nvidia_smi_compute_cap{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 9
+nvidia_smi_compute_cap{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 9
+# HELP nvidia_smi_compute_mode compute_mode
+# TYPE nvidia_smi_compute_mode gauge
+nvidia_smi_compute_mode{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_compute_mode{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_count count
+# TYPE nvidia_smi_count gauge
+nvidia_smi_count{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 2
+nvidia_smi_count{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2
+# HELP nvidia_smi_display_active display_active
+# TYPE nvidia_smi_display_active gauge
+nvidia_smi_display_active{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_display_active{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_display_attached display_attached
+# TYPE nvidia_smi_display_attached gauge
+nvidia_smi_display_attached{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_display_attached{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_ecc_errors_corrected_aggregate_device_memory ecc.errors.corrected.aggregate.device_memory
+# TYPE nvidia_smi_ecc_errors_corrected_aggregate_device_memory gauge
+nvidia_smi_ecc_errors_corrected_aggregate_device_memory{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_aggregate_device_memory{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_aggregate_dram ecc.errors.corrected.aggregate.dram
+# TYPE nvidia_smi_ecc_errors_corrected_aggregate_dram gauge
+nvidia_smi_ecc_errors_corrected_aggregate_dram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_aggregate_dram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_aggregate_sram ecc.errors.corrected.aggregate.sram
+# TYPE nvidia_smi_ecc_errors_corrected_aggregate_sram gauge
+nvidia_smi_ecc_errors_corrected_aggregate_sram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_aggregate_sram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_aggregate_total ecc.errors.corrected.aggregate.total
+# TYPE nvidia_smi_ecc_errors_corrected_aggregate_total gauge
+nvidia_smi_ecc_errors_corrected_aggregate_total{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_aggregate_total{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_volatile_device_memory ecc.errors.corrected.volatile.device_memory
+# TYPE nvidia_smi_ecc_errors_corrected_volatile_device_memory gauge
+nvidia_smi_ecc_errors_corrected_volatile_device_memory{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_volatile_device_memory{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_volatile_dram ecc.errors.corrected.volatile.dram
+# TYPE nvidia_smi_ecc_errors_corrected_volatile_dram gauge
+nvidia_smi_ecc_errors_corrected_volatile_dram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_volatile_dram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_volatile_sram ecc.errors.corrected.volatile.sram
+# TYPE nvidia_smi_ecc_errors_corrected_volatile_sram gauge
+nvidia_smi_ecc_errors_corrected_volatile_sram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_volatile_sram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_corrected_volatile_total ecc.errors.corrected.volatile.total
+# TYPE nvidia_smi_ecc_errors_corrected_volatile_total gauge
+nvidia_smi_ecc_errors_corrected_volatile_total{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_corrected_volatile_total{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_device_memory ecc.errors.uncorrected.aggregate.device_memory
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_device_memory gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_device_memory{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_device_memory{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_dram ecc.errors.uncorrected.aggregate.dram
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_dram gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_dram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_dram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram ecc.errors.uncorrected.aggregate.sram
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_l2 ecc.errors.uncorrected.aggregate.sram.l2
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_l2 gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_l2{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_l2{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_mcu ecc.errors.uncorrected.aggregate.sram.mcu
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_mcu gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_mcu{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_mcu{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_other ecc.errors.uncorrected.aggregate.sram.other
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_other gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_other{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_other{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_parity ecc.errors.uncorrected.aggregate.sram.parity
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_parity gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_parity{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_parity{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_pcie ecc.errors.uncorrected.aggregate.sram.pcie
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_pcie gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_pcie{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_pcie{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_secded ecc.errors.uncorrected.aggregate.sram.secded
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_secded gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_secded{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_secded{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_sm ecc.errors.uncorrected.aggregate.sram.sm
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_sm gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_sm{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_sm{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_sram_threshold_exceeded ecc.errors.uncorrected.aggregate.sram.thresholdExceeded
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_sram_threshold_exceeded gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_threshold_exceeded{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_sram_threshold_exceeded{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_aggregate_total ecc.errors.uncorrected.aggregate.total
+# TYPE nvidia_smi_ecc_errors_uncorrected_aggregate_total gauge
+nvidia_smi_ecc_errors_uncorrected_aggregate_total{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_aggregate_total{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_volatile_device_memory ecc.errors.uncorrected.volatile.device_memory
+# TYPE nvidia_smi_ecc_errors_uncorrected_volatile_device_memory gauge
+nvidia_smi_ecc_errors_uncorrected_volatile_device_memory{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_volatile_device_memory{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_volatile_dram ecc.errors.uncorrected.volatile.dram
+# TYPE nvidia_smi_ecc_errors_uncorrected_volatile_dram gauge
+nvidia_smi_ecc_errors_uncorrected_volatile_dram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_volatile_dram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_volatile_sram ecc.errors.uncorrected.volatile.sram
+# TYPE nvidia_smi_ecc_errors_uncorrected_volatile_sram gauge
+nvidia_smi_ecc_errors_uncorrected_volatile_sram{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_volatile_sram{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_volatile_sram_parity ecc.errors.uncorrected.volatile.sram.parity
+# TYPE nvidia_smi_ecc_errors_uncorrected_volatile_sram_parity gauge
+nvidia_smi_ecc_errors_uncorrected_volatile_sram_parity{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_volatile_sram_parity{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_volatile_sram_secded ecc.errors.uncorrected.volatile.sram.secded
+# TYPE nvidia_smi_ecc_errors_uncorrected_volatile_sram_secded gauge
+nvidia_smi_ecc_errors_uncorrected_volatile_sram_secded{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_volatile_sram_secded{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_errors_uncorrected_volatile_total ecc.errors.uncorrected.volatile.total
+# TYPE nvidia_smi_ecc_errors_uncorrected_volatile_total gauge
+nvidia_smi_ecc_errors_uncorrected_volatile_total{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_ecc_errors_uncorrected_volatile_total{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_ecc_mode_current ecc.mode.current
+# TYPE nvidia_smi_ecc_mode_current gauge
+nvidia_smi_ecc_mode_current{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_ecc_mode_current{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_ecc_mode_pending ecc.mode.pending
+# TYPE nvidia_smi_ecc_mode_pending gauge
+nvidia_smi_ecc_mode_pending{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_ecc_mode_pending{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_edpp_multiplier_ratio edpp_multiplier [%]
+# TYPE nvidia_smi_edpp_multiplier_ratio gauge
+nvidia_smi_edpp_multiplier_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_edpp_multiplier_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_encoder_stats_average_fps encoder.stats.averageFps
+# TYPE nvidia_smi_encoder_stats_average_fps gauge
+nvidia_smi_encoder_stats_average_fps{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_encoder_stats_average_fps{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_encoder_stats_average_latency encoder.stats.averageLatency
+# TYPE nvidia_smi_encoder_stats_average_latency gauge
+nvidia_smi_encoder_stats_average_latency{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_encoder_stats_average_latency{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_encoder_stats_session_count encoder.stats.sessionCount
+# TYPE nvidia_smi_encoder_stats_session_count gauge
+nvidia_smi_encoder_stats_session_count{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_encoder_stats_session_count{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_energy_joules_total Total energy consumed by the GPU in joules since the driver was last loaded. Resets on a driver reload; absent on GPUs that cannot report it.
+# TYPE nvidia_smi_energy_joules_total counter
+nvidia_smi_energy_joules_total{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_energy_joules_total{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_enforced_power_limit_watts enforced.power.limit [W]
+# TYPE nvidia_smi_enforced_power_limit_watts gauge
+nvidia_smi_enforced_power_limit_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 700
+nvidia_smi_enforced_power_limit_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 700
+# HELP nvidia_smi_fabric_clique_id fabric.cliqueId
+# TYPE nvidia_smi_fabric_clique_id gauge
+nvidia_smi_fabric_clique_id{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_fabric_clique_id{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_fabric_state fabric.state
+# TYPE nvidia_smi_fabric_state gauge
+nvidia_smi_fabric_state{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3
+nvidia_smi_fabric_state{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3
+# HELP nvidia_smi_failed_scrapes_total Number of failed collections
+# TYPE nvidia_smi_failed_scrapes_total counter
+nvidia_smi_failed_scrapes_total 0
+# HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
+# TYPE nvidia_smi_gpu_info gauge
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="0",name="NVIDIA H200",pci_bus_id="00000000:01:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64",vbios_version="96.00.A5.00.03"} 1
+nvidia_smi_gpu_info{compute_cap="9.0",cuda_version="13.1",driver_model_current="[N/A]",driver_model_pending="[N/A]",driver_version="590.48.01",index="1",name="NVIDIA H200",pci_bus_id="00000000:02:00.0",pci_sub_device_id="0x18BE10DE",serial="0000000000000",uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9",vbios_version="96.00.A5.00.03"} 1
+# HELP nvidia_smi_gpu_recovery_action gpu_recovery_action
+# TYPE nvidia_smi_gpu_recovery_action gauge
+nvidia_smi_gpu_recovery_action{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_gpu_recovery_action{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_gsp_mode_current gsp.mode.current
+# TYPE nvidia_smi_gsp_mode_current gauge
+nvidia_smi_gsp_mode_current{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_gsp_mode_current{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_gsp_mode_default gsp.mode.default
+# TYPE nvidia_smi_gsp_mode_default gauge
+nvidia_smi_gsp_mode_default{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_gsp_mode_default{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_index index
+# TYPE nvidia_smi_index gauge
+nvidia_smi_index{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_index{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_inforom_ecc inforom.ecc
+# TYPE nvidia_smi_inforom_ecc gauge
+nvidia_smi_inforom_ecc{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 7.16
+nvidia_smi_inforom_ecc{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 7.16
+# HELP nvidia_smi_inforom_oem inforom.oem
+# TYPE nvidia_smi_inforom_oem gauge
+nvidia_smi_inforom_oem{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 2.1
+nvidia_smi_inforom_oem{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2.1
+# HELP nvidia_smi_last_collect_success Whether the most recent collection succeeded (1) or not (0)
+# TYPE nvidia_smi_last_collect_success gauge
+nvidia_smi_last_collect_success 1
+# HELP nvidia_smi_memory_free_bytes memory.free [MiB]
+# TYPE nvidia_smi_memory_free_bytes gauge
+nvidia_smi_memory_free_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.16178026496e+11
+nvidia_smi_memory_free_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.16178026496e+11
+# HELP nvidia_smi_memory_reserved_bytes memory.reserved [MiB]
+# TYPE nvidia_smi_memory_reserved_bytes gauge
+nvidia_smi_memory_reserved_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 6.43825664e+08
+nvidia_smi_memory_reserved_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 6.43825664e+08
+# HELP nvidia_smi_memory_total_bytes memory.total [MiB]
+# TYPE nvidia_smi_memory_total_bytes gauge
+nvidia_smi_memory_total_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.50754820096e+11
+nvidia_smi_memory_total_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.50754820096e+11
+# HELP nvidia_smi_memory_used_bytes memory.used [MiB]
+# TYPE nvidia_smi_memory_used_bytes gauge
+nvidia_smi_memory_used_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3.3934016512e+10
+nvidia_smi_memory_used_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3.3934016512e+10
+# HELP nvidia_smi_mig_info A metric with a constant '1' value labeled by the identity of a MIG device: the parent GPU's uuid, the MIG device's own uuid, its GPU instance and compute instance ids, and its profile.
+# TYPE nvidia_smi_mig_info gauge
+nvidia_smi_mig_info{compute_instance_id="0",gpu_instance_id="2",mig_uuid="292b7eb0-0beb-5abe-04b8-475f1ff17b99",profile="1c.3g.71gb",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_mig_info{compute_instance_id="0",gpu_instance_id="7",mig_uuid="7b2137fb-43a7-dedc-f0da-909404e7eccd",profile="1g.18gb",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_mig_info{compute_instance_id="1",gpu_instance_id="2",mig_uuid="6a6c5d1f-3ffa-f46e-0761-8edb556c091d",profile="1c.3g.71gb",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+# HELP nvidia_smi_mig_memory_free_bytes Memory of the GPU instance (free). The framebuffer belongs to the GPU instance and is shared by its compute instances (verified live: sibling compute instances report identical values).
+# TYPE nvidia_smi_mig_memory_free_bytes gauge
+nvidia_smi_mig_memory_free_bytes{gpu_instance_id="2",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3.2971181613e+10
+nvidia_smi_mig_memory_free_bytes{gpu_instance_id="7",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.8256575223e+10
+# HELP nvidia_smi_mig_memory_reserved_bytes Memory of the GPU instance (reserved). The framebuffer belongs to the GPU instance and is shared by its compute instances (verified live: sibling compute instances report identical values).
+# TYPE nvidia_smi_mig_memory_reserved_bytes gauge
+nvidia_smi_mig_memory_reserved_bytes{gpu_instance_id="2",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3.81178347e+08
+nvidia_smi_mig_memory_reserved_bytes{gpu_instance_id="7",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 9.6636764e+07
+# HELP nvidia_smi_mig_memory_total_bytes Memory of the GPU instance (total). The framebuffer belongs to the GPU instance and is shared by its compute instances (verified live: sibling compute instances report identical values).
+# TYPE nvidia_smi_mig_memory_total_bytes gauge
+nvidia_smi_mig_memory_total_bytes{gpu_instance_id="2",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 7.6235669504e+10
+nvidia_smi_mig_memory_total_bytes{gpu_instance_id="7",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.9327352832e+10
+# HELP nvidia_smi_mig_memory_used_bytes Memory of the GPU instance (used). The framebuffer belongs to the GPU instance and is shared by its compute instances (verified live: sibling compute instances report identical values).
+# TYPE nvidia_smi_mig_memory_used_bytes gauge
+nvidia_smi_mig_memory_used_bytes{gpu_instance_id="2",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 4.2883309544e+10
+nvidia_smi_mig_memory_used_bytes{gpu_instance_id="7",uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 9.74140845e+08
+# HELP nvidia_smi_mig_mode_current mig.mode.current
+# TYPE nvidia_smi_mig_mode_current gauge
+nvidia_smi_mig_mode_current{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_mig_mode_current{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_mig_mode_pending mig.mode.pending
+# TYPE nvidia_smi_mig_mode_pending gauge
+nvidia_smi_mig_mode_pending{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_mig_mode_pending{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_name name
+# TYPE nvidia_smi_name gauge
+nvidia_smi_name{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 200
+nvidia_smi_name{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 200
+# HELP nvidia_smi_nvml_return_code NVML return code of the most recent collection (0 = success)
+# TYPE nvidia_smi_nvml_return_code gauge
+nvidia_smi_nvml_return_code 0
+# HELP nvidia_smi_pci_base_class pci.baseClass
+# TYPE nvidia_smi_pci_base_class gauge
+nvidia_smi_pci_base_class{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3
+nvidia_smi_pci_base_class{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3
+# HELP nvidia_smi_pci_bus pci.bus
+# TYPE nvidia_smi_pci_bus gauge
+nvidia_smi_pci_bus{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_pci_bus{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2
+# HELP nvidia_smi_pci_device pci.device
+# TYPE nvidia_smi_pci_device gauge
+nvidia_smi_pci_device{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_pci_device{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_pci_device_id pci.device_id
+# TYPE nvidia_smi_pci_device_id gauge
+nvidia_smi_pci_device_id{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 5.90680286e+08
+nvidia_smi_pci_device_id{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 5.90680286e+08
+# HELP nvidia_smi_pci_domain pci.domain
+# TYPE nvidia_smi_pci_domain gauge
+nvidia_smi_pci_domain{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_pci_domain{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_pci_sub_class pci.subClass
+# TYPE nvidia_smi_pci_sub_class gauge
+nvidia_smi_pci_sub_class{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 2
+nvidia_smi_pci_sub_class{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2
+# HELP nvidia_smi_pci_sub_device_id pci.sub_device_id
+# TYPE nvidia_smi_pci_sub_device_id gauge
+nvidia_smi_pci_sub_device_id{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 4.15109342e+08
+nvidia_smi_pci_sub_device_id{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 4.15109342e+08
+# HELP nvidia_smi_pcie_link_gen_current pcie.link.gen.current
+# TYPE nvidia_smi_pcie_link_gen_current gauge
+nvidia_smi_pcie_link_gen_current{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 5
+nvidia_smi_pcie_link_gen_current{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 5
+# HELP nvidia_smi_pcie_link_gen_gpucurrent pcie.link.gen.gpucurrent
+# TYPE nvidia_smi_pcie_link_gen_gpucurrent gauge
+nvidia_smi_pcie_link_gen_gpucurrent{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 5
+nvidia_smi_pcie_link_gen_gpucurrent{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 5
+# HELP nvidia_smi_pcie_link_gen_gpumax pcie.link.gen.gpumax
+# TYPE nvidia_smi_pcie_link_gen_gpumax gauge
+nvidia_smi_pcie_link_gen_gpumax{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 5
+nvidia_smi_pcie_link_gen_gpumax{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 5
+# HELP nvidia_smi_pcie_link_gen_max pcie.link.gen.max
+# TYPE nvidia_smi_pcie_link_gen_max gauge
+nvidia_smi_pcie_link_gen_max{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 5
+nvidia_smi_pcie_link_gen_max{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 5
+# HELP nvidia_smi_pcie_link_width_current pcie.link.width.current
+# TYPE nvidia_smi_pcie_link_width_current gauge
+nvidia_smi_pcie_link_width_current{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 16
+nvidia_smi_pcie_link_width_current{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 16
+# HELP nvidia_smi_pcie_link_width_max pcie.link.width.max
+# TYPE nvidia_smi_pcie_link_width_max gauge
+nvidia_smi_pcie_link_width_max{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 16
+nvidia_smi_pcie_link_width_max{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 16
+# HELP nvidia_smi_pcie_throughput_rx_bytes_per_second PCIe traffic received by the GPU, sampled by the driver over a dedicated 20ms window.
+# TYPE nvidia_smi_pcie_throughput_rx_bytes_per_second gauge
+nvidia_smi_pcie_throughput_rx_bytes_per_second{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 9.950037259513843e+08
+nvidia_smi_pcie_throughput_rx_bytes_per_second{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 2.0661402729099436e+09
+# HELP nvidia_smi_pcie_throughput_tx_bytes_per_second PCIe traffic transmitted by the GPU, sampled by the driver over a dedicated 20ms window.
+# TYPE nvidia_smi_pcie_throughput_tx_bytes_per_second gauge
+nvidia_smi_pcie_throughput_tx_bytes_per_second{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1.2444794109305713e+09
+nvidia_smi_pcie_throughput_tx_bytes_per_second{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1.8914627843641977e+09
+# HELP nvidia_smi_persistence_mode persistence_mode
+# TYPE nvidia_smi_persistence_mode gauge
+nvidia_smi_persistence_mode{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_persistence_mode{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_platform_gpu_fabric_guid platform.gpu_fabric_guid
+# TYPE nvidia_smi_platform_gpu_fabric_guid gauge
+nvidia_smi_platform_gpu_fabric_guid{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_platform_gpu_fabric_guid{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_platform_host_id platform.host_id
+# TYPE nvidia_smi_platform_host_id gauge
+nvidia_smi_platform_host_id{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_platform_host_id{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_platform_module_id platform.module_id
+# TYPE nvidia_smi_platform_module_id gauge
+nvidia_smi_platform_module_id{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_platform_module_id{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_platform_slot_number platform.slot_number
+# TYPE nvidia_smi_platform_slot_number gauge
+nvidia_smi_platform_slot_number{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_platform_slot_number{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_platform_tray_index platform.tray_index
+# TYPE nvidia_smi_platform_tray_index gauge
+nvidia_smi_platform_tray_index{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_platform_tray_index{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_power_default_limit_watts power.default_limit [W]
+# TYPE nvidia_smi_power_default_limit_watts gauge
+nvidia_smi_power_default_limit_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 700
+nvidia_smi_power_default_limit_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 700
+# HELP nvidia_smi_power_draw_average_watts power.draw.average [W]
+# TYPE nvidia_smi_power_draw_average_watts gauge
+nvidia_smi_power_draw_average_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 627.4
+nvidia_smi_power_draw_average_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 627.4
+# HELP nvidia_smi_power_draw_instant_watts power.draw.instant [W]
+# TYPE nvidia_smi_power_draw_instant_watts gauge
+nvidia_smi_power_draw_instant_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 626.26
+nvidia_smi_power_draw_instant_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 626.26
+# HELP nvidia_smi_power_draw_watts power.draw [W]
+# TYPE nvidia_smi_power_draw_watts gauge
+nvidia_smi_power_draw_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 627.4
+nvidia_smi_power_draw_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 627.4
+# HELP nvidia_smi_power_limit_watts power.limit [W]
+# TYPE nvidia_smi_power_limit_watts gauge
+nvidia_smi_power_limit_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 700
+nvidia_smi_power_limit_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 700
+# HELP nvidia_smi_power_max_limit_watts power.max_limit [W]
+# TYPE nvidia_smi_power_max_limit_watts gauge
+nvidia_smi_power_max_limit_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 700
+nvidia_smi_power_max_limit_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 700
+# HELP nvidia_smi_power_min_limit_watts power.min_limit [W]
+# TYPE nvidia_smi_power_min_limit_watts gauge
+nvidia_smi_power_min_limit_watts{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 200
+nvidia_smi_power_min_limit_watts{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 200
+# HELP nvidia_smi_protected_memory_free_bytes protected_memory.free [MiB]
+# TYPE nvidia_smi_protected_memory_free_bytes gauge
+nvidia_smi_protected_memory_free_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_protected_memory_free_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_protected_memory_total_bytes protected_memory.total [MiB]
+# TYPE nvidia_smi_protected_memory_total_bytes gauge
+nvidia_smi_protected_memory_total_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_protected_memory_total_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_protected_memory_used_bytes protected_memory.used [MiB]
+# TYPE nvidia_smi_protected_memory_used_bytes gauge
+nvidia_smi_protected_memory_used_bytes{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_protected_memory_used_bytes{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_pstate pstate
+# TYPE nvidia_smi_pstate gauge
+nvidia_smi_pstate{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_pstate{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_correctable remapped_rows.correctable
+# TYPE nvidia_smi_remapped_rows_correctable gauge
+nvidia_smi_remapped_rows_correctable{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_correctable{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_failure remapped_rows.failure
+# TYPE nvidia_smi_remapped_rows_failure gauge
+nvidia_smi_remapped_rows_failure{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_failure{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_histogram_high remapped_rows.histogram.high
+# TYPE nvidia_smi_remapped_rows_histogram_high gauge
+nvidia_smi_remapped_rows_histogram_high{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_histogram_high{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_histogram_low remapped_rows.histogram.low
+# TYPE nvidia_smi_remapped_rows_histogram_low gauge
+nvidia_smi_remapped_rows_histogram_low{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_histogram_low{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_histogram_max remapped_rows.histogram.max
+# TYPE nvidia_smi_remapped_rows_histogram_max gauge
+nvidia_smi_remapped_rows_histogram_max{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 3072
+nvidia_smi_remapped_rows_histogram_max{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 3072
+# HELP nvidia_smi_remapped_rows_histogram_none remapped_rows.histogram.none
+# TYPE nvidia_smi_remapped_rows_histogram_none gauge
+nvidia_smi_remapped_rows_histogram_none{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_histogram_none{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_histogram_partial remapped_rows.histogram.partial
+# TYPE nvidia_smi_remapped_rows_histogram_partial gauge
+nvidia_smi_remapped_rows_histogram_partial{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_histogram_partial{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_pending remapped_rows.pending
+# TYPE nvidia_smi_remapped_rows_pending gauge
+nvidia_smi_remapped_rows_pending{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_pending{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_remapped_rows_uncorrectable remapped_rows.uncorrectable
+# TYPE nvidia_smi_remapped_rows_uncorrectable gauge
+nvidia_smi_remapped_rows_uncorrectable{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_remapped_rows_uncorrectable{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_serial serial
+# TYPE nvidia_smi_serial gauge
+nvidia_smi_serial{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_serial{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_temperature_gpu temperature.gpu
+# TYPE nvidia_smi_temperature_gpu gauge
+nvidia_smi_temperature_gpu{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 52
+nvidia_smi_temperature_gpu{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 52
+# HELP nvidia_smi_temperature_gpu_tlimit temperature.gpu.tlimit
+# TYPE nvidia_smi_temperature_gpu_tlimit gauge
+nvidia_smi_temperature_gpu_tlimit{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 35
+nvidia_smi_temperature_gpu_tlimit{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 35
+# HELP nvidia_smi_temperature_memory temperature.memory
+# TYPE nvidia_smi_temperature_memory gauge
+nvidia_smi_temperature_memory{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 40
+nvidia_smi_temperature_memory{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 40
+# HELP nvidia_smi_utilization_decoder_ratio utilization.decoder [%]
+# TYPE nvidia_smi_utilization_decoder_ratio gauge
+nvidia_smi_utilization_decoder_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_utilization_decoder_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_utilization_encoder_ratio utilization.encoder [%]
+# TYPE nvidia_smi_utilization_encoder_ratio gauge
+nvidia_smi_utilization_encoder_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_utilization_encoder_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_utilization_gpu_ratio utilization.gpu [%]
+# TYPE nvidia_smi_utilization_gpu_ratio gauge
+nvidia_smi_utilization_gpu_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 1
+nvidia_smi_utilization_gpu_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 1
+# HELP nvidia_smi_utilization_jpeg_ratio utilization.jpeg [%]
+# TYPE nvidia_smi_utilization_jpeg_ratio gauge
+nvidia_smi_utilization_jpeg_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_utilization_jpeg_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_utilization_memory_ratio utilization.memory [%]
+# TYPE nvidia_smi_utilization_memory_ratio gauge
+nvidia_smi_utilization_memory_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0.07
+nvidia_smi_utilization_memory_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0.07
+# HELP nvidia_smi_utilization_ofa_ratio utilization.ofa [%]
+# TYPE nvidia_smi_utilization_ofa_ratio gauge
+nvidia_smi_utilization_ofa_ratio{uuid="1c67088e-9ecb-4564-bb97-6151ecc2ef64"} 0
+nvidia_smi_utilization_ofa_ratio{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9"} 0
+# HELP nvidia_smi_xid_errors_total Number of XID errors observed on the GPU since the exporter started. A series appears when its first event arrives; earlier history cannot be replayed.
+# TYPE nvidia_smi_xid_errors_total counter
+nvidia_smi_xid_errors_total{uuid="ef427e4f-1970-42f2-ab0c-ecf0e56a33b9",xid="79"} 2

--- a/internal/nvidiasmi/computeapps.go
+++ b/internal/nvidiasmi/computeapps.go
@@ -37,9 +37,10 @@ type ComputeApp struct {
 	// "[Insufficient Permissions]" in restricted containers.
 	UsedMemory string
 	// GPUInstanceID and ComputeInstanceID attribute the process to a MIG
-	// instance. Only the nvml backend fills them, and only for processes on
-	// MIG-partitioned GPUs; they stay empty otherwise (this query's fixed
-	// field set predates MIG and is never extended, per the comment above).
+	// instance. The nvml backend fills them for processes on
+	// MIG-partitioned GPUs, and the demo backend for its configured
+	// topology; they stay empty otherwise (this query's fixed field set
+	// predates MIG and is never extended, per the comment above).
 	GPUInstanceID     string
 	ComputeInstanceID string
 }


### PR DESCRIPTION
The new demo collection backend serves realistic synthetic metrics on any platform, with no GPU, no driver and no external binary. It replays a real captured nvidia-smi with values fluctuating between scrapes, and synthesizes the NVML-only metric families coherently on top: the energy counter integrates the power draw the table itself reports (sampled privately when the field selection excludes it), MIG instances form a configurable topology with deterministic identities where a busy instance runs hot, PCIe throughput jitters within bounds, XID error counters accumulate over time, and per-process series carry stable MIG attribution.

The synthesized data mirrors real hardware semantics: GPUs carrying a MIG topology report MIG mode enabled, per-instance utilization is absent on the first collection that sees an instance, and whole collection cycles are serialized so one configuration snapshot rules everything a cycle serves.

The simulated setup is configurable through a file extending the development fake's format with a demo-specific section. The configuration is validated and test-served at startup, re-read on every collection cycle so edits apply live, and an edit resets the synthesized counters like a driver reload would. A broken edit fails the collection until fixed, and a built-in two-GPU scenario serves as the zero-config default. A fixed seed makes the whole output deterministic, which a golden integration test pins end to end.

Only two curated captures are embedded into the binary for this, the full development corpus stays out, guarded by a dependency test.

This exists for trying the exporter out without hardware and for developing dashboards and alerts against realistic data.

Stacked on #466 and #467.