### PR TITLE
feat: ship GPU health alert rules with the helm chart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,8 @@ jobs:
           cmp docs/grafana/dashboard-overview.json charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-overview.json
       - name: Lint chart
         run: ct lint --config .ct.yaml --all
+      - name: Validate alert rules
+        run: hack/alerts/verify.sh
       - name: Check that the chart README is current
         run: |
           docker run --rm -v "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.14.2

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -185,12 +185,31 @@ What to do when upgrading:
 
 All optional resources are off by default. `serviceMonitor` and `podMonitor`
 require the Prometheus Operator CRDs (enable one of them, not both).
-`prometheusRule` adds alerts on the exporter's collection health metrics: if
-the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU
-nodes via `nodeSelector` or `affinity` before enabling it, otherwise the
-alerts fire for nodes that cannot collect GPU metrics by design. The alert
-expressions select all `nvidia_smi_*` series, so when installing multiple
-releases of this chart, enable the rules in only one of them.
+`prometheusRule` adds alerts on the exporter's collection health and on GPU
+health: driver-requested recovery actions, critical Xid errors, uncorrectable
+ECC errors, memory row-remap and page-retirement state, hardware thermal
+slowdown and power braking. Every alert's description says what to do about
+it. The defaults are deliberately conservative for consumer and homelab
+hardware; rules that depend on fleet knowledge (absolute temperature, GPU
+count) or that are normal on thermally-limited systems (software thermal
+slowdown) ship disabled, and each rule can be toggled individually. Some
+rules need the NVML backend (Xid) or specific query fields (ECC, remapped
+rows); where the metric is absent the rule simply never fires. When
+upgrading a release that already had `prometheusRule.enabled: true`, the new
+GPU health rules arrive enabled: review the list below and disable any you
+do not want. One real
+hardware fault can raise several of these alerts at once (for example an
+uncorrectable ECC error also produces an Xid and a recovery action); that
+overlap is deliberate, because no single signal exists on every backend,
+driver and GPU generation combination. Group them in your Alertmanager route
+by `instance` if you prefer one notification per node.
+
+If the exporter also runs on nodes without GPUs, restrict the DaemonSet to
+GPU nodes via `nodeSelector` or `affinity` before enabling `prometheusRule`,
+otherwise the collection alerts fire for nodes that cannot collect GPU
+metrics by design. The alert expressions select all `nvidia_smi_*` series, so
+when installing multiple releases of this chart, enable the rules in only one
+of them.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
 and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
 as a ConfigMap labeled for the Grafana sidecar.
@@ -264,10 +283,27 @@ grafanaDashboard:
 | prometheusRule.collectionFailing.enabled | bool | `true` | Alert when the most recent collection failed for some time |
 | prometheusRule.collectionFailing.for | string | `"10m"` | How long collection must be failing before the alert fires |
 | prometheusRule.collectionFailing.severity | string | `"warning"` | Severity label of the alert |
+| prometheusRule.collectionSlow.enabled | bool | `true` | Alert when collecting GPU metrics is slow for 10 minutes. Healthy nvidia-smi answers well under a second with the persistence daemon running; sustained slowness often precedes a wedged driver. |
+| prometheusRule.collectionSlow.thresholdSeconds | int | `5` | Collection duration in seconds above which the alert fires |
 | prometheusRule.collectionStale.enabled | bool | `true` | Alert when the last successful collection is too far in the past |
 | prometheusRule.collectionStale.severity | string | `"warning"` | Severity label of the alert |
 | prometheusRule.collectionStale.thresholdSeconds | int | `300` | Seconds since the last successful collection before the alert fires |
 | prometheusRule.enabled | bool | `false` | Create a Prometheus Operator PrometheusRule with default alerts (requires the Prometheus Operator CRDs). In clusters where the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU nodes via nodeSelector or affinity before enabling this, otherwise the alerts fire for nodes that cannot collect GPU metrics by design. |
+| prometheusRule.gpuMissing.enabled | bool | `false` | Alert when a machine reports fewer GPUs than its recent maximum while collection stays healthy, which catches GPUs that silently fall off the bus on the default backend. Off by default: it also fires for up to 6 hours after deliberately removing a GPU and needs a stable instance label across exporter restarts. |
+| prometheusRule.powerBrake.enabled | bool | `true` | Alert when an external hardware power brake throttles a GPU for 5 minutes: a power delivery problem (PSU, cables, rack power). The configured software power limit never raises this. |
+| prometheusRule.recoveryAction.enabled | bool | `true` | Alert when the driver itself requests a GPU recovery action (reset, reboot, drain). The most direct health signal there is; needs a recent driver (570+), silently absent on older ones. |
+| prometheusRule.retiredPagesPending.enabled | bool | `true` | Alert when a GPU memory page retirement waits for a reboot to take effect (pre-Ampere GPUs) |
+| prometheusRule.rowRemapFailure.enabled | bool | `true` | Alert when GPU memory row remapping failed, which is NVIDIA's stated RMA criterion |
+| prometheusRule.rowRemapPending.enabled | bool | `true` | Alert when a GPU memory row remap waits for a GPU reset to take effect |
+| prometheusRule.swThermalSlowdown.enabled | bool | `false` | Alert when the driver throttles a GPU at its temperature target for 30 minutes. Off by default: this is normal on thermally-limited consumer and laptop systems under sustained load. |
+| prometheusRule.temperatureHigh.enabled | bool | `false` | Alert when the GPU core temperature stays above the threshold for 10 minutes. Off by default: safe temperatures differ per GPU generation (a datacenter A100 throttles around 83C while laptop GPUs sit at 87C by design), so tune the threshold to your fleet before enabling. |
+| prometheusRule.temperatureHigh.thresholdCelsius | int | `85` | Core temperature in Celsius above which the alert fires |
+| prometheusRule.thermalSlowdown.enabled | bool | `true` | Alert when hardware thermal protection throttles a GPU for 5 minutes: cooling is failing at the hardware trip point. The driver applies the right per-model threshold, so this works across GPU generations. Disable if it fires routinely on thermally-limited mobile/small-form-factor systems. |
+| prometheusRule.uncorrectableEcc.enabled | bool | `true` | Alert when a GPU reports uncorrectable ECC memory errors since its last reset. Data may have been corrupted; a GPU reset repairs the memory on Ampere and newer. Corrected (single-bit) errors never alert. |
+| prometheusRule.xidCritical.codes | list | `[48,62,64,74,79,95,119,120]` | Xid codes treated as critical (reset/reboot class) |
+| prometheusRule.xidCritical.enabled | bool | `true` | Alert on Xid errors whose NVIDIA-recommended action is a GPU reset or node reboot. Needs the NVML backend; never fires on the default nvidia-smi backend. |
+| prometheusRule.xidWarning.codes | list | `[94]` | Xid codes treated as warning (restart-app class) |
+| prometheusRule.xidWarning.enabled | bool | `true` | Alert on Xid errors whose recommended action is an application restart. Explicit allowlist: application-caused Xids (13, 31, 43, ...) and informational ones (63, 92) deliberately never alert. |
 | queryFieldNames | list | `["AUTO"]` | `nvidia-smi` fields to be queried by the exporter. `AUTO` auto-detects them. |
 | queryFieldNamesExclude | list | `[]` | `nvidia-smi` fields to exclude from being queried. Names match literally, with `*` as a wildcard for any sequence of characters. |
 | readinessProbe | object | `{"httpGet":{"path":"/-/ready","port":"http"}}` | Readiness probe for the exporter container, process-level like the liveness probe. Set to `null` to disable the probe. |
@@ -295,7 +331,7 @@ grafanaDashboard:
 | telemetryPath | string | `"/metrics"` | The path to expose the metrics from |
 | test.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the `helm test` pod |
 | test.image.repository | string | `"docker.io/library/busybox"` | Image repository for the `helm test` connection-check pod |
-| test.image.tag | string | `"1.37"` | Image tag for the `helm test` pod |
+| test.image.tag | string | `"1.38"` | Image tag for the `helm test` pod |
 | tolerations | list | `[]` | Tolerations for the pods. GPU node pools are often tainted (e.g. `nvidia.com/gpu=present:NoSchedule`) so that only GPU workloads land on them. This chart deliberately requests no GPU resource, so add a matching toleration here or the exporter will not schedule on those nodes. |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Update strategy of the DaemonSet. Raise `rollingUpdate.maxUnavailable` (absolute or percentage) to roll out faster on large clusters, or use `type: OnDelete` for manually staged rollouts. |
 | volumeMounts | list | `[]` | Extra volume mounts for the exporter container |

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -185,12 +185,31 @@ What to do when upgrading:
 
 All optional resources are off by default. `serviceMonitor` and `podMonitor`
 require the Prometheus Operator CRDs (enable one of them, not both).
-`prometheusRule` adds alerts on the exporter's collection health metrics: if
-the exporter also runs on nodes without GPUs, restrict the DaemonSet to GPU
-nodes via `nodeSelector` or `affinity` before enabling it, otherwise the
-alerts fire for nodes that cannot collect GPU metrics by design. The alert
-expressions select all `nvidia_smi_*` series, so when installing multiple
-releases of this chart, enable the rules in only one of them.
+`prometheusRule` adds alerts on the exporter's collection health and on GPU
+health: driver-requested recovery actions, critical Xid errors, uncorrectable
+ECC errors, memory row-remap and page-retirement state, hardware thermal
+slowdown and power braking. Every alert's description says what to do about
+it. The defaults are deliberately conservative for consumer and homelab
+hardware; rules that depend on fleet knowledge (absolute temperature, GPU
+count) or that are normal on thermally-limited systems (software thermal
+slowdown) ship disabled, and each rule can be toggled individually. Some
+rules need the NVML backend (Xid) or specific query fields (ECC, remapped
+rows); where the metric is absent the rule simply never fires. When
+upgrading a release that already had `prometheusRule.enabled: true`, the new
+GPU health rules arrive enabled: review the list below and disable any you
+do not want. One real
+hardware fault can raise several of these alerts at once (for example an
+uncorrectable ECC error also produces an Xid and a recovery action); that
+overlap is deliberate, because no single signal exists on every backend,
+driver and GPU generation combination. Group them in your Alertmanager route
+by `instance` if you prefer one notification per node.
+
+If the exporter also runs on nodes without GPUs, restrict the DaemonSet to
+GPU nodes via `nodeSelector` or `affinity` before enabling `prometheusRule`,
+otherwise the collection alerts fire for nodes that cannot collect GPU
+metrics by design. The alert expressions select all `nvidia_smi_*` series, so
+when installing multiple releases of this chart, enable the rules in only one
+of them.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
 and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
 as a ConfigMap labeled for the Grafana sidecar.

--- a/charts/nvidia-gpu-exporter/templates/prometheusrule.yaml
+++ b/charts/nvidia-gpu-exporter/templates/prometheusrule.yaml
@@ -1,42 +1,274 @@
-{{- if .Values.prometheusRule.enabled }}
+{{- /*
+Rule subtrees may be absent when upgrading with --reuse-values from an older
+release, so every new subtree is read with dig and carries its default here.
+The two original rules keep their full knobs for compatibility.
+*/}}
+{{- $pr := .Values.prometheusRule }}
+{{- $on := dict
+  "collectionFailing" (dig "collectionFailing" "enabled" true $pr)
+  "collectionStale" (dig "collectionStale" "enabled" true $pr)
+  "collectionSlow" (dig "collectionSlow" "enabled" true $pr)
+  "recoveryAction" (dig "recoveryAction" "enabled" true $pr)
+  "xidCritical" (dig "xidCritical" "enabled" true $pr)
+  "xidWarning" (dig "xidWarning" "enabled" true $pr)
+  "uncorrectableEcc" (dig "uncorrectableEcc" "enabled" true $pr)
+  "rowRemapFailure" (dig "rowRemapFailure" "enabled" true $pr)
+  "rowRemapPending" (dig "rowRemapPending" "enabled" true $pr)
+  "retiredPagesPending" (dig "retiredPagesPending" "enabled" true $pr)
+  "thermalSlowdown" (dig "thermalSlowdown" "enabled" true $pr)
+  "swThermalSlowdown" (dig "swThermalSlowdown" "enabled" false $pr)
+  "powerBrake" (dig "powerBrake" "enabled" true $pr)
+  "temperatureHigh" (dig "temperatureHigh" "enabled" false $pr)
+  "gpuMissing" (dig "gpuMissing" "enabled" false $pr)
+}}
+{{- $any := false }}
+{{- range $k, $v := $on }}{{- if $v }}{{- $any = true }}{{- end }}{{- end }}
+{{- /* the two tiers carry contradictory instructions, so one code must never be in both */}}
+{{- $xidCritical := dig "xidCritical" "codes" (list 48 62 64 74 79 95 119 120) $pr }}
+{{- $xidWarning := dig "xidWarning" "codes" (list 94) $pr }}
+{{- range $c := $xidCritical }}
+{{- range $w := $xidWarning }}
+{{- if eq (toString $c) (toString $w) }}
+{{- fail (printf "prometheusRule: xid code %v must not be in both xidCritical.codes and xidWarning.codes" $c) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and $pr.enabled $any }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "nvidia-gpu-exporter.fullname" . }}
   labels:
     {{- include "nvidia-gpu-exporter.labels" . | nindent 4 }}
-  {{- with .Values.prometheusRule.additionalLabels }}
+  {{- with $pr.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   groups:
     - name: nvidia-gpu-exporter
       rules:
-        {{- if .Values.prometheusRule.collectionFailing.enabled }}
+        {{- if get $on "collectionFailing" }}
         - alert: NvidiaGpuExporterCollectionFailing
           expr: nvidia_smi_last_collect_success == 0
-          for: {{ .Values.prometheusRule.collectionFailing.for }}
+          for: {{ dig "collectionFailing" "for" "10m" $pr }}
           labels:
-            severity: {{ .Values.prometheusRule.collectionFailing.severity }}
+            severity: {{ dig "collectionFailing" "severity" "warning" $pr }}
           annotations:
-            summary: nvidia-smi collection is failing on {{ printf "{{ $labels.instance }}" }}
+            summary: GPU metric collection is failing on {{ printf "{{ $labels.instance }}" }}
             description: >-
               The exporter on {{ printf "{{ $labels.instance }}" }} cannot collect GPU metrics.
-              Check that the node has a GPU, the NVIDIA driver works, and the pod runs with
-              the NVIDIA runtime.
+              Run nvidia-smi on the node by hand and check dmesg for NVRM/Xid messages. The most
+              common cause is a driver/library mismatch after a driver upgrade, fixed by a reboot.
+              Also check that the node has a GPU and the pod runs with the NVIDIA runtime.
         {{- end }}
-        {{- if .Values.prometheusRule.collectionStale.enabled }}
+        {{- if get $on "collectionStale" }}
         - alert: NvidiaGpuExporterCollectionStale
           expr: >-
             time() - nvidia_smi_last_collect_success_timestamp_seconds
-            > {{ .Values.prometheusRule.collectionStale.thresholdSeconds }}
+            > {{ dig "collectionStale" "thresholdSeconds" 300 $pr }}
           labels:
-            severity: {{ .Values.prometheusRule.collectionStale.severity }}
+            severity: {{ dig "collectionStale" "severity" "warning" $pr }}
           annotations:
             summary: GPU metrics are stale on {{ printf "{{ $labels.instance }}" }}
             description: >-
               The last successful nvidia-smi collection on {{ printf "{{ $labels.instance }}" }}
-              is older than {{ .Values.prometheusRule.collectionStale.thresholdSeconds }} seconds.
-              The served GPU metrics no longer reflect the current state.
+              is older than {{ dig "collectionStale" "thresholdSeconds" 300 $pr }} seconds.
+              The served GPU metrics no longer reflect the current state. Check for a wedged
+              driver: run nvidia-smi by hand and check dmesg for NVRM/Xid messages.
+        {{- end }}
+        {{- if get $on "collectionSlow" }}
+        - alert: NvidiaGpuExporterCollectionSlow
+          expr: nvidia_smi_last_collect_duration_seconds > {{ dig "collectionSlow" "thresholdSeconds" 5 $pr }}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: GPU metric collection is slow on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              Collecting GPU metrics on {{ printf "{{ $labels.instance }}" }} takes longer than
+              {{ dig "collectionSlow" "thresholdSeconds" 5 $pr }} seconds. A healthy nvidia-smi
+              answers well under a second when the persistence daemon runs. Enable persistence
+              mode (nvidia-persistenced) and check dmesg for Xid messages: sustained slowness
+              often precedes a wedged driver. Collections that hang entirely are caught by the
+              failing/stale alerts instead of this one.
+        {{- end }}
+        {{- if get $on "recoveryAction" }}
+        - alert: NvidiaGpuRecoveryActionNeeded
+          expr: nvidia_smi_gpu_recovery_action > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: A GPU on {{ printf "{{ $labels.instance }}" }} needs a recovery action
+            description: >-
+              The NVIDIA driver itself reports that GPU {{ printf "{{ $labels.uuid }}" }} needs recovery. The value names the
+              action: 1 = reset the GPU, 2 = reboot the node, 3 = drain peer-to-peer workloads,
+              4 = drain and reset. Drain the GPU's workloads, then apply the action
+              (current value: {{ printf "{{ $value }}" }}).
+        {{- end }}
+        {{- if get $on "xidCritical" }}
+        - alert: NvidiaGpuXidCritical
+          expr: >-
+            time() - nvidia_smi_xid_last_timestamp_seconds{xid=~"{{ $xidCritical | join "|" }}"}
+            < 600
+          labels:
+            severity: critical
+          annotations:
+            summary: Critical GPU Xid error on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              GPU {{ printf "{{ $labels.uuid }}" }} reported Xid {{ printf "{{ $labels.xid }}" }}, a critical error, in the last 10
+              minutes. Drain the GPU. Among the default codes, 48/62/64/95/119/120 mean an
+              uncorrectable memory, microcontroller or GSP fault: reset the GPU (the reset also
+              applies pending row remaps). Xid 79 means the GPU fell off the PCIe bus: reboot the
+              node, and reseat the card or check its power if it recurs. Xid 74 is an NVLink
+              fault: reset the GPU or reboot. Check dmesg for the matching NVRM Xid line.
+              Requires the NVML backend.
+        {{- end }}
+        {{- if get $on "xidWarning" }}
+        - alert: NvidiaGpuXidWarning
+          expr: >-
+            time() - nvidia_smi_xid_last_timestamp_seconds{xid=~"{{ $xidWarning | join "|" }}"}
+            < 600
+          labels:
+            severity: warning
+          annotations:
+            summary: GPU Xid error on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              GPU {{ printf "{{ $labels.uuid }}" }} reported Xid {{ printf "{{ $labels.xid }}" }} in
+              the last 10 minutes. Xids in this tier (default: 94, a contained memory error) hit
+              one application without harming the GPU: restart the affected application, and
+              reset the GPU at the next convenient window. Requires the NVML backend.
+        {{- end }}
+        {{- if get $on "uncorrectableEcc" }}
+        - alert: NvidiaGpuUncorrectableEccErrors
+          expr: nvidia_smi_ecc_errors_uncorrected_volatile_total > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: Uncorrectable GPU memory errors on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              GPU {{ printf "{{ $labels.uuid }}" }} hit uncorrectable ECC memory errors since its last reset, so results may
+              have been corrupted. Drain the GPU and reset it at the next window: on Ampere and
+              newer the reset triggers row remapping, which permanently repairs the location.
+              If errors recur after a reset, run the NVIDIA field diagnostic and consider an RMA.
+        {{- end }}
+        {{- if get $on "rowRemapFailure" }}
+        - alert: NvidiaGpuRowRemapFailure
+          expr: nvidia_smi_remapped_rows_failure == 1
+          labels:
+            severity: critical
+          annotations:
+            summary: GPU memory row remapping failed on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              GPU {{ printf "{{ $labels.uuid }}" }} can no longer repair its memory by row remapping, which is NVIDIA's
+              stated RMA criterion. Drain the GPU, run the NVIDIA field diagnostic and start
+              an RMA.
+        {{- end }}
+        {{- if get $on "rowRemapPending" }}
+        - alert: NvidiaGpuRowRemapPending
+          expr: nvidia_smi_remapped_rows_pending == 1
+          labels:
+            severity: warning
+          annotations:
+            summary: GPU memory row remap pending on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              A memory repair on GPU {{ printf "{{ $labels.uuid }}" }} is recorded but needs a GPU reset to take effect; until then the
+              degraded region stays in use. Schedule a GPU reset or node reboot at the next
+              convenient window.
+        {{- end }}
+        {{- if get $on "retiredPagesPending" }}
+        - alert: NvidiaGpuRetiredPagesPending
+          expr: nvidia_smi_retired_pages_pending == 1
+          labels:
+            severity: warning
+          annotations:
+            summary: GPU memory page retirement pending on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              A memory page retirement on GPU {{ printf "{{ $labels.uuid }}" }} is recorded but needs a reboot to take effect (pre-Ampere
+              GPUs). Reboot the node at the next convenient window.
+        {{- end }}
+        {{- if get $on "thermalSlowdown" }}
+        - alert: NvidiaGpuThermalSlowdown
+          expr: >-
+            nvidia_smi_clocks_event_reasons_hw_thermal_slowdown == 1
+            or nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown == 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: A GPU on {{ printf "{{ $labels.instance }}" }} is in hardware thermal slowdown
+            description: >-
+              Hardware thermal protection has been throttling GPU {{ printf "{{ $labels.uuid }}" }} for 5 minutes, which
+              costs a large share of its throughput and means cooling is failing at the
+              hardware trip point. Check fans, airflow, dust and ambient temperature; on a
+              desktop card also consider repasting. If this fires routinely on a
+              thermally-limited mobile or small-form-factor system, disable this rule.
+        {{- end }}
+        {{- if get $on "swThermalSlowdown" }}
+        - alert: NvidiaGpuSoftwareThermalSlowdown
+          expr: >-
+            nvidia_smi_clocks_event_reasons_sw_thermal_slowdown == 1
+            or nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: A GPU on {{ printf "{{ $labels.instance }}" }} is thermally throttled
+            description: >-
+              The driver has been throttling GPU {{ printf "{{ $labels.uuid }}" }} at its temperature target for 30 minutes.
+              This is normal on thermally-limited systems under sustained load, which is why the
+              rule is opt-in; if the throttling is unexpected, improve cooling.
+        {{- end }}
+        {{- if get $on "powerBrake" }}
+        - alert: NvidiaGpuPowerBrake
+          expr: >-
+            nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown == 1
+            or nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown == 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: A GPU on {{ printf "{{ $labels.instance }}" }} is power-brake throttled
+            description: >-
+              An external hardware power brake has been throttling GPU {{ printf "{{ $labels.uuid }}" }} for 5 minutes. This
+              is a power delivery problem, not a workload property: check the PSU, the power
+              cables/connectors and, in a datacenter, the rack power. The configured software
+              power limit does not raise this flag.
+        {{- end }}
+        {{- if get $on "temperatureHigh" }}
+        - alert: NvidiaGpuTemperatureHigh
+          expr: nvidia_smi_temperature_gpu > {{ dig "temperatureHigh" "thresholdCelsius" 85 $pr }}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: A GPU on {{ printf "{{ $labels.instance }}" }} runs hot
+            description: >-
+              The core of GPU {{ printf "{{ $labels.uuid }}" }} has been above
+              {{ dig "temperatureHigh" "thresholdCelsius" 85 $pr }}C for 10 minutes. Check
+              cooling and airflow. This rule is opt-in because safe temperatures differ per
+              GPU generation; tune the threshold to your fleet.
+        {{- end }}
+        {{- if get $on "gpuMissing" }}
+        - alert: NvidiaGpuMissing
+          expr: >-
+            (
+              count by (job, instance) (nvidia_smi_gpu_info)
+              or
+              0 * sum by (job, instance) (nvidia_smi_last_collect_success)
+            )
+            < max_over_time((count by (job, instance) (nvidia_smi_gpu_info))[6h:5m])
+            and on (job, instance) nvidia_smi_last_collect_success == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: A GPU disappeared on {{ printf "{{ $labels.instance }}" }}
+            description: >-
+              nvidia-smi reports fewer GPUs on {{ printf "{{ $labels.instance }}" }} than the
+              maximum seen in the last 6 hours while collection stays healthy. A GPU that fell
+              off the PCIe bus can vanish silently like this. Check dmesg for Xid 79, reseat the
+              card or check its power, and reboot the node. This rule is opt-in: it also fires
+              for up to 6 hours after deliberately removing a GPU, and it needs a stable
+              instance label across exporter restarts.
         {{- end }}
 {{- end }}

--- a/charts/nvidia-gpu-exporter/values.schema.json
+++ b/charts/nvidia-gpu-exporter/values.schema.json
@@ -290,6 +290,147 @@
             }
           },
           "additionalProperties": false
+        },
+        "collectionSlow": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "thresholdSeconds": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "recoveryAction": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "xidCritical": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "codes": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "minItems": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "xidWarning": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "codes": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "minItems": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "uncorrectableEcc": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "rowRemapFailure": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "rowRemapPending": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "retiredPagesPending": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "thermalSlowdown": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "swThermalSlowdown": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "powerBrake": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "temperatureHigh": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "thresholdCelsius": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "gpuMissing": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/charts/nvidia-gpu-exporter/values.yaml
+++ b/charts/nvidia-gpu-exporter/values.yaml
@@ -172,6 +172,82 @@ prometheusRule:
     thresholdSeconds: 300
     # -- Severity label of the alert
     severity: warning
+  collectionSlow:
+    # -- Alert when collecting GPU metrics is slow for 10 minutes. Healthy
+    # nvidia-smi answers well under a second with the persistence daemon
+    # running; sustained slowness often precedes a wedged driver.
+    enabled: true
+    # -- Collection duration in seconds above which the alert fires
+    thresholdSeconds: 5
+  recoveryAction:
+    # -- Alert when the driver itself requests a GPU recovery action (reset,
+    # reboot, drain). The most direct health signal there is; needs a recent
+    # driver (570+), silently absent on older ones.
+    enabled: true
+  xidCritical:
+    # -- Alert on Xid errors whose NVIDIA-recommended action is a GPU reset
+    # or node reboot. Needs the NVML backend; never fires on the default
+    # nvidia-smi backend.
+    enabled: true
+    # -- Xid codes treated as critical (reset/reboot class)
+    codes: [48, 62, 64, 74, 79, 95, 119, 120]
+  xidWarning:
+    # -- Alert on Xid errors whose recommended action is an application
+    # restart. Explicit allowlist: application-caused Xids (13, 31, 43, ...)
+    # and informational ones (63, 92) deliberately never alert.
+    enabled: true
+    # -- Xid codes treated as warning (restart-app class)
+    codes: [94]
+  uncorrectableEcc:
+    # -- Alert when a GPU reports uncorrectable ECC memory errors since its
+    # last reset. Data may have been corrupted; a GPU reset repairs the
+    # memory on Ampere and newer. Corrected (single-bit) errors never alert.
+    enabled: true
+  rowRemapFailure:
+    # -- Alert when GPU memory row remapping failed, which is NVIDIA's
+    # stated RMA criterion
+    enabled: true
+  rowRemapPending:
+    # -- Alert when a GPU memory row remap waits for a GPU reset to take
+    # effect
+    enabled: true
+  retiredPagesPending:
+    # -- Alert when a GPU memory page retirement waits for a reboot to take
+    # effect (pre-Ampere GPUs)
+    enabled: true
+  thermalSlowdown:
+    # -- Alert when hardware thermal protection throttles a GPU for 5
+    # minutes: cooling is failing at the hardware trip point. The driver
+    # applies the right per-model threshold, so this works across GPU
+    # generations. Disable if it fires routinely on thermally-limited
+    # mobile/small-form-factor systems.
+    enabled: true
+  swThermalSlowdown:
+    # -- Alert when the driver throttles a GPU at its temperature target for
+    # 30 minutes. Off by default: this is normal on thermally-limited
+    # consumer and laptop systems under sustained load.
+    enabled: false
+  powerBrake:
+    # -- Alert when an external hardware power brake throttles a GPU for 5
+    # minutes: a power delivery problem (PSU, cables, rack power). The
+    # configured software power limit never raises this.
+    enabled: true
+  temperatureHigh:
+    # -- Alert when the GPU core temperature stays above the threshold for
+    # 10 minutes. Off by default: safe temperatures differ per GPU
+    # generation (a datacenter A100 throttles around 83C while laptop GPUs
+    # sit at 87C by design), so tune the threshold to your fleet before
+    # enabling.
+    enabled: false
+    # -- Core temperature in Celsius above which the alert fires
+    thresholdCelsius: 85
+  gpuMissing:
+    # -- Alert when a machine reports fewer GPUs than its recent maximum
+    # while collection stays healthy, which catches GPUs that silently fall
+    # off the bus on the default backend. Off by default: it also fires for
+    # up to 6 hours after deliberately removing a GPU and needs a stable
+    # instance label across exporter restarts.
+    enabled: false
 
 grafanaDashboard:
   # -- Create a ConfigMap with the Grafana dashboards (single-GPU detail and
@@ -247,7 +323,7 @@ test:
     # -- Image repository for the `helm test` connection-check pod
     repository: docker.io/library/busybox
     # -- Image tag for the `helm test` pod
-    tag: "1.37"
+    tag: "1.38"
     # -- Image pull policy for the `helm test` pod
     pullPolicy: IfNotPresent
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -88,11 +88,15 @@ through driver events or the kernel log:
   recent event was received by the exporter (the driver events carry no
   timestamp of their own).
 
-For alerting, prefer the timestamp:
-`time() - nvidia_smi_xid_last_timestamp_seconds < 300` fires for any XID in
-the last five minutes, including a series' very first event. A rate-based
-expression like `increase(nvidia_smi_xid_errors_total[5m]) > 0` misses that
-first event, because Prometheus never observed the zero before it.
+For alerting, prefer the timestamp and filter to an explicit code allowlist:
+`time() - nvidia_smi_xid_last_timestamp_seconds{xid=~"48|62|64|74|79|95|119|120"} < 300`
+fires for the reset/reboot-class XIDs in the last five minutes, including a
+series' very first event. Alerting on every code is noise: many XIDs are
+application faults (13, 31, 43) or informational (63, 92) with no operator
+action. A rate-based expression like
+`increase(nvidia_smi_xid_errors_total[5m]) > 0` also misses a series' first
+event, because Prometheus never observed the zero before it. The Helm chart
+ships ready-made rules built this way.
 
 Nothing needs configuring; on setups where the driver does not support
 event registration the families simply stay empty.

--- a/hack/alerts/.gitignore
+++ b/hack/alerts/.gitignore
@@ -1,0 +1,1 @@
+rendered/

--- a/hack/alerts/tests.yaml
+++ b/hack/alerts/tests.yaml
@@ -1,0 +1,286 @@
+# promtool unit tests for the chart's alert rules, run by verify.sh against
+# rendered/rules-noann.yml (the rendered rules with annotations stripped, so
+# these tests assert behavior, not wording; verify.sh asserts the wording).
+#
+# The scenarios encode the review findings that were fixable only by testing:
+# a pre-existing ECC count at first scrape must alert (level check, not
+# increase()), the legacy clocks_throttle_reasons_* family must alert on old
+# drivers, a never-successful exporter must not raise the stale alert, and
+# GpuMissing must catch both the partial and the all-GPUs-gone drop.
+rule_files:
+  - rendered/rules-noann.yml
+
+evaluation_interval: 1m
+
+tests:
+  # exporter self-health: failing, stale (only after a first success), slow
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_last_collect_success{job="gpu", instance="a"}'
+        values: "0x20"
+      # never-successful exporter: no timestamp series exists at all
+      - series: 'nvidia_smi_last_collect_duration_seconds{job="gpu", instance="a"}'
+        values: "0.1x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NvidiaGpuExporterCollectionFailing
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, severity: warning}
+      # no first success ever -> no timestamp series -> stale must stay quiet
+      - eval_time: 15m
+        alertname: NvidiaGpuExporterCollectionStale
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_last_collect_success{job="gpu", instance="a"}'
+        values: "1x30"
+      # one success at t=0, then the timestamp freezes: stale after 300s
+      - series: 'nvidia_smi_last_collect_success_timestamp_seconds{job="gpu", instance="a"}'
+        values: "60x30"
+      - series: 'nvidia_smi_last_collect_duration_seconds{job="gpu", instance="a"}'
+        values: "6x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: NvidiaGpuExporterCollectionStale
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, severity: warning}
+      - eval_time: 20m
+        alertname: NvidiaGpuExporterCollectionSlow
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, severity: warning}
+
+  # driver-requested recovery action
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_gpu_recovery_action{job="gpu", instance="a", uuid="g0"}'
+        values: "2x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NvidiaGpuRecoveryActionNeeded
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: critical}
+
+  # Xid tiers: 79 critical, 94 warning, 13 (application fault) neither
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_xid_last_timestamp_seconds{job="gpu", instance="a", uuid="g0", xid="79"}'
+        values: "540x15"
+      - series: 'nvidia_smi_xid_last_timestamp_seconds{job="gpu", instance="a", uuid="g0", xid="94"}'
+        values: "540x15"
+      - series: 'nvidia_smi_xid_last_timestamp_seconds{job="gpu", instance="a", uuid="g0", xid="13"}'
+        values: "540x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NvidiaGpuXidCritical
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, xid: "79", severity: critical}
+      - eval_time: 10m
+        alertname: NvidiaGpuXidWarning
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, xid: "94", severity: warning}
+
+  # ECC level check: a count that is already non-zero at the first scrape
+  # must alert (increase() would read 0 here - review finding)
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_ecc_errors_uncorrected_volatile_total{job="gpu", instance="a", uuid="g0"}'
+        values: "5x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NvidiaGpuUncorrectableEccErrors
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: critical}
+
+  # ECC 0 -> 1 transition alerts, and a clean 0 does not
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_ecc_errors_uncorrected_volatile_total{job="gpu", instance="a", uuid="g0"}'
+        values: "0 0 0 0 0 1x10"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: NvidiaGpuUncorrectableEccErrors
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: NvidiaGpuUncorrectableEccErrors
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: critical}
+
+  # memory repair states
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_remapped_rows_failure{job="gpu", instance="a", uuid="g0"}'
+        values: "1x10"
+      - series: 'nvidia_smi_remapped_rows_pending{job="gpu", instance="a", uuid="g1"}'
+        values: "1x10"
+      - series: 'nvidia_smi_retired_pages_pending{job="gpu", instance="a", uuid="g2"}'
+        values: "1x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NvidiaGpuRowRemapFailure
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: critical}
+      - eval_time: 5m
+        alertname: NvidiaGpuRowRemapPending
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g1, severity: warning}
+      - eval_time: 5m
+        alertname: NvidiaGpuRetiredPagesPending
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g2, severity: warning}
+
+  # throttle flags, modern metric family
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{job="gpu", instance="a", uuid="g0"}'
+        values: "1x15"
+      - series: 'nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{job="gpu", instance="a", uuid="g1"}'
+        values: "1x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NvidiaGpuThermalSlowdown
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: warning}
+      - eval_time: 10m
+        alertname: NvidiaGpuPowerBrake
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g1, severity: warning}
+
+  # throttle flags, legacy clocks_throttle_reasons_* family (older drivers on
+  # the exec backend - review finding: without the OR these alerts silently
+  # vanish on exactly the older consumer cards)
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_clocks_throttle_reasons_hw_thermal_slowdown{job="gpu", instance="a", uuid="g0"}'
+        values: "1x15"
+      - series: 'nvidia_smi_clocks_throttle_reasons_hw_power_brake_slowdown{job="gpu", instance="a", uuid="g1"}'
+        values: "1x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NvidiaGpuThermalSlowdown
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: warning}
+      - eval_time: 10m
+        alertname: NvidiaGpuPowerBrake
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g1, severity: warning}
+
+  # software thermal slowdown (opt-in rule), modern and legacy families
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{job="gpu", instance="a", uuid="g0"}'
+        values: "1x40"
+      - series: 'nvidia_smi_clocks_throttle_reasons_sw_thermal_slowdown{job="gpu", instance="a", uuid="g1"}'
+        values: "1x40"
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NvidiaGpuSoftwareThermalSlowdown
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: warning}
+          - exp_labels: {job: gpu, instance: a, uuid: g1, severity: warning}
+
+  # temperature threshold (rendered with the default 85C)
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_temperature_gpu{job="gpu", instance="a", uuid="g0"}'
+        values: "90x20"
+      - series: 'nvidia_smi_temperature_gpu{job="gpu", instance="a", uuid="g1"}'
+        values: "70x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NvidiaGpuTemperatureHigh
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, uuid: g0, severity: warning}
+
+  # GpuMissing, partial drop: one of two GPUs stops reporting at t=15m while
+  # collection stays healthy
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_gpu_info{job="gpu", instance="a", uuid="g0"}'
+        values: "1x45"
+      - series: 'nvidia_smi_gpu_info{job="gpu", instance="a", uuid="g1"}'
+        values: "1x15"
+      - series: 'nvidia_smi_last_collect_success{job="gpu", instance="a"}'
+        values: "1x45"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: NvidiaGpuMissing
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, severity: warning}
+
+  # GpuMissing, all GPUs gone: every gpu_info series vanishes at t=15m but
+  # the exporter itself stays healthy (empty-vector case - review finding:
+  # without the zero-fill the single-GPU machine never alerts)
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_gpu_info{job="gpu", instance="a", uuid="g0"}'
+        values: "1x15"
+      - series: 'nvidia_smi_last_collect_success{job="gpu", instance="a"}'
+        values: "1x45"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: NvidiaGpuMissing
+        exp_alerts:
+          - exp_labels: {job: gpu, instance: a, severity: warning}
+
+  # healthy machine raises nothing: every alertable metric is PRESENT with
+  # its healthy value, so this proves the rules stay quiet on real healthy
+  # data, not merely on absent series (review finding)
+  - interval: 1m
+    input_series:
+      - series: 'nvidia_smi_last_collect_success{job="gpu", instance="a"}'
+        values: "1x30"
+      - series: 'nvidia_smi_last_collect_duration_seconds{job="gpu", instance="a"}'
+        values: "0.1x30"
+      - series: 'nvidia_smi_gpu_recovery_action{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_ecc_errors_uncorrected_volatile_total{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_remapped_rows_failure{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_remapped_rows_pending{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_retired_pages_pending{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{job="gpu", instance="a", uuid="g0"}'
+        values: "0x30"
+      - series: 'nvidia_smi_temperature_gpu{job="gpu", instance="a", uuid="g0"}'
+        values: "70x30"
+      - series: 'nvidia_smi_gpu_info{job="gpu", instance="a", uuid="g0"}'
+        values: "1x30"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: NvidiaGpuExporterCollectionFailing
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuExporterCollectionSlow
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuRecoveryActionNeeded
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuUncorrectableEccErrors
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuRowRemapFailure
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuRowRemapPending
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuRetiredPagesPending
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuThermalSlowdown
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuPowerBrake
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuTemperatureHigh
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: NvidiaGpuMissing
+        exp_alerts: []

--- a/hack/alerts/verify.sh
+++ b/hack/alerts/verify.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Validate the Helm chart's alert rules without any cluster:
+#   1. render the PrometheusRule with every rule enabled, at real durations
+#   2. promtool check rules
+#   3. promtool unit tests (tests.yaml) against an annotation-stripped copy,
+#      so the behavior tests don't break on wording changes
+#   4. static assertions: the Xid critical/warning code lists stay disjoint,
+#      and the annotations carry the corrective actions
+# Needs only docker + python3; helm, yq and promtool run from pinned images.
+set -euo pipefail
+
+HELM_IMAGE=alpine/helm:3.19.0
+YQ_IMAGE=mikefarah/yq:4.48.1
+PROM_IMAGE=prom/prometheus:v3.13.1
+
+here="$(cd "$(dirname "$0")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+out="$here/rendered"
+
+mkdir -p "$out"
+rm -f "$out"/*.yml "$out"/*.yaml
+
+chart="$repo/charts/nvidia-gpu-exporter"
+
+# derive the rule list from values.yaml instead of hardcoding it, so a new
+# rule cannot silently escape CI coverage
+rule_keys() { # $1: true|false|any - filter by the enabled default
+  docker run --rm -i "$YQ_IMAGE" eval \
+    '.prometheusRule | to_entries[] | select((.value | type) == "!!map" and (.value | has("enabled"))'"$([ "$1" = any ] || echo " and (.value.enabled == $1)")"') | .key' \
+    - < "$chart/values.yaml"
+}
+
+enable_flags=()
+while IFS= read -r rule; do
+  enable_flags+=("--set" "prometheusRule.$rule.enabled=true")
+done < <(rule_keys false)
+
+docker run --rm -v "$chart:/chart:ro" "$HELM_IMAGE" \
+  template ci /chart \
+  --show-only templates/prometheusrule.yaml \
+  --set prometheusRule.enabled=true \
+  "${enable_flags[@]}" |
+  docker run --rm -i "$YQ_IMAGE" eval '{"groups": .spec.groups}' - > "$out/rules.yml"
+
+total="$(rule_keys any | wc -l | tr -d ' ')"
+rendered="$(grep -c "alert:" "$out/rules.yml")"
+if [ "$rendered" != "$total" ]; then
+  echo "FAIL: full render produced $rendered rules, expected $total (a rule escaped the render?)" >&2
+  exit 1
+fi
+
+docker run --rm -i "$YQ_IMAGE" eval 'del(.groups[].rules[].annotations)' - \
+  < "$out/rules.yml" > "$out/rules-noann.yml"
+
+echo "--- render edge cases"
+# 1. --reuse-values upgrade simulation: an old release's values object has
+# NONE of the new rule subtrees (helm does not backfill new chart defaults
+# on --reuse-values, see helm/helm#8085). Every subtree nulled must render
+# exactly the rules whose values.yaml default is enabled, proving the
+# template's dig fallbacks stay in lockstep with values.yaml.
+{
+  echo "prometheusRule:"
+  echo "  enabled: true"
+  while IFS= read -r rule; do echo "  $rule: null"; done < <(rule_keys any)
+} > "$out/upgrade-sim-values.yaml"
+expected="$(rule_keys true | wc -l | tr -d ' ')"
+got="$(docker run --rm -v "$chart:/chart:ro" -v "$out:/w:ro" "$HELM_IMAGE" \
+  template ci /chart -f /w/upgrade-sim-values.yaml \
+  --show-only templates/prometheusrule.yaml | grep -c "alert:")"
+if [ "$got" != "$expected" ]; then
+  echo "FAIL: upgrade simulation rendered $got rules, expected $expected (dig defaults drifted from values.yaml?)" >&2
+  exit 1
+fi
+echo "upgrade simulation renders $got default-on rules"
+
+# 2. enabled=true with every rule disabled must suppress the resource
+disable_flags=()
+while IFS= read -r rule; do
+  disable_flags+=("--set" "prometheusRule.$rule.enabled=false")
+done < <(rule_keys any)
+kinds="$(docker run --rm -v "$chart:/chart:ro" "$HELM_IMAGE" \
+  template ci /chart --set prometheusRule.enabled=true "${disable_flags[@]}" |
+  grep -c "kind: PrometheusRule" || true)"
+if [ "$kinds" != "0" ]; then
+  echo "FAIL: all-rules-disabled still rendered $kinds PrometheusRule resource(s)" >&2
+  exit 1
+fi
+echo "all-rules-disabled suppresses the resource"
+
+echo "--- promtool check rules"
+docker run --rm -v "$here:/w" --entrypoint /bin/promtool "$PROM_IMAGE" \
+  check rules /w/rendered/rules.yml
+
+echo "--- promtool test rules"
+docker run --rm -v "$here:/w" --entrypoint /bin/promtool "$PROM_IMAGE" \
+  test rules /w/tests.yaml
+
+echo "--- static assertions"
+python3 - "$out/rules.yml" << 'PY'
+import re
+import sys
+
+text = open(sys.argv[1]).read()
+
+def fail(msg):
+    sys.exit(f"FAIL: {msg}")
+
+# the two Xid allowlists must stay disjoint, or one event pages twice with
+# conflicting guidance
+regexes = re.findall(r'xid=~"([0-9|]+)"', text)
+if len(regexes) != 2:
+    fail(f"expected exactly 2 xid regexes, found {len(regexes)}")
+critical, warning = ({s for s in r.split("|")} for r in regexes)
+if critical & warning:
+    fail(f"xid code lists overlap: {sorted(critical & warning)}")
+
+# every alert must tell the operator what to do; spot-check the load-bearing
+# corrective actions survive template/wording edits
+required = {
+    "NvidiaGpuRecoveryActionNeeded": ["1 = reset the GPU", "2 = reboot the node", "current value:"],
+    "NvidiaGpuXidCritical": ["Drain the GPU", "reboot the node", "dmesg"],
+    "NvidiaGpuXidWarning": ["restart the", "application"],
+    "NvidiaGpuUncorrectableEccErrors": ["reset", "RMA"],
+    "NvidiaGpuRowRemapFailure": ["RMA"],
+    "NvidiaGpuRowRemapPending": ["reset"],
+    "NvidiaGpuRetiredPagesPending": ["reboot"],
+    "NvidiaGpuThermalSlowdown": ["fans", "airflow"],
+    "NvidiaGpuSoftwareThermalSlowdown": ["cooling"],
+    "NvidiaGpuPowerBrake": ["PSU", "cables"],
+    "NvidiaGpuExporterCollectionSlow": ["persistence"],
+    "NvidiaGpuMissing": ["Xid 79", "reseat"],
+}
+blocks = re.split(r"- alert: ", text)[1:]
+byname = {b.split("\n", 1)[0].strip(): b for b in blocks}
+for alert, needles in required.items():
+    block = byname.get(alert) or fail(f"alert {alert} not rendered")
+    for needle in needles:
+        if needle not in block:
+            fail(f"{alert}: annotation lost its corrective action ({needle!r})")
+
+print("static assertions OK")
+PY
+
+echo "alert rules OK"

--- a/hack/compose/README.md
+++ b/hack/compose/README.md
@@ -38,6 +38,8 @@ Then open:
   *Data source* dropdown between "Prometheus - NVML" and "Prometheus - Exec"
   to compare the two surfaces of the selected machine.
 - Prometheus (exec): <http://localhost:9090>, (NVML): <http://localhost:9091>
+- Alertmanager: <http://localhost:9093> — the chart's alert rules evaluated
+  against both flavors (see "Verify the alert rules")
 - Exporter metrics: <http://localhost:9835/metrics> (exec-consumer),
   <http://localhost:9836/metrics> (exec-datacenter), <http://localhost:9837/metrics>
   (nvml-consumer), <http://localhost:9838/metrics> (nvml-datacenter)
@@ -55,7 +57,61 @@ service names) make Grafana or Prometheus trip over stale state; run
 `docker compose down -v` once to reset.
 
 `render-dashboard.sh` (run by `up.sh`) needs `python3` on the host, in
-addition to Docker.
+addition to Docker. `render-rules.sh` (also run by `up.sh`) needs only
+Docker: it runs helm and yq from pinned images.
+
+## Verify the alert rules
+
+`render-rules.sh` renders the Helm chart's PrometheusRule into
+`prometheus/rules/` with **every** rule force-enabled and all `for:`
+durations shortened to 30s, so the stack always evaluates exactly what the
+chart ships and alerts appear within a minute. Both Prometheuses evaluate
+the same rules and send to the one Alertmanager; their `backend` external
+label (`exec`/`demo`) keeps the two flavors' alerts apart there. After
+changing the chart's rules, re-run `./hack/compose/render-rules.sh` and
+Prometheus picks the change up on restart (`docker compose restart
+prometheus prometheus-demo`).
+
+What fires out of the box, all on the sick consumer card unless noted:
+
+- `NvidiaGpuRecoveryActionNeeded`, `NvidiaGpuUncorrectableEccErrors`,
+  `NvidiaGpuRowRemapFailure`, `NvidiaGpuRowRemapPending`,
+  `NvidiaGpuRetiredPagesPending`, `NvidiaGpuThermalSlowdown`,
+  `NvidiaGpuTemperatureHigh` — from the sick card's pinned overrides, on
+  both backends.
+- `NvidiaGpuXidCritical` (Xid 79) and `NvidiaGpuXidWarning` (Xid 94) — from
+  the datacenter machine's seeded XID history, demo backend only (the exec
+  surface honestly has no XID metrics). Xid 13 is also seeded and
+  deliberately fires nothing (application fault).
+- Healthy cards fire nothing: the alertable slowdown flags are pinned 0 on
+  them, and only cosmetic flags flip randomly.
+
+The exporter self-health alerts need a broken exporter, kept out of the
+default stack:
+
+- `NvidiaGpuExporterCollectionFailing`: start the failure box with
+  `docker compose --profile broken up -d exec-broken` — its fake nvidia-smi
+  exits non-zero from boot (instance `broken` on the exec Prometheus).
+- `NvidiaGpuExporterCollectionStale`: edit `machines/consumer.yaml` live and
+  add `exit: 15` at the top level; collection starts failing fast, the last
+  success timestamp ages, and the stale alert follows the failing one.
+  Remove the line to recover. A from-boot broken exporter never emits the
+  stale timestamp, which is why stale needs this healthy-then-fail
+  transition instead of the broken profile.
+- `NvidiaGpuExporterCollectionSlow`: add `delay: 2s` instead. Careful with
+  larger values: the delay applies per fake-nvidia-smi invocation, the
+  compute-apps query doubles it, and past the stack's 5s scrape timeout the
+  scrape dies before it can report a slow duration (the dev render lowers
+  the slow threshold to 2s for exactly this headroom reason).
+- `NvidiaGpuSoftwareThermalSlowdown` and `NvidiaGpuPowerBrake`: flip the
+  machine-level `clocks_event_reasons.sw_thermal_slowdown` or
+  `.hw_power_brake_slowdown` override in `machines/consumer.yaml` from `0`
+  to `1`; revert to recover.
+- `NvidiaGpuMissing`: shrink the `gpus:` list of a machine live (e.g. 8 to
+  7 entries); the alert compares against the recent 6h maximum. The
+  all-GPUs-gone form cannot be driven here (the fake refuses a zero-GPU
+  config, which breaks collection and trips the healthy-collection gate
+  instead); it is covered by a promtool unit test in `hack/alerts/`.
 
 ## What "same machine, two surfaces" means (and its limits)
 

--- a/hack/compose/alertmanager/alertmanager.yml
+++ b/hack/compose/alertmanager/alertmanager.yml
@@ -1,0 +1,10 @@
+# Local dev Alertmanager: the UI (localhost:9093) is the verification surface,
+# alerts go nowhere. backend distinguishes the exec and demo Prometheus so the
+# same alert from both flavors shows up as two entries instead of deduping.
+route:
+  receiver: "null"
+  group_by: [alertname, instance, backend]
+  group_wait: 5s
+  group_interval: 30s
+receivers:
+  - name: "null"

--- a/hack/compose/docker-compose.yaml
+++ b/hack/compose/docker-compose.yaml
@@ -67,12 +67,27 @@ services:
     ports:
       - "9838:9835"
 
+  # opt-in failure box for the exporter self-health alerts: nvidia-smi exits
+  # non-zero from boot. Start with: docker compose --profile broken up
+  exec-broken:
+    profiles: ["broken"]
+    build:
+      context: ../..
+      dockerfile: hack/compose/Dockerfile
+    command:
+      - "--nvidia-smi-command=/usr/local/bin/fake-nvidia-smi --config /etc/machines/consumer.yaml --exit 15 --stderr-msg 'Unable to determine the device handle for GPU 0000:01:00.0'"
+    volumes:
+      - ./machines:/etc/machines:ro
+    ports:
+      - "9839:9835"
+
   prometheus:
     image: prom/prometheus:v3.13.1
     ports:
       - "9090:9090"
     volumes:
       - ./prometheus/config:/etc/prometheus
+      - ./prometheus/rules:/etc/prometheus/rules:ro
       - prometheus-data:/prometheus
     depends_on:
       - exec-consumer
@@ -84,10 +99,20 @@ services:
       - "9091:9090"
     volumes:
       - ./prometheus/config-demo:/etc/prometheus
+      - ./prometheus/rules:/etc/prometheus/rules:ro
       - prometheus-demo-data:/prometheus
     depends_on:
       - nvml-consumer
       - nvml-datacenter
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager:/etc/alertmanager:ro
 
   grafana:
     image: grafana/grafana:13.1.0

--- a/hack/compose/machines/consumer.yaml
+++ b/hack/compose/machines/consumer.yaml
@@ -32,6 +32,12 @@ gpus:
       gpu_recovery_action: "Node Reboot"
       temperature.gpu: 93
       clocks_event_reasons.hw_thermal_slowdown: 1
+      # memory-repair states for the alert rules: remap failed (RMA
+      # criterion), a remap and a page retirement waiting for a reset.
+      # Yes/No enum fields, the exporter maps them to 1/0.
+      remapped_rows.failure: "Yes"
+      remapped_rows.pending: "Yes"
+      retired_pages.pending: "Yes"
       # ECC preview on the sick card only: the 4080 capture reports no ECC,
       # these force the banner tile red + populate the datacenter ECC detail
       # panel. Healthy cards keep "No ECC" so the overview dashboard can show
@@ -62,12 +68,15 @@ overrides:
   clocks.current.graphics: {min: 2500, max: 3140}
   # states the jitter does not cover. Integer 0:1 flips a flag ~50/50 per
   # scrape and per GPU; bare integers parse fine for pstate and compute mode.
+  # Only flags WITHOUT an alert rule flip randomly: the alertable slowdown
+  # flags (hw_thermal, sw_thermal, hw_power_brake) stay 0 on healthy cards so
+  # they cannot flicker pending alerts, and the sick card pins its own.
   clocks_event_reasons.sw_power_cap:                {min: 0, max: 1}
   clocks_event_reasons.sync_boost:                  {min: 0, max: 1}
-  clocks_event_reasons.hw_thermal_slowdown:         {min: 0, max: 1}
+  clocks_event_reasons.hw_thermal_slowdown:         0
   clocks_event_reasons.gpu_idle:                    {min: 0, max: 1}
-  clocks_event_reasons.sw_thermal_slowdown:         {min: 0, max: 1}
-  clocks_event_reasons.hw_power_brake_slowdown:     {min: 0, max: 1}
+  clocks_event_reasons.sw_thermal_slowdown:         0
+  clocks_event_reasons.hw_power_brake_slowdown:     0
   clocks_event_reasons.applications_clocks_setting: {min: 0, max: 1}
   compute_mode:                                     {min: 0, max: 3}
   pstate:                                           {min: 0, max: 5}  # busy states, coherent with the load

--- a/hack/compose/machines/datacenter.yaml
+++ b/hack/compose/machines/datacenter.yaml
@@ -18,6 +18,9 @@ extras:
         - {gi: 7, profile: 1g.18gb}
   xids:
     initial:
+      # one per alert tier: 79 fires the critical Xid alert, 94 the warning
+      # one, and 13 (application fault) deliberately fires nothing
       - {gpu: 1, xid: 79, count: 2}
+      - {gpu: 0, xid: 94, count: 1}
       - {gpu: 0, xid: 13, count: 1}
     interval: 5m

--- a/hack/compose/prometheus/.gitignore
+++ b/hack/compose/prometheus/.gitignore
@@ -1,1 +1,2 @@
 data/
+rules/

--- a/hack/compose/prometheus/config-demo/prometheus.yml
+++ b/hack/compose/prometheus/config-demo/prometheus.yml
@@ -1,7 +1,19 @@
 global:
   # short interval so the dashboard moves quickly while iterating
   scrape_interval: 5s
-  evaluation_interval: 15s
+  evaluation_interval: 5s
+  external_labels:
+    # distinguishes this Prometheus's alerts from the exec flavor's in
+    # Alertmanager; without it identical alerts from both backends dedupe
+    backend: demo
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
 
 scrape_configs:
   - job_name: "nvidia_gpu_exporter"

--- a/hack/compose/prometheus/config/prometheus.yml
+++ b/hack/compose/prometheus/config/prometheus.yml
@@ -1,7 +1,19 @@
 global:
   # short interval so the dashboard moves quickly while iterating
   scrape_interval: 5s
-  evaluation_interval: 15s
+  evaluation_interval: 5s
+  external_labels:
+    # distinguishes this Prometheus's alerts from the demo flavor's in
+    # Alertmanager; without it identical alerts from both backends dedupe
+    backend: exec
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
 
 scrape_configs:
   - job_name: "nvidia_gpu_exporter"
@@ -15,3 +27,8 @@ scrape_configs:
       - targets: ["exec-datacenter:9835"]
         labels:
           instance: datacenter
+      # only up when the stack runs with --profile broken; a down target
+      # produces no nvidia_smi_* series, so no alerts while absent
+      - targets: ["exec-broken:9835"]
+        labels:
+          instance: broken

--- a/hack/compose/render-rules.sh
+++ b/hack/compose/render-rules.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Render the Helm chart's PrometheusRule into a plain Prometheus rule file for
+# the dev stack, so the stack always tests exactly what the chart ships - no
+# hand-maintained copy. Every rule is force-enabled (the chart keeps a few off
+# by default), the `for:` durations are shortened so the local
+# fire-every-alert loop takes seconds, not tens of minutes, and the slow
+# threshold drops to 2s because the stack's 5s scrape interval caps the scrape
+# timeout below the chart's 5s default (a slower fake would just fail the
+# scrape instead of proving the slow alert).
+#
+# Helm and yq run through docker on pinned images: the dev stack's host
+# dependencies stay docker + python3.
+set -euo pipefail
+
+HELM_IMAGE=alpine/helm:3.19.0
+YQ_IMAGE=mikefarah/yq:4.48.1
+DEV_FOR=30s
+
+here="$(cd "$(dirname "$0")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+out_dir="$here/prometheus/rules"
+
+mkdir -p "$out_dir"
+rm -f "$out_dir"/*.yml
+
+# derive the default-off rules from the chart's values.yaml instead of
+# hardcoding them, so a new rule cannot silently escape the dev stack
+enable_flags=()
+while IFS= read -r rule; do
+  enable_flags+=("--set" "prometheusRule.$rule.enabled=true")
+done < <(docker run --rm -i "$YQ_IMAGE" eval \
+  '.prometheusRule | to_entries[] | select((.value | type) == "!!map" and (.value | has("enabled")) and (.value.enabled == false)) | .key' \
+  - < "$repo/charts/nvidia-gpu-exporter/values.yaml")
+
+docker run --rm -v "$repo/charts/nvidia-gpu-exporter:/chart:ro" "$HELM_IMAGE" \
+  template dev /chart \
+  --show-only templates/prometheusrule.yaml \
+  --set prometheusRule.enabled=true \
+  "${enable_flags[@]}" \
+  --set prometheusRule.collectionSlow.thresholdSeconds=2 \
+  --set prometheusRule.collectionStale.thresholdSeconds=60 |
+  docker run --rm -i "$YQ_IMAGE" eval '
+    {"groups": .spec.groups}
+    | (.groups[].rules[] | select(has("for")) | .for) = "'"$DEV_FOR"'"
+  ' - > "$out_dir/nvidia-gpu-exporter.yml"
+
+echo "rendered $out_dir/nvidia-gpu-exporter.yml"

--- a/hack/compose/up.sh
+++ b/hack/compose/up.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 "$here/render-dashboard.sh"
+"$here/render-rules.sh"
 cd "$here"
 docker compose config --quiet
 exec docker compose up --build "$@"


### PR DESCRIPTION
The chart's optional PrometheusRule grows from exporter self-health into a curated GPU health set: driver-requested recovery actions, two Xid tiers with explicit code allowlists, uncorrectable ECC errors, memory row remap and page retirement states, hardware thermal and power brake slowdown, slow collection, plus opt-in rules for absolute temperature, software thermal slowdown and disappearing GPUs. Every alert description says what to do about it, defaults stay conservative for consumer and homelab hardware, and each rule can be toggled individually. The throttle rules cover both the current and the legacy metric family so older drivers keep their coverage.

The dev compose stack gains an Alertmanager and evaluates the rules rendered from the chart itself against both backend flavors, with deterministic failure injection to drive every alert and an opt-in broken exporter box for the self-health ones.

A verification suite renders the rules with everything enabled and runs promtool checks and unit tests in CI, covering the reuse-values upgrade path, the all-rules-disabled render, both throttle metric families and the corrective action texts.

Closes #429.
