### PR TITLE
feat: add a demo flavor to the local dev compose stack

### DIFF
--- a/hack/compose/README.md
+++ b/hack/compose/README.md
@@ -1,11 +1,22 @@
 # Local dev stack
 
 A one-command stack for developing the exporter and its Grafana dashboards on a
-machine with **no GPU**. It runs the real exporter against the fake nvidia-smi
-(`cmd/fake-nvidia-smi`), scrapes it with Prometheus, and serves the dashboards
-in Grafana with live, moving values. Two exporter instances play two "nodes"
-(an eight-GPU consumer box on `fake.yaml`, a two-GPU passive L40S box on
-`fake2.yaml`), so per-node filtering and multi-GPU comparison are exercisable.
+machine with **no GPU**. It runs two flavors side by side:
+
+- **exec flavor** — the real exporter against the fake nvidia-smi binary
+  (`cmd/fake-nvidia-smi`): `node1` (an eight-GPU consumer box on `fake.yaml`,
+  one card deliberately sick) and `node2` (a two-GPU passive L40S box on
+  `fake2.yaml`), scraped by `prometheus` (:9090).
+- **demo flavor** — the exporter's built-in demo backend
+  (`--collect.backend=demo`), which serves the NVML-superset surface (MIG
+  instances, XID error counters, energy, PCIe throughput) with synthetic
+  data: `demo1` (two H200s with a MIG topology and XID history, `demo1.yaml`)
+  and `demo2` (a single consumer card, `demo2.yaml`), scraped by
+  `prometheus-demo` (:9091).
+
+Grafana carries both Prometheuses as data sources, so the dashboards' data
+source dropdown flips between the two worlds. The provisioned dev dashboards
+preselect the demo flavor, the richer surface where dashboard work happens.
 
 ## Run
 
@@ -17,11 +28,12 @@ in Grafana with live, moving values. Two exporter instances play two "nodes"
 Then open:
 
 - Grafana: <http://localhost:3000> (anonymous admin, no login) — the **Nvidia GPU
-  Metrics** and **Nvidia GPU Overview** dashboards are provisioned and already
-  pointed at Prometheus.
-- Prometheus: <http://localhost:9090>
-- Exporter metrics: <http://localhost:9835/metrics> (node one),
-  <http://localhost:9836/metrics> (node two)
+  Metrics** and **Nvidia GPU Overview** dashboards are provisioned, pointed at
+  the demo Prometheus; switch the *Data source* dropdown for the exec flavor.
+- Prometheus (exec): <http://localhost:9090>, (demo): <http://localhost:9091>
+- Exporter metrics: <http://localhost:9835/metrics> (node1),
+  <http://localhost:9836/metrics> (node2), <http://localhost:9837/metrics>
+  (demo1), <http://localhost:9838/metrics> (demo2)
 
 Stop and wipe the throwaway state (Prometheus/Grafana volumes):
 
@@ -29,10 +41,19 @@ Stop and wipe the throwaway state (Prometheus/Grafana volumes):
 cd hack/compose && docker compose down -v
 ```
 
-The compose code, provisioning, and `fake.yaml` are committed and maintained; the
-running containers and their data volumes are disposable.
+The compose code, provisioning, and the fake/demo configs are committed and
+maintained; the running containers and their data volumes are disposable.
+Existing volumes upgrade in place (the exec data source keeps its historical
+name and uid, so provisioning upserts it); if Grafana ever fails to start
+over a conflicting manually-added data source, `docker compose down -v`
+resets the throwaway state.
+
+`render-dashboard.sh` (run by `up.sh`) needs `python3` on the host, in
+addition to Docker.
 
 ## Make the data interesting
+
+### exec flavor
 
 `fake/fake.yaml` drives the fake. `fluctuate: true` jitters everything that
 naturally moves (utilization, temperature, power, clocks, fan, memory) around
@@ -55,14 +76,26 @@ drive a different card, change `capture:` to any embedded capture name.
 report no fan speed, which exercises the "metric absent" paths on the
 dashboards.
 
+### demo flavor
+
+`demo/demo1.yaml` and `demo/demo2.yaml` use the same format plus a
+demo-specific `extras:` block (MIG topology, XID events, PCIe ranges; the
+full reference is the demo mode section in `docs/CONFIGURE.md`). The demo
+backend re-reads its file on every collection cycle, so edits apply live
+here too; an edit resets the synthesized counters, like a driver reload.
+demo1's MIG topology deliberately hosts two compute instances on one GPU
+instance: any dashboard join that forgets to pre-aggregate `mig_info` per
+GPU instance shows doubled values here before it ships.
+
 ## Iterate on the dashboards
 
 The dashboards are authored in the Grafana UI and exported to
 `docs/grafana/dashboard.json` (single-GPU detail, grafana.com 14574) and
 `docs/grafana/dashboard-overview.json` (multi-GPU comparison). Those files
-select their data source through a template variable, which resolves to
-this stack's sole Prometheus on its own, so `render-dashboard.sh` simply
-copies them into the provisioning directory.
+select their data source through a template variable; `render-dashboard.sh`
+copies them into the provisioning directory, flipping `editable` on and
+preselecting the demo data source (the published artifacts themselves stay
+data-source-neutral).
 
 Loop: edit the JSON under `docs/grafana/` (or edit in the UI and export it
 there), run `./hack/compose/render-dashboard.sh`, and Grafana reloads within a

--- a/hack/compose/demo/demo1.yaml
+++ b/hack/compose/demo/demo1.yaml
@@ -1,0 +1,21 @@
+# Demo node 1: the rich scenario. Two H200s, a MIG topology on GPU 0 whose
+# first GPU instance hosts two compute instances (the live probe for
+# dashboard join cardinality), a pre-seeded XID history and slow ongoing XID
+# events. The exporter re-reads this file on every collection cycle: edit,
+# save, and the next scrape serves it. An edit resets the synthesized
+# counters (energy, XIDs), like a driver reload would.
+capture: linux-x86_64__nvidia-h200__590.48.01
+state: load
+fluctuate: true
+gpus: 2
+extras:
+  mig:
+    - gpu: 0
+      instances:
+        - {gi: 2, profile: 3g.71gb, cis: 2, busy: true}
+        - {gi: 7, profile: 1g.18gb}
+  xids:
+    initial:
+      - {gpu: 1, xid: 79, count: 2}
+      - {gpu: 0, xid: 13, count: 1}
+    interval: 5m

--- a/hack/compose/demo/demo2.yaml
+++ b/hack/compose/demo/demo2.yaml
@@ -1,0 +1,15 @@
+# Demo node 2: the counterpoint. A single consumer card, no MIG, no XID
+# history: proves per-node filtering and the dashboards' handling of absent
+# NVML families. PCIe idles low compared to demo1's datacenter box.
+capture: linux-x86_64__nvidia-geforce-rtx-4080-super__595.71.05
+state: load
+fluctuate: true
+# the capture's own uuid is scrubbed to zeros; give the card an explicit
+# stable identity (the generated ones are index-derived and would collide
+# with demo1's first GPU)
+gpus:
+  - uuid: GPU-8d2f6c3a-4b1e-4f7a-9c5d-2e8b7a1f6d40
+extras:
+  pcie:
+    tx-bytes-per-second: {min: 0.05e9, max: 0.8e9}
+    rx-bytes-per-second: {min: 0.1e9, max: 1.5e9}

--- a/hack/compose/docker-compose.yaml
+++ b/hack/compose/docker-compose.yaml
@@ -1,8 +1,13 @@
 name: nvidia-gpu-exporter-dev
 
-# Local dev stack: the exporter scraping a fake nvidia-smi (no GPU needed),
-# Prometheus scraping the exporter, and Grafana with the dashboard provisioned
-# and pointed at Prometheus. See README.md.
+# Local dev stack, two flavors side by side (see README.md):
+#   exec flavor: node1/node2 run the exporter against a fake nvidia-smi
+#     binary, scraped by `prometheus` (:9090)
+#   demo flavor: demo1/demo2 run the exporter's demo backend (the
+#     nvml-superset surface - MIG, XID, energy, PCIe - synthesized
+#     in-process), scraped by `prometheus-demo` (:9091)
+# Grafana carries both Prometheuses as data sources; the dashboards'
+# data source dropdown flips between the two worlds.
 
 services:
   # first "node": eight consumer cards incl. one deliberately sick, fake.yaml
@@ -37,6 +42,40 @@ services:
     ports:
       - "9836:9835"
 
+  # third and fourth "nodes": the demo backend, serving the nvml-superset
+  # families (mig_*, xid_*, energy, pcie) with synthetic data and no fake
+  # binary involved. demo1 is the rich one: MIG topology with a multi-CI GPU
+  # instance (the live probe for dashboard join cardinality), XID history and
+  # ongoing events. demo2 is a plain consumer card, proving per-node
+  # filtering and the dashboards' handling of absent NVML families. Both
+  # re-read their config file on every collection cycle: edit, save, scrape.
+  demo1:
+    build:
+      context: ../..
+      dockerfile: hack/compose/Dockerfile
+    command:
+      - "--collect.backend=demo"
+      - "--demo-config=/etc/demo/demo1.yaml"
+      - "--collect.compute-apps"
+      - "--collect.compute-apps-mig"
+    volumes:
+      - ./demo:/etc/demo:ro
+    ports:
+      - "9837:9835"
+
+  demo2:
+    build:
+      context: ../..
+      dockerfile: hack/compose/Dockerfile
+    command:
+      - "--collect.backend=demo"
+      - "--demo-config=/etc/demo/demo2.yaml"
+      - "--collect.compute-apps"
+    volumes:
+      - ./demo:/etc/demo:ro
+    ports:
+      - "9838:9835"
+
   prometheus:
     image: prom/prometheus:v3.13.1
     ports:
@@ -47,6 +86,17 @@ services:
     depends_on:
       - node1
       - node2
+
+  prometheus-demo:
+    image: prom/prometheus:v3.13.1
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus/config-demo:/etc/prometheus
+      - prometheus-demo-data:/prometheus
+    depends_on:
+      - demo1
+      - demo2
 
   grafana:
     image: grafana/grafana:13.1.0
@@ -64,7 +114,9 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+      - prometheus-demo
 
 volumes:
   prometheus-data:
+  prometheus-demo-data:
   grafana-data:

--- a/hack/compose/grafana/provisioning/datasources/prometheus.yml
+++ b/hack/compose/grafana/provisioning/datasources/prometheus.yml
@@ -1,5 +1,8 @@
 apiVersion: 1
 
+# Both flavors' Prometheuses, with stable uids: the dashboards' data source
+# variable stores the uid, and render-dashboard.sh stamps the dev copies to
+# preselect the demo one (the richer surface, where dashboard work happens).
 datasources:
   - name: Prometheus
     type: prometheus
@@ -8,3 +11,14 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+    jsonData:
+      timeInterval: 5s
+
+  - name: Prometheus (demo)
+    type: prometheus
+    uid: prometheus-demo
+    access: proxy
+    url: http://prometheus-demo:9090
+    editable: false
+    jsonData:
+      timeInterval: 5s

--- a/hack/compose/prometheus/config-demo/prometheus.yml
+++ b/hack/compose/prometheus/config-demo/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  # short interval so the dashboard moves quickly while iterating
+  scrape_interval: 5s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "nvidia_gpu_exporter"
+    static_configs:
+      - targets: ["demo1:9835", "demo2:9835"]

--- a/hack/compose/render-dashboard.sh
+++ b/hack/compose/render-dashboard.sh
@@ -2,12 +2,14 @@
 # Copy the published dashboards into provisioning copies for the dev stack.
 #
 # docs/grafana/dashboard.json (grafana.com 14574) and
-# docs/grafana/dashboard-overview.json are the published artifacts. They
-# select their data source through a template variable, which resolves to
-# this stack's sole Prometheus on its own, so no substitution is needed. The
-# published artifacts ship non-editable, so the dev copies flip that one flag
-# back, otherwise the author-in-the-UI loop below would be blocked
-# (allowUiUpdates in the provider does not override the dashboard model).
+# docs/grafana/dashboard-overview.json are the published artifacts. The dev
+# copies differ in exactly two ways:
+#   - editable is flipped back on (the published artifacts ship
+#     non-editable, which would block the author-in-the-UI loop;
+#     allowUiUpdates in the provider does not override the dashboard model)
+#   - the data source variable is preselected to the demo Prometheus, the
+#     richer surface (MIG/XID/energy/PCIe), where dashboard work happens;
+#     the dropdown still flips to the exec flavor at any time
 # Grafana's provider polls the output, so re-run this after editing a
 # dashboard to see the change live.
 set -euo pipefail
@@ -19,7 +21,29 @@ render() {
   local dst="$here/grafana/dashboards/$2"
 
   mkdir -p "$(dirname "$dst")"
-  sed 's/"editable": false/"editable": true/' "$src" > "$dst"
+  python3 - "$src" "$dst" << 'PY'
+import json
+import sys
+
+src, dst = sys.argv[1], sys.argv[2]
+
+with open(src) as f:
+    dashboard = json.load(f)
+
+dashboard["editable"] = True
+
+for variable in dashboard.get("templating", {}).get("list", []):
+    if variable.get("type") == "datasource":
+        variable["current"] = {
+            "selected": True,
+            "text": "Prometheus (demo)",
+            "value": "prometheus-demo",
+        }
+
+with open(dst, "w") as f:
+    json.dump(dashboard, f, indent=2)
+    f.write("\n")
+PY
   echo "rendered $dst"
 }
 

--- a/hack/compose/up.sh
+++ b/hack/compose/up.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Bring up the dev stack: render the dashboard, then start compose. Extra args
-# are passed through to `docker compose up` (e.g. -d, --build).
+# Bring up the dev stack: render the dashboards, validate the compose file,
+# then start compose. Extra args are passed through to `docker compose up`
+# (e.g. -d, --build).
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 "$here/render-dashboard.sh"
 cd "$here"
+docker compose config --quiet
 exec docker compose up --build "$@"


### PR DESCRIPTION
The local dev stack now runs two flavors side by side. The existing nodes replaying a fake nvidia-smi keep their Prometheus, and two new nodes run the demo backend with a second Prometheus: a rich datacenter scenario with a MIG topology, where one GPU instance deliberately hosts two compute instances to expose dashboard join cardinality mistakes, plus XID history and ongoing events, and a plain consumer card as the counterpoint for per-node filtering and absent-family handling.

Grafana provisions both Prometheuses as data sources, and the rendered dev copies of the dashboards preselect the demo one, since it serves the metric families only the driver library provides on real hardware. The data source dropdown still switches to the other flavor at any time, and the published dashboard artifacts stay data source neutral.

The demo node configs are live-editable like the fake ones, the startup script validates the compose file before bringing the stack up, and the stack README describes both flavors.

Stacked on #468.