### PR TITLE
chore(ci): run the build on pull request base changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,15 @@ on:
   pull_request:
     branches:
       - main
+    # the default types miss the base-branch change of a retargeted PR (it
+    # arrives as "edited"), so a stacked PR that lands on main after its
+    # parent merges would never get a run. The job-level guard below skips
+    # the title/description edits that also arrive as "edited".
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
@@ -23,8 +32,10 @@ defaults:
   run:
     shell: bash --noprofile --norc -euox pipefail {0}
 
+# run edited-events only when the edit changed the base branch
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -89,6 +100,7 @@ jobs:
         run: git diff --exit-code
 
   chart:
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
A stacked PR that gets retargeted to the default branch after its parent merges never got a CI run: the base change arrives as an edited event, which the default pull request trigger types ignore, so every such PR needed a manual close and reopen to become mergeable (this bit on every PR of the recently merged stack).

The workflow now listens for edited events too, and both jobs skip the ones that did not change the base branch, so plain title or description edits still cost nothing. Validated with actionlint.