### PR TITLE
docs: add an agent guide and refresh the documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Copilot instructions
+
+Read `AGENTS.md` in the repository root first. It is the project guide, and everything below is only the short version for when you have not opened it.
+
+- This exporter's metric names and labels are a public contract. Renaming or relabeling an established series silently breaks users' dashboards and alerts, so treat existing names as frozen.
+- The expected `.metrics` files under `internal/integration/testdata/` are generated, not hand-edited. Regenerate them with the integration suite's `-update` flag and review the diff.
+- The Helm chart's `README.md` is generated and must never be edited directly: its prose lives in `README.md.gotmpl`, and its values reference comes from the comments in `values.yaml`. Regenerate with helm-docs after changing either. A new key in `values.yaml` also needs an entry in `values.schema.json`, which rejects unknown keys.
+- The Grafana dashboards under `docs/grafana/` are the source of truth; the copies shipped in the chart must stay byte-identical, and CI enforces it. See `docs/grafana/README.md` for the query conventions, several of which fail silently when violated.
+- Verify with `go test ./...` and the `task lint:*` target relevant to what you changed; CI runs the full `task lint` set.
+- Commits follow the conventional-commit format (`type(scope): imperative description`) with a body explaining what changed and why, and carry a DCO sign-off. Do not add AI attribution of any kind, such as "generated with" lines or AI co-author trailers.

--- a/.gitignore
+++ b/.gitignore
@@ -1,146 +1,51 @@
-# Created by https://www.toptal.com/developers/gitignore/api/go,macos,jetbrains+all
-# Edit at https://www.toptal.com/developers/gitignore?templates=go,macos,jetbrains+all
-
 ### Go ###
-# Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
 
-# Test binary, built with `go test -c`
+# test binaries and coverage output
 *.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-### Go Patch ###
 /vendor/
-/Godeps/
 
-### JetBrains+all ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
-
-# CMake
-cmake-build-*/
-
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
-
-# File-based project format
-*.iws
-
-# IntelliJ
-out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Cursive Clojure plugin
-.idea/replstate.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-
-# Editor-based Rest Client
-.idea/httpRequests
-
-# Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
-
-### JetBrains+all Patch ###
-# Ignores the whole .idea folder and all .iml files
-# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
-
+### Editors / IDEs ###
 .idea/
-
-# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
-
 *.iml
-modules.xml
-.idea/misc.xml
 *.ipr
-
-# Sonarlint plugin
-.idea/sonarlint
+*.iws
+.vscode/
 
 ### macOS ###
-# General
 .DS_Store
 .AppleDouble
 .LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
 ._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
 .Spotlight-V100
-.TemporaryItems
 .Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
 
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
+### Agent tooling ###
+# local, uncommitted agent instructions (CLAUDE.local.md and friends).
+# Root-anchored so a legitimate *.local.md elsewhere in the tree stays visible.
+/*.local.md
+/*.override.md
+# harness runtime state
+.claude/settings.local.json
+.claude/worktrees/
+.claude/checkpoints/
+.claude/mailbox/
+.claude/routines/.state/
+.claude/scheduled_tasks.json
+.claude/scheduled_tasks.lock
+.claude/agent-registry.json
+.claude/agent-memory-local/
+.claude/first-run
+.claude/assistant-daemon-state.json
 
-# End of https://www.toptal.com/developers/gitignore/api/go,macos,jetbrains+all
-
+### Project ###
+# goreleaser output
 /dist
+# local scratch space: designs, experiments, private captures
 /_work

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -226,7 +226,11 @@ dockers_v2:
       - linux/amd64
 
 scoops:
-  - repository:
+    # only the static build, like every other publisher; the cgo nvml flavor
+    # must never leak into the scoop manifest
+  - ids:
+      - nvidia_gpu_exporter-archive
+    repository:
       owner: utkuozdemir
       name: scoop_nvidia_gpu_exporter
       token: "{{ .Env.PRIVATE_ACCESS_TOKEN }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,246 @@
+# nvidia_gpu_exporter — agent guide
+
+This is the project's knowledge base for humans and agents working in this repository.
+Maintain it as you go: whenever you learn something durable about how this repo works, add it here.
+It is not append-only, so fix or delete anything that becomes wrong or outdated.
+
+Keep it timeless.
+Two rules keep it from rotting: **prefer pointers over copies**, and **prefer invariants over inventories**.
+Never restate a flag list, a metric list, a chart value, a file count, a version number or the current state of some in-flight work.
+Those live in the code and the docs, they change constantly, and a stale copy here is worse than no copy.
+What belongs here is the map, and the reasoning that is not written down anywhere else.
+
+`CLAUDE.md`, `GEMINI.md` and `.github/copilot-instructions.md` point at this file, so this is the one place to edit.
+The Copilot file additionally inlines a few of the rules below, because its consumer injects that file verbatim instead of following the pointer; keep those copies in sync.
+
+Markdown note: `task lint:assets` runs `markdownlint` over every tracked markdown file except the generated chart README, this one included, so it has to pass.
+Keep one sentence per line and the first line as the single top-level heading.
+
+## What this repo is
+
+A Prometheus exporter for NVIDIA GPUs, distributed as a single static Go binary.
+By default it runs `nvidia-smi`, parses its CSV output and exports the result, which is why it works anywhere that binary works (Linux, Windows, macOS, containers, WSL2) with no C bindings and no NVIDIA userspace of its own.
+
+The distribution surface is wide for a project this size: archives, native packages, container images on more than one registry, a Helm chart, Windows package manifests, a systemd unit, a native Windows service, and the Grafana dashboards.
+`.goreleaser.yml` and `.github/workflows/release.yml` are the authority on what is published and where.
+Almost all of it is produced by the release pipeline from this repository, with one exception: the dashboards are published to grafana.com by hand.
+
+The niche is deliberate.
+DCGM and the NVIDIA GPU Operator own the datacenter fleet-management case.
+This exporter aims at everything `nvidia-smi` can reach and heavier tooling cannot or will not: consumer and prosumer cards, small clusters and edge boxes, virtualized and locked-down environments, mixed old-and-new fleets, and remote scraping over a wrapper command.
+When a change would only make sense for a large managed datacenter fleet, it is probably the wrong project for it.
+
+## The three collection backends
+
+Everything about the exporter's shape follows from there being three ways to obtain a reading.
+
+`exec` is the default and the only one available on every platform.
+It runs `nvidia-smi` as a subprocess and parses the CSV.
+It is the only backend that can honor a custom command, which is what makes remote scraping over ssh and privilege wrappers like `sudo` work.
+It is also the strongest isolation against a misbehaving driver, because a wedged subprocess can be killed and an in-process driver call cannot.
+
+`nvml` reads the driver library directly through go-nvml, and is still labelled experimental.
+It requires cgo and Linux, so it exists only as a separate release flavor whose default backend is flipped at link time.
+On top of the query-field metrics it shares with the exec backend, it serves families only the driver library can provide.
+Its query-field vocabulary is a compiled catalog, not runtime discovery, so it is not automatically a superset of what exec can reach.
+The catalog explicitly defers fields it has no verified mapping for, and a field a new driver adds appears under exec's discovery first.
+`internal/nvmlnative/catalog.go` holds both the catalog and the deferral list, and the drift tests force adding a newly-seen field to one or the other as an explicit decision.
+
+`demo` serves synthetic data with no GPU, no driver and no Linux.
+It is not a fourth code path: it runs the real exec pipeline against an in-process fake `nvidia-smi`, then synthesizes the NVML-only families on top.
+So it is pure Go, works on any platform, and stays faithful to the real backends' quirks almost for free.
+
+Two invariants hold this together, and both are easy to break by accident:
+
+- For every query field both backends serve, they must emit identical metrics, down to the label sets and values.
+  Users switch between the backends and their dashboards and alerts must keep working.
+  The nvml catalog exists precisely to guarantee this, and it stores the exact header strings `nvidia-smi` prints, not paraphrases of them.
+  Declining to serve a field is allowed; serving it differently is not.
+- The demo backend targets the nvml surface, not the exec one, closely enough that dashboards and alerts can be developed against it.
+  It approximates that surface without replicating it, and the differences are documented in the demo mode section of `docs/CONFIGURE.md`.
+  The one most likely to mislead: demo always serves the PCIe throughput family, while the real nvml backend serves it only when asked.
+
+Flag combinations that a chosen backend cannot honor are startup errors rather than silent ignores.
+A user passing a custom command with the nvml backend means something the backend cannot do, and failing loudly is the only honest answer.
+
+## Code map
+
+- `cmd/nvidia_gpu_exporter`: the binary.
+  Thin: process lifecycle, signal handling, and the Windows service and install commands behind build tags.
+  Everything real lives behind `internal/app`.
+- `cmd/fake-nvidia-smi`: the fake `nvidia-smi` as a standalone binary, with the whole capture corpus embedded.
+- `internal/app`: the single entry point behind both the binary and the in-process tests.
+  Flag parsing and validation, backend wiring, metric registration, HTTP serving.
+  Tests drive the real entry, not a reimplementation of it.
+- `internal/collect`: collection scheduling and health accounting, backend-agnostic.
+  `Live` collects synchronously and shares one in-flight run between concurrent scrapes; `Cached` collects on a timer and serves the latest result.
+  The `Snapshot` type keeps *data* and *health* strictly separate, and health is read from explicit booleans, never inferred from an error being non-nil.
+  A failed collection publishes no GPU data instead of serving the last known good reading, in both modes, so a stale value can never be mistaken for a live one.
+  The auxiliary families (per-process, and the nvml extras) fail softly instead: they go absent without failing the collection.
+- `internal/exporter`: turns a snapshot into Prometheus metrics.
+  Conditionally-described families follow one precedent: a disabled feature contributes no descriptors at all, so `Describe` and `Collect` stay consistent.
+- `internal/nvidiasmi`: the exec backend: command splitting, field resolution, CSV parsing, value transformation, per-process queries.
+- `internal/nvmlnative`: the nvml backend, guarded by `linux && cgo` build tags with an unavailable stub for every other target.
+  Holds the field catalog, the MIG and XID paths, and the drift tests.
+- `internal/demo`: the demo backend's configuration and its synthesizers for the NVML-only families.
+- `internal/fakesmi`: the fake `nvidia-smi` implementation, shared by the standalone binary and the demo backend.
+- `internal/captures` and `internal/capture`: the recorded corpus and its parser.
+- `internal/demodata`: the small curated capture subset the demo backend embeds.
+- `internal/integration`: the end-to-end suite.
+
+## The capture corpus and how testing works
+
+This is the most unusual part of the repository, and the part most often misread.
+
+The exporter parses text whose shape varies by GPU model, driver version, operating system and load state.
+Owning that hardware is impossible, so the project records real `nvidia-smi` output into self-contained capture files and treats them as the test substrate.
+`internal/captures/README.md` documents the format, the masking rules and how contributors add one; read it before touching anything in that area.
+
+The captures are executable.
+The fake `nvidia-smi` replays a capture verbatim and answers arbitrary field subsets by projecting columns out of the recorded CSV, with no baked-in knowledge of GPUs or fields.
+The integration suite then runs the real exporter against the fake for every capture in the corpus and compares the scraped output against a checked-in expected file.
+Contributing a capture therefore extends the test matrix automatically, and a new capture fails the suite until its expected output is generated and reviewed.
+
+Consequences to keep in mind before changing anything here:
+
+- The expected `.metrics` files are compared byte for byte and are regenerated with the suite's `-update` flag, never hand-edited.
+  Always read the resulting diff: it is the review step, and it is the only place where a change in exported output becomes visible.
+- `.gitattributes` pins the corpus captures and expected outputs to LF.
+  This is load-bearing, not cosmetic.
+  A CRLF conversion on a Windows checkout would break the entire suite.
+- The full corpus must never reach the shipped binary; only the curated demo subset may.
+  A test asserts this by inspecting the binary's dependency graph, because the failure mode is silent size growth, not a broken build.
+- The GPU-hardware parity test is behind a build tag and never runs in CI, but CI compiles it, so it cannot rot between the rare sessions where real hardware is available.
+- The nvml backend's drift tests check its catalog and its required driver symbols against the recorded captures, so a driver that renames or withdraws something is caught offline.
+
+## Metrics and their compatibility contract
+
+Exported metric names are a public contract, and breaking one is the most expensive mistake available in this repo.
+The Grafana dashboard has a large installed base and there are alerting rules in the wild, so a renamed or relabeled series breaks strangers' monitoring silently.
+Treat every established name as frozen unless there is an explicit decision otherwise.
+
+Some specifics that regularly surprise people:
+
+- Metric names derive from the returned header strings `nvidia-smi` prints, not from the query field names.
+  That is why the nvml catalog stores those header strings byte-exactly, and why a driver renaming a header renames a metric.
+- The `nvidia_smi_` prefix names the data schema, not the collection mechanism.
+  It stays as-is in every backend, including the ones that never run `nvidia-smi`.
+- The failed-collection counter's name says "scrapes" and counts collections.
+  It has been a misnomer since background collection decoupled the two, and it stays, because the migration cost lands on users and the benefit is cosmetic.
+- Health metrics are backend-neutral except the collection status one, which differs by backend on purpose.
+  Reporting an NVML status under a metric named after a process exit code would silently change an established metric's meaning.
+- Adding labels to an existing family changes series identity, so it goes behind an opt-in flag.
+  The MIG attribution labels on the per-process metrics are the precedent to follow.
+- Fields that report a state rather than a number are mapped to numbers.
+  An unavailable value is not exported at all; an unrecognized value is also not exported, but is logged, because guessing at a brand-new driver state is worse than a visible gap.
+
+`docs/METRICS.md` carries the reference and the per-family semantics; keep it in sync when the surface changes.
+
+## Grafana dashboards
+
+There are two: a per-GPU detail dashboard and a multi-GPU overview that drills down into it.
+Both are published on grafana.com.
+
+They are authored in the Grafana UI and exported to `docs/grafana/`, which is the source of truth.
+The Helm chart ships copies, and CI compares them byte for byte, so the two locations must be updated together.
+Publishing to grafana.com is a manual step outside the release pipeline.
+
+`docs/grafana/README.md` carries the query and panel conventions the dashboards depend on.
+Read it before changing any panel query: several of those conventions fail silently when violated.
+
+`task lint:dashboard` runs grafana's dashboard-linter in strict mode.
+Rule exclusions live next to the dashboards, each with a written reason, and the bar for adding one is that the rule conflicts with the dashboard's long-published design.
+The instance-selector template variable in particular is not named `instance` and cannot be renamed: every bookmarked URL carries the current name, so the linter rule is excluded instead of obeyed.
+
+## Helm chart
+
+The chart deploys a DaemonSet and is the primary Kubernetes install path.
+
+Its central design decision: GPU access comes from the NVIDIA container runtime, injected via a runtime class and the NVIDIA environment variables, and the exporter never requests an `nvidia.com/gpu` resource.
+The device plugin allocates whole GPUs exclusively, so a monitoring pod that requested one would take it away from real workloads.
+Anything that reintroduces a GPU resource request is a bug.
+
+Other things that are easy to trip over:
+
+- Chart and app versions are stamped from the release tag; the in-repo versions are placeholders.
+  The chart major is deliberately the app major plus one, a legacy of the chart's history that must be preserved by the release job.
+- The chart README is assembled by helm-docs and CI fails if it is out of date, so never edit `README.md` directly.
+  Its prose lives in `README.md.gotmpl`; only the values reference is generated, from the comments in `values.yaml`.
+  Edit whichever of the two is appropriate, then regenerate.
+- `values.schema.json` validates the values strictly and rejects unknown keys.
+  A new value subtree added without a matching schema entry survives review and then fails chart linting and installation, so the two change together.
+- The alert rules are values-driven, and `hack/alerts/verify.sh` renders and unit-tests them without a cluster.
+  It also simulates an upgrade that reuses a previous release's values, because Helm does not backfill new chart defaults on `--reuse-values`; that is why the templates use defaulted lookups instead of direct value references, and why new value subtrees must stay nil-safe.
+- Alert rules ship with corrective actions in their annotations, and the verification script asserts the load-bearing ones survive rewording.
+
+## Building, testing and linting
+
+`Taskfile.yml` is the entry point and mirrors what CI runs.
+`task lint` covers everything: Go, module tidiness, markdown, shell scripts, the dashboards, and the release configuration.
+`task fmt` applies the formatters.
+The individual `task lint:*` targets are the ones to reach for while iterating, since the full set needs several external tools installed.
+
+The Go toolchain version is pinned in `go.mod` and CI reads it from there, so there is one place to change it.
+Linting is `golangci-lint` configured to enable linters by default and disable a short, individually-justified list; new code is expected to satisfy it instead of accumulating suppressions.
+
+CI additionally runs a goreleaser snapshot on every change.
+That is intentional: it validates the packaging inputs (the systemd unit, the package scriptlets, the archive layouts) in CI instead of letting them fail for the first time during a real release.
+It deliberately skips the container, signing and SBOM stages, so those paths are exercised only by a real release.
+
+## Release pipeline
+
+Releases are cut by pushing a version tag, which triggers the release workflow; the Taskfile has a target that derives the next version from the commit history and pushes the tag.
+
+The pipeline builds two binary flavors from the same source: the fully static default build, and the cgo nvml flavor.
+Keeping the two apart is a real invariant.
+The packages and the primary container image explicitly pin themselves to the static build, because a cgo binary silently reaching the deb, the rpm or the main image would ship something that cannot run where those artifacts are expected to run.
+The nvml flavor is published as its own archive and as a suffixed image tag.
+
+Release artifacts are signed two ways.
+The GPG key signs the checksums file, which transitively covers every binary, archive and package, and it also signs the packaged Helm chart's provenance file.
+Cosign signs the container images and the OCI chart keyless, tied to the release workflow's identity.
+The release job verifies that the imported signing key matches the fingerprint the chart advertises, and fails loudly if it does not.
+`hack/generate-signing-key.sh` documents and performs key generation and rotation.
+
+The chart is published twice: to GHCR as an OCI artifact, and to a Helm repository on the `gh-pages` branch.
+Both are expected to stay available; dropping either breaks existing users.
+
+One packaging footgun: the nvml image tag suffix parses as a semver pre-release.
+Strict semver therefore sorts the flavored tag *below* the plain one of the same version, while tooling that sorts lexically or by push time may pick it instead, so automation consuming these tags needs an explicit filter either way.
+
+## Developing without a GPU
+
+In increasing order of setup:
+
+- Run the exporter against the fake `nvidia-smi` binary via the custom command flag, replaying any capture in the corpus.
+  Good for parser and field work.
+- Run the exporter with the demo backend.
+  Good for anything that needs the NVML-only families, and the only option that exercises them at all without hardware.
+- Bring up the compose stack under `hack/compose`, which simulates several machines and serves each through both backend flavors, with Prometheus, Grafana and Alertmanager wired up.
+  This is the environment for dashboard and alert work; its README documents how to drive specific states and make specific alerts fire.
+
+The simulated machine configurations are re-read on every collection cycle, so editing one changes the next scrape with no restart.
+
+## Conventions
+
+- Commits follow the conventional-commit format: a `type(scope): imperative description` title plus a body explaining what changed and why.
+  The changelog is generated by grouping commits on that type, so the type is functional, not decorative.
+- History on the default branch stays linear.
+  Integrate by rebase or squash, never by merge commit, and rebase branches onto the default branch rather than merging it into them.
+- Commits carry a DCO sign-off.
+- Nothing carries AI attribution: no "generated with" lines, no AI co-author trailers, in commits, pull requests or anywhere else.
+- Documentation is split by audience: the README orients, `docs/` carries installation, configuration and metrics reference, and community files live under `.github/`.
+  Deep, area-specific documentation lives next to the thing it documents, not in `docs/`.
+- Dependencies are updated by Renovate, configured to merge qualifying updates as branches without opening pull requests; `.renovaterc.json` is the authority on which update classes qualify.
+  Branch automerge only works while the default branch has no rule requiring a pull request before merging, so if dependency pull requests start appearing for passing updates, that rule is the thing to look for.
+  Required status checks are fine and are what actually gate those merges.
+
+## Reference pointers
+
+- `README.md`: what the project is and who it is for.
+- `docs/INSTALL.md`, `docs/CONFIGURE.md`, `docs/METRICS.md`: the user-facing reference.
+- `docs/grafana/README.md`: dashboard query and panel conventions.
+- `internal/captures/README.md`: the capture format, contribution flow and how captures drive the tests.
+- `hack/compose/README.md`: the local dev stack, including how to provoke specific alerts.
+- `charts/nvidia-gpu-exporter/README.md`: the chart's values reference and deployment notes.
+- `.github/CONTRIBUTING.md`: the contributor-facing process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# nvidia_gpu_exporter — agent guide
+
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# nvidia_gpu_exporter — agent guide
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ probably the better fit; this exporter aims at the cases above.
 ## Highlights
 
 - Will work on any system that has `nvidia-smi(.exe)?` binary - Windows, Linux, MacOS... No C bindings required
-- Doesn't even need to run the monitored machine: can be configured to execute `nvidia-smi` command remotely
+- Doesn't even need to run on the monitored machine: can be configured to execute `nvidia-smi` command remotely
 - Auto-discovery of the metric fields `nvidia-smi` can expose (future-compatible)
 - Optional per-process GPU metrics: see which process uses how much GPU memory
 - Optional background collection: run `nvidia-smi` on a timer instead of on every scrape
-- Comes with its own [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
+- Comes with its own Grafana dashboards: a [per-GPU detail](https://grafana.com/grafana/dashboards/14574) one and a [multi-GPU overview](https://grafana.com/grafana/dashboards/25547)
 
 ## Try it without a GPU
 
@@ -72,17 +72,20 @@ and an XID error history. The simulated setup is configurable; see
 
 ## Visualization
 
-You can use the official [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
-to see your GPU metrics in a nicely visualized way.
+There are two official Grafana dashboards, and they link to each other in Grafana:
 
-Here's how it looks:
+- [Nvidia GPU Metrics](https://grafana.com/grafana/dashboards/14574) (ID `14574`),
+  the per-GPU detail view.
+- [Nvidia GPU Overview](https://grafana.com/grafana/dashboards/25547) (ID `25547`),
+  which compares all GPUs of a node side by side and drills down into the
+  detail dashboard.
+
+Import either by ID in Grafana (*Dashboards* - *New* - *Import*), or enable
+`grafanaDashboard` in the Helm chart to get both provisioned automatically. The
+JSON is also in this repository under [docs/grafana](docs/grafana).
+
+Here's how they look:
 ![Grafana dashboard](https://raw.githubusercontent.com/utkuozdemir/nvidia_gpu_exporter/main/docs/grafana/dashboard.png)
-
-For machines with more than one GPU there is a companion
-[overview dashboard](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
-that compares all GPUs of a node side by side and drills down into the
-single-GPU dashboard above. Import it from the JSON file, or enable
-`grafanaDashboard` in the Helm chart to get both dashboards provisioned.
 
 ![Grafana overview dashboard](https://raw.githubusercontent.com/utkuozdemir/nvidia_gpu_exporter/main/docs/grafana/dashboard-overview.png)
 

--- a/charts/nvidia-gpu-exporter/Chart.yaml
+++ b/charts/nvidia-gpu-exporter/Chart.yaml
@@ -29,4 +29,4 @@ annotations:
     - name: Grafana dashboard
       url: https://grafana.com/grafana/dashboards/14574
     - name: Grafana dashboard (multi-GPU overview)
-      url: https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json
+      url: https://grafana.com/grafana/dashboards/25547

--- a/charts/nvidia-gpu-exporter/README.md
+++ b/charts/nvidia-gpu-exporter/README.md
@@ -211,7 +211,7 @@ metrics by design. The alert expressions select all `nvidia_smi_*` series, so
 when installing multiple releases of this chart, enable the rules in only one
 of them.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
-and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
+and its [multi-GPU overview companion](https://grafana.com/grafana/dashboards/25547)
 as a ConfigMap labeled for the Grafana sidecar.
 
 With [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack),

--- a/charts/nvidia-gpu-exporter/README.md.gotmpl
+++ b/charts/nvidia-gpu-exporter/README.md.gotmpl
@@ -211,7 +211,7 @@ metrics by design. The alert expressions select all `nvidia_smi_*` series, so
 when installing multiple releases of this chart, enable the rules in only one
 of them.
 `grafanaDashboard` ships the [Grafana dashboard](https://grafana.com/grafana/dashboards/14574)
-and its [multi-GPU overview companion](https://github.com/utkuozdemir/nvidia_gpu_exporter/blob/main/docs/grafana/dashboard-overview.json)
+and its [multi-GPU overview companion](https://grafana.com/grafana/dashboards/25547)
 as a ConfigMap labeled for the Grafana sidecar.
 
 With [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack),

--- a/charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-overview.json
+++ b/charts/nvidia-gpu-exporter/dashboards/nvidia-gpu-overview.json
@@ -50,6 +50,7 @@
   "description": "Compare all GPUs of one node side by side: current state, utilization, thermals, throttling and health per GPU. Companion to the Nvidia GPU Metrics dashboard (single-GPU detail, click a GPU in the table to drill down). Shows physical GPUs as reported by nvidia-smi, MIG instances are not broken out: rows are the parent GPUs, whose utilization is not reported in MIG mode and shows n/a. Based on the prometheus metrics from github.com/utkuozdemir/nvidia_gpu_exporter",
   "editable": false,
   "fiscalYearStartMonth": 0,
+  "gnetId": 25547,
   "graphTooltip": 1,
   "id": null,
   "links": [

--- a/docs/CONFIGURE.md
+++ b/docs/CONFIGURE.md
@@ -329,11 +329,14 @@ Things to keep in mind:
 ## Experimental: native NVML backend
 
 `--collect.backend=nvml` reads GPU metrics directly from the driver library
-(`libnvidia-ml.so.1`) instead of running `nvidia-smi`. Its metric surface is
-a superset of the default backend's: every metric derived from the
-`nvidia-smi` query fields is identical in name, labels and value (verified
-field-by-field against live hardware), and on top of that shared core the
-nvml backend serves metric families only the driver library can provide.
+(`libnvidia-ml.so.1`) instead of running `nvidia-smi`. For every query field
+both backends serve, the metric is identical in name, labels and value
+(verified field-by-field against live hardware), and on top of that shared
+core the nvml backend serves metric families only the driver library can
+provide. Its query-field vocabulary is a built-in catalog rather than
+runtime discovery, though, so it is not automatically a superset: a handful
+of fields have no verified mapping yet and are deliberately not served, and
+a field a newer driver adds shows up under the default backend first.
 
 What each backend can do (`demo` serves synthetic data, see
 [Demo mode](#demo-mode)):
@@ -370,7 +373,7 @@ What it buys:
 
 - It needs no `nvidia-smi` binary. In containers, the NVIDIA container runtime
   injecting the driver library is enough. The `-nvml` release artifacts and image tags (for example
-  `utkuozdemir/nvidia_gpu_exporter:1.5.0-nvml`) carry this backend and
+  `utkuozdemir/nvidia_gpu_exporter:latest-nvml`) carry this backend and
   default to it, so they need no flag at all; `--collect.backend=exec`
   switches them back. Note for semver-based image automation (e.g. a Flux
   `ImagePolicy`): the `-nvml` suffix parses as a semver pre-release, so

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -32,13 +32,13 @@ Follow the steps below:
 If you are on a Debian-based system (.deb), you can install the exporter with the following command:
 
 ```bash
-sudo dpkg -i nvidia-gpu-exporter_1.3.1_linux_amd64.deb
+sudo dpkg -i nvidia-gpu-exporter_<version>_linux_amd64.deb
 ```
 
 If you are on a Red Hat-based system (.rpm), you can install the exporter with the following command:
 
 ```bash
-sudo rpm -i nvidia-gpu-exporter_1.3.1_linux_amd64.rpm
+sudo rpm -i nvidia-gpu-exporter_<version>_linux_amd64.rpm
 ```
 
 **Note:** .rpm and .deb packages only support systems using systemd as init system.
@@ -53,7 +53,8 @@ sudo rpm -i nvidia-gpu-exporter_1.3.1_linux_amd64.rpm
 Sample steps for Linux 64-bit:
 
 ```bash
-VERSION=1.3.1
+# pick a release from https://github.com/utkuozdemir/nvidia_gpu_exporter/releases
+VERSION=X.Y.Z
 wget https://github.com/utkuozdemir/nvidia_gpu_exporter/releases/download/v${VERSION}/nvidia_gpu_exporter_${VERSION}_linux_x86_64.tar.gz
 tar -xvzf nvidia_gpu_exporter_${VERSION}_linux_x86_64.tar.gz
 mv nvidia_gpu_exporter /usr/bin
@@ -240,8 +241,12 @@ docker run -d \
   --gpus all \
   -e NVIDIA_DRIVER_CAPABILITIES=utility \
   -p 9835:9835 \
-  utkuozdemir/nvidia_gpu_exporter:1.7.0
+  utkuozdemir/nvidia_gpu_exporter:latest
 ```
+
+The examples on this page use `latest` so they can be pasted as-is. For
+anything you actually run, pin a release tag instead, so that picking up a new
+version stays a deliberate change.
 
 `--gpus all` turns on Docker's NVIDIA integration for the container and
 exposes all GPUs to it. `NVIDIA_DRIVER_CAPABILITIES=utility` declares that
@@ -251,7 +256,7 @@ documentation of intent and compatibility with older setups rather than a
 restriction.
 
 There is also an experimental `-nvml` image variant (for example
-`utkuozdemir/nvidia_gpu_exporter:1.7.0-nvml`) that reads the driver library
+`utkuozdemir/nvidia_gpu_exporter:latest-nvml`) that reads the driver library
 directly instead of running `nvidia-smi`. See [CONFIGURE.md](CONFIGURE.md).
 
 > [!TIP]
@@ -262,7 +267,7 @@ With docker-compose:
 ```yaml
 services:
   nvidia_gpu_exporter:
-    image: utkuozdemir/nvidia_gpu_exporter:1.7.0
+    image: utkuozdemir/nvidia_gpu_exporter:latest
     restart: unless-stopped
     environment:
       - NVIDIA_DRIVER_CAPABILITIES=utility
@@ -354,7 +359,7 @@ spec:
       runtimeClassName: nvidia # omit if the NVIDIA runtime is your cluster default
       containers:
         - name: exporter
-          image: utkuozdemir/nvidia_gpu_exporter:1.7.0
+          image: utkuozdemir/nvidia_gpu_exporter:latest # pin a release tag in production
           env:
             - name: NVIDIA_VISIBLE_DEVICES
               value: all

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,17 +1,25 @@
 # Metrics
 
-This is an example output of the returned metrics.
+This page describes the exported metrics and their semantics.
 
-Note that when `AUTO` query fields mode is used (it is the default),
-the exporter will discover new fields and expose them on a best-effort basis.
+Which metrics appear depends on your GPU, driver and operating system, since
+the query fields are auto-discovered by default (`AUTO`): the exporter picks
+up new fields and exposes them on a best-effort basis.
 
-The experimental NVML backend exports a superset of these metrics: every
-metric below is identical in both backends, except that the NVML backend
-reports `nvidia_smi_nvml_return_code` in place of
-`nvidia_smi_command_exit_code`. On top of that shared core it serves the
-NVML-only families described in the next section. The demo backend serves
-the same surface as the NVML backend, with synthetic data (see the demo
-mode section in [CONFIGURE.md](CONFIGURE.md)).
+For a complete, real example of what a scrape looks like, see the expected
+outputs the integration tests compare against, under
+[internal/integration/testdata](../internal/integration/testdata). There is
+one file per captured GPU, driver and load state, each the exact
+`nvidia_smi_*` output the exporter produces for it, so they stay current by
+construction. The exporter additionally exposes the standard Go runtime,
+process and `promhttp` metric families, which are not shown there.
+
+For every query field the NVML backend and the default backend both serve,
+the metric is identical, except that the NVML backend reports
+`nvidia_smi_nvml_return_code` in place of `nvidia_smi_command_exit_code`. On
+top of that shared core it serves the NVML-only families described in the
+next section. The demo backend approximates the NVML backend's surface with
+synthetic data (see the demo mode section in [CONFIGURE.md](CONFIGURE.md)).
 
 ## NVML-only metrics
 
@@ -142,289 +150,59 @@ performance-state number. `gpu_recovery_action` and `fabric_state` only appear
 when the hardware and driver report them (recovery action needs a recent
 driver), so their absence from an exporter's output is expected, not a bug.
 
+## What a scrape looks like
+
+An excerpt, from a single-GPU machine. Each per-GPU series is labeled by the
+GPU `uuid`, so it joins with `nvidia_smi_gpu_info`, which carries the
+identity labels:
+
 ```text
-# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
-# TYPE go_gc_duration_seconds summary
-go_gc_duration_seconds{quantile="0"} 0
-go_gc_duration_seconds{quantile="0.25"} 0
-go_gc_duration_seconds{quantile="0.5"} 0
-go_gc_duration_seconds{quantile="0.75"} 0
-go_gc_duration_seconds{quantile="1"} 0
-go_gc_duration_seconds_sum 0
-go_gc_duration_seconds_count 0
-# HELP go_goroutines Number of goroutines that currently exist.
-# TYPE go_goroutines gauge
-go_goroutines 7
-# HELP go_info Information about the Go environment.
-# TYPE go_info gauge
-go_info{version="go1.16.5"} 1
-# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
-# TYPE go_memstats_alloc_bytes gauge
-go_memstats_alloc_bytes 1.169224e+06
-# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
-# TYPE go_memstats_alloc_bytes_total counter
-go_memstats_alloc_bytes_total 1.169224e+06
-# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
-# TYPE go_memstats_buck_hash_sys_bytes gauge
-go_memstats_buck_hash_sys_bytes 1.44498e+06
-# HELP go_memstats_frees_total Total number of frees.
-# TYPE go_memstats_frees_total counter
-go_memstats_frees_total 273
-# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
-# TYPE go_memstats_gc_cpu_fraction gauge
-go_memstats_gc_cpu_fraction 0
-# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
-# TYPE go_memstats_gc_sys_bytes gauge
-go_memstats_gc_sys_bytes 4.110176e+06
-# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
-# TYPE go_memstats_heap_alloc_bytes gauge
-go_memstats_heap_alloc_bytes 1.169224e+06
-# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
-# TYPE go_memstats_heap_idle_bytes gauge
-go_memstats_heap_idle_bytes 6.397952e+07
-# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
-# TYPE go_memstats_heap_inuse_bytes gauge
-go_memstats_heap_inuse_bytes 2.637824e+06
-# HELP go_memstats_heap_objects Number of allocated objects.
-# TYPE go_memstats_heap_objects gauge
-go_memstats_heap_objects 6126
-# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
-# TYPE go_memstats_heap_released_bytes gauge
-go_memstats_heap_released_bytes 6.397952e+07
-# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
-# TYPE go_memstats_heap_sys_bytes gauge
-go_memstats_heap_sys_bytes 6.6617344e+07
-# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
-# TYPE go_memstats_last_gc_time_seconds gauge
-go_memstats_last_gc_time_seconds 0
-# HELP go_memstats_lookups_total Total number of pointer lookups.
-# TYPE go_memstats_lookups_total counter
-go_memstats_lookups_total 0
-# HELP go_memstats_mallocs_total Total number of mallocs.
-# TYPE go_memstats_mallocs_total counter
-go_memstats_mallocs_total 6399
-# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
-# TYPE go_memstats_mcache_inuse_bytes gauge
-go_memstats_mcache_inuse_bytes 9600
-# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
-# TYPE go_memstats_mcache_sys_bytes gauge
-go_memstats_mcache_sys_bytes 16384
-# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
-# TYPE go_memstats_mspan_inuse_bytes gauge
-go_memstats_mspan_inuse_bytes 46240
-# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
-# TYPE go_memstats_mspan_sys_bytes gauge
-go_memstats_mspan_sys_bytes 49152
-# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
-# TYPE go_memstats_next_gc_bytes gauge
-go_memstats_next_gc_bytes 4.473924e+06
-# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
-# TYPE go_memstats_other_sys_bytes gauge
-go_memstats_other_sys_bytes 885044
-# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
-# TYPE go_memstats_stack_inuse_bytes gauge
-go_memstats_stack_inuse_bytes 491520
-# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
-# TYPE go_memstats_stack_sys_bytes gauge
-go_memstats_stack_sys_bytes 491520
-# HELP go_memstats_sys_bytes Number of bytes obtained from system.
-# TYPE go_memstats_sys_bytes gauge
-go_memstats_sys_bytes 7.36146e+07
-# HELP go_threads Number of OS threads created.
-# TYPE go_threads gauge
-go_threads 8
-# HELP nvidia_gpu_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which nvidia_gpu_exporter was built.
-# TYPE nvidia_gpu_exporter_build_info gauge
-nvidia_gpu_exporter_build_info{branch="",goversion="go1.16.5",revision="",version=""} 1
-# HELP nvidia_smi_accounting_buffer_size accounting.buffer_size
-# TYPE nvidia_smi_accounting_buffer_size gauge
-nvidia_smi_accounting_buffer_size{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 4000
-# HELP nvidia_smi_accounting_mode accounting.mode
-# TYPE nvidia_smi_accounting_mode gauge
-nvidia_smi_accounting_mode{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_current_graphics_clock_hz clocks.current.graphics [MHz]
-# TYPE nvidia_smi_clocks_current_graphics_clock_hz gauge
-nvidia_smi_clocks_current_graphics_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 6e+06
-# HELP nvidia_smi_clocks_current_memory_clock_hz clocks.current.memory [MHz]
-# TYPE nvidia_smi_clocks_current_memory_clock_hz gauge
-nvidia_smi_clocks_current_memory_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1.6e+07
-# HELP nvidia_smi_clocks_current_sm_clock_hz clocks.current.sm [MHz]
-# TYPE nvidia_smi_clocks_current_sm_clock_hz gauge
-nvidia_smi_clocks_current_sm_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 6e+06
-# HELP nvidia_smi_clocks_current_video_clock_hz clocks.current.video [MHz]
-# TYPE nvidia_smi_clocks_current_video_clock_hz gauge
-nvidia_smi_clocks_current_video_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 5.4e+08
-# HELP nvidia_smi_clocks_max_graphics_clock_hz clocks.max.graphics [MHz]
-# TYPE nvidia_smi_clocks_max_graphics_clock_hz gauge
-nvidia_smi_clocks_max_graphics_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 2.28e+09
-# HELP nvidia_smi_clocks_max_memory_clock_hz clocks.max.memory [MHz]
-# TYPE nvidia_smi_clocks_max_memory_clock_hz gauge
-nvidia_smi_clocks_max_memory_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 7.751e+09
-# HELP nvidia_smi_clocks_max_sm_clock_hz clocks.max.sm [MHz]
-# TYPE nvidia_smi_clocks_max_sm_clock_hz gauge
-nvidia_smi_clocks_max_sm_clock_hz{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 2.28e+09
-# HELP nvidia_smi_clocks_event_reasons_active clocks_event_reasons.active
-# TYPE nvidia_smi_clocks_event_reasons_active gauge
-nvidia_smi_clocks_event_reasons_active{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 4
-# HELP nvidia_smi_clocks_event_reasons_applications_clocks_setting clocks_event_reasons.applications_clocks_setting
-# TYPE nvidia_smi_clocks_event_reasons_applications_clocks_setting gauge
-nvidia_smi_clocks_event_reasons_applications_clocks_setting{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_event_reasons_gpu_idle clocks_event_reasons.gpu_idle
-# TYPE nvidia_smi_clocks_event_reasons_gpu_idle gauge
-nvidia_smi_clocks_event_reasons_gpu_idle{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown clocks_event_reasons.hw_power_brake_slowdown
-# TYPE nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown gauge
-nvidia_smi_clocks_event_reasons_hw_power_brake_slowdown{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_event_reasons_hw_slowdown clocks_event_reasons.hw_slowdown
-# TYPE nvidia_smi_clocks_event_reasons_hw_slowdown gauge
-nvidia_smi_clocks_event_reasons_hw_slowdown{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_event_reasons_hw_thermal_slowdown clocks_event_reasons.hw_thermal_slowdown
-# TYPE nvidia_smi_clocks_event_reasons_hw_thermal_slowdown gauge
-nvidia_smi_clocks_event_reasons_hw_thermal_slowdown{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_event_reasons_supported clocks_event_reasons.supported
-# TYPE nvidia_smi_clocks_event_reasons_supported gauge
-nvidia_smi_clocks_event_reasons_supported{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 511
-# HELP nvidia_smi_clocks_event_reasons_sw_power_cap clocks_event_reasons.sw_power_cap
-# TYPE nvidia_smi_clocks_event_reasons_sw_power_cap gauge
-nvidia_smi_clocks_event_reasons_sw_power_cap{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1
-# HELP nvidia_smi_clocks_event_reasons_sw_thermal_slowdown clocks_event_reasons.sw_thermal_slowdown
-# TYPE nvidia_smi_clocks_event_reasons_sw_thermal_slowdown gauge
-nvidia_smi_clocks_event_reasons_sw_thermal_slowdown{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_clocks_event_reasons_sync_boost clocks_event_reasons.sync_boost
-# TYPE nvidia_smi_clocks_event_reasons_sync_boost gauge
-nvidia_smi_clocks_event_reasons_sync_boost{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_command_exit_code Exit code of the most recent nvidia-smi run
-# TYPE nvidia_smi_command_exit_code gauge
-nvidia_smi_command_exit_code 0
-# HELP nvidia_smi_compute_mode compute_mode
-# TYPE nvidia_smi_compute_mode gauge
-nvidia_smi_compute_mode{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_count count
-# TYPE nvidia_smi_count gauge
-nvidia_smi_count{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1
-# HELP nvidia_smi_display_active display_active
-# TYPE nvidia_smi_display_active gauge
-nvidia_smi_display_active{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_display_mode display_mode
-# TYPE nvidia_smi_display_mode gauge
-nvidia_smi_display_mode{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1
-# HELP nvidia_smi_driver_version driver_version
-# TYPE nvidia_smi_driver_version gauge
-nvidia_smi_driver_version{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 471.11
-# HELP nvidia_smi_encoder_stats_average_fps encoder.stats.averageFps
-# TYPE nvidia_smi_encoder_stats_average_fps gauge
-nvidia_smi_encoder_stats_average_fps{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_encoder_stats_average_latency encoder.stats.averageLatency
-# TYPE nvidia_smi_encoder_stats_average_latency gauge
-nvidia_smi_encoder_stats_average_latency{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_encoder_stats_session_count encoder.stats.sessionCount
-# TYPE nvidia_smi_encoder_stats_session_count gauge
-nvidia_smi_encoder_stats_session_count{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_enforced_power_limit_watts enforced.power.limit [W]
-# TYPE nvidia_smi_enforced_power_limit_watts gauge
-nvidia_smi_enforced_power_limit_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 250
-# HELP nvidia_smi_failed_scrapes_total Number of failed collections
-# TYPE nvidia_smi_failed_scrapes_total counter
-nvidia_smi_failed_scrapes_total 0
-# HELP nvidia_smi_fan_speed_ratio fan.speed [%]
-# TYPE nvidia_smi_fan_speed_ratio gauge
-nvidia_smi_fan_speed_ratio{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0.38
 # HELP nvidia_smi_gpu_info A metric with a constant '1' value labeled by gpu uuid, name, driver_model_current, driver_model_pending, vbios_version, driver_version, pci_bus_id, serial, compute_cap, pci_sub_device_id, index, cuda_version.
 # TYPE nvidia_smi_gpu_info gauge
-nvidia_smi_gpu_info{cuda_version="11.4",driver_model_current="WDDM",driver_model_pending="WDDM",driver_version="471.11",name="NVIDIA GeForce RTX 2080 SUPER",uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa",vbios_version="90.04.7a.40.73",pci_bus_id="00000000:71:00.0",serial="[N/A]",compute_cap="7.5",pci_sub_device_id="0x40051458",index="0"} 1
-# HELP nvidia_smi_index index
-# TYPE nvidia_smi_index gauge
-nvidia_smi_index{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_inforom_oem inforom.oem
-# TYPE nvidia_smi_inforom_oem gauge
-nvidia_smi_inforom_oem{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1.1
-# HELP nvidia_smi_last_collect_duration_seconds Duration of the most recent collection
-# TYPE nvidia_smi_last_collect_duration_seconds gauge
-nvidia_smi_last_collect_duration_seconds 0.055694458
+nvidia_smi_gpu_info{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa",name="NVIDIA GeForce RTX 2080 SUPER",driver_version="471.11",cuda_version="11.4",pci_bus_id="00000000:71:00.0",index="0",...} 1
+# HELP nvidia_smi_utilization_gpu_ratio utilization.gpu [%]
+# TYPE nvidia_smi_utilization_gpu_ratio gauge
+nvidia_smi_utilization_gpu_ratio{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0.42
+# HELP nvidia_smi_memory_used_bytes memory.used [MiB]
+# TYPE nvidia_smi_memory_used_bytes gauge
+nvidia_smi_memory_used_bytes{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 7.06740224e+08
+# HELP nvidia_smi_power_draw_watts power.draw [W]
+# TYPE nvidia_smi_power_draw_watts gauge
+nvidia_smi_power_draw_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 28.07
+# HELP nvidia_smi_temperature_gpu temperature.gpu
+# TYPE nvidia_smi_temperature_gpu gauge
+nvidia_smi_temperature_gpu{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 34
+```
+
+Alongside the per-GPU series, the exporter reports its own collection health.
+These carry no `uuid` label, and they are what alerting on the exporter
+itself should use:
+
+```text
 # HELP nvidia_smi_last_collect_success Whether the most recent collection succeeded (1) or not (0)
 # TYPE nvidia_smi_last_collect_success gauge
 nvidia_smi_last_collect_success 1
 # HELP nvidia_smi_last_collect_success_timestamp_seconds Unix timestamp of the most recent successful collection
 # TYPE nvidia_smi_last_collect_success_timestamp_seconds gauge
 nvidia_smi_last_collect_success_timestamp_seconds 1.751475457e+09
-# HELP nvidia_smi_memory_free_bytes memory.free [MiB]
-# TYPE nvidia_smi_memory_free_bytes gauge
-nvidia_smi_memory_free_bytes{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 7.883194368e+09
-# HELP nvidia_smi_memory_total_bytes memory.total [MiB]
-# TYPE nvidia_smi_memory_total_bytes gauge
-nvidia_smi_memory_total_bytes{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 8.589934592e+09
-# HELP nvidia_smi_memory_used_bytes memory.used [MiB]
-# TYPE nvidia_smi_memory_used_bytes gauge
-nvidia_smi_memory_used_bytes{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 7.06740224e+08
-# HELP nvidia_smi_name name
-# TYPE nvidia_smi_name gauge
-nvidia_smi_name{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 2080
-# HELP nvidia_smi_pci_bus pci.bus
-# TYPE nvidia_smi_pci_bus gauge
-nvidia_smi_pci_bus{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 12
-# HELP nvidia_smi_pci_device pci.device
-# TYPE nvidia_smi_pci_device gauge
-nvidia_smi_pci_device{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_pci_device_id pci.device_id
-# TYPE nvidia_smi_pci_device_id gauge
-nvidia_smi_pci_device_id{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 7809
-# HELP nvidia_smi_pci_domain pci.domain
-# TYPE nvidia_smi_pci_domain gauge
-nvidia_smi_pci_domain{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_pci_sub_device_id pci.sub_device_id
-# TYPE nvidia_smi_pci_sub_device_id gauge
-nvidia_smi_pci_sub_device_id{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1.074074712e+09
-# HELP nvidia_smi_pcie_link_gen_current pcie.link.gen.current
-# TYPE nvidia_smi_pcie_link_gen_current gauge
-nvidia_smi_pcie_link_gen_current{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 3
-# HELP nvidia_smi_pcie_link_gen_max pcie.link.gen.max
-# TYPE nvidia_smi_pcie_link_gen_max gauge
-nvidia_smi_pcie_link_gen_max{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 3
-# HELP nvidia_smi_pcie_link_width_current pcie.link.width.current
-# TYPE nvidia_smi_pcie_link_width_current gauge
-nvidia_smi_pcie_link_width_current{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 16
-# HELP nvidia_smi_pcie_link_width_max pcie.link.width.max
-# TYPE nvidia_smi_pcie_link_width_max gauge
-nvidia_smi_pcie_link_width_max{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 16
-# HELP nvidia_smi_power_default_limit_watts power.default_limit [W]
-# TYPE nvidia_smi_power_default_limit_watts gauge
-nvidia_smi_power_default_limit_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 250
-# HELP nvidia_smi_power_draw_watts power.draw [W]
-# TYPE nvidia_smi_power_draw_watts gauge
-nvidia_smi_power_draw_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 28.07
-# HELP nvidia_smi_power_limit_watts power.limit [W]
-# TYPE nvidia_smi_power_limit_watts gauge
-nvidia_smi_power_limit_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 250
-# HELP nvidia_smi_power_management power.management
-# TYPE nvidia_smi_power_management gauge
-nvidia_smi_power_management{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 1
-# HELP nvidia_smi_power_max_limit_watts power.max_limit [W]
-# TYPE nvidia_smi_power_max_limit_watts gauge
-nvidia_smi_power_max_limit_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 350
-# HELP nvidia_smi_power_min_limit_watts power.min_limit [W]
-# TYPE nvidia_smi_power_min_limit_watts gauge
-nvidia_smi_power_min_limit_watts{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 105
-# HELP nvidia_smi_pstate pstate
-# TYPE nvidia_smi_pstate gauge
-nvidia_smi_pstate{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 8
-# HELP nvidia_smi_temperature_gpu temperature.gpu
-# TYPE nvidia_smi_temperature_gpu gauge
-nvidia_smi_temperature_gpu{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 34
-# HELP nvidia_smi_utilization_gpu_ratio utilization.gpu [%]
-# TYPE nvidia_smi_utilization_gpu_ratio gauge
-nvidia_smi_utilization_gpu_ratio{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP nvidia_smi_utilization_memory_ratio utilization.memory [%]
-# TYPE nvidia_smi_utilization_memory_ratio gauge
-nvidia_smi_utilization_memory_ratio{uuid="df6e7a7c-7314-46f8-abc4-b88b36dcf3aa"} 0
-# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
-# TYPE promhttp_metric_handler_requests_in_flight gauge
-promhttp_metric_handler_requests_in_flight 1
-# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
-# TYPE promhttp_metric_handler_requests_total counter
-promhttp_metric_handler_requests_total{code="200"} 0
-promhttp_metric_handler_requests_total{code="500"} 0
-promhttp_metric_handler_requests_total{code="503"} 0
+# HELP nvidia_smi_last_collect_duration_seconds Duration of the most recent collection
+# TYPE nvidia_smi_last_collect_duration_seconds gauge
+nvidia_smi_last_collect_duration_seconds 0.055694458
+# HELP nvidia_smi_failed_scrapes_total Number of failed collections
+# TYPE nvidia_smi_failed_scrapes_total counter
+nvidia_smi_failed_scrapes_total 0
+# HELP nvidia_smi_command_exit_code Exit code of the most recent nvidia-smi run
+# TYPE nvidia_smi_command_exit_code gauge
+nvidia_smi_command_exit_code 0
 ```
+
+Note that `nvidia_smi_failed_scrapes_total` counts failed *collections*, not
+failed scrapes. The two came apart when background collection was added; the
+name is kept for compatibility.
+
+The full set is much larger and varies by hardware. See
+[internal/integration/testdata](../internal/integration/testdata) for
+complete outputs across every captured GPU.
 
 ## Per-process metrics (opt-in)
 

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,62 @@
+# Grafana dashboards
+
+Two dashboards live here, and these files are the source of truth for both:
+
+- `dashboard.json`: the per-GPU detail dashboard, published as
+  [grafana.com 14574](https://grafana.com/grafana/dashboards/14574).
+- `dashboard-overview.json`: the multi-GPU overview, published as
+  [grafana.com 25547](https://grafana.com/grafana/dashboards/25547), which
+  drills down into the detail dashboard.
+
+Each carries the `nvidia_gpu_exporter` tag and a "Related dashboards" link, so
+they find each other in Grafana once both are installed.
+
+The Helm chart ships copies under `charts/nvidia-gpu-exporter/dashboards/`, and CI
+compares them byte for byte, so a change here must be mirrored there in the same
+commit. Publishing a new revision to grafana.com is a manual step, separate from
+the release pipeline.
+
+`task lint:dashboard` runs
+[grafana/dashboard-linter](https://github.com/grafana/dashboard-linter) in strict
+mode. Rule exclusions live in `.lint`, each with a written reason; the bar for
+adding one is that the rule conflicts with the dashboards' long-published design.
+
+The dashboards are normally authored in the Grafana UI and exported back into
+these files, but editing the JSON directly is fine too.
+
+## Query and panel conventions
+
+Each of these came out of a panel that looked fine and was wrong, so treat them
+as correctness rules rather than style. Most fail silently when violated: the
+panel still renders, it just shows the wrong thing or nothing at all. Verify any
+query change against the local dev stack (`hack/compose`), including its empty
+and failed-collection cases, before committing.
+
+- **Enrichment joins for legends** take the form
+  `(expr) * on(uuid) group_left(index, name) nvidia_smi_gpu_info{...}`.
+  The parentheses are load-bearing, because `*` binds tighter than `+` and `or`.
+- **Table targets need an absence sentinel.** Every table target ORs an arm of
+  the form `... nvidia_smi_gpu_info * 0 - 1`, and `-1` maps to an n/a-style cell.
+  Without it, a totally absent series makes the join drop whole columns. The
+  sentinel arm must be aggregated down to the same labels as the joined left
+  side, otherwise it doubles the series.
+- **MIG joins must tolerate heterogeneous compute instances.** A GPU instance
+  hosting several compute instances hard-errors any join carrying the profile
+  label. Strip the compute-instance prefix with `label_replace` before
+  aggregating.
+- **Panels reading NVML-only families need an `unless`-guarded uuid-only arm**,
+  or they go blank instead of degrading when a collection fails.
+- **State timelines** use fixed/`text` color mode with no thresholds key; the
+  value mappings carry the band colors.
+- **Multi-GPU timeseries** use `palette-classic`, because dynamically-named
+  series cannot take a custom palette.
+
+## Compatibility
+
+The dashboards have a large installed base, which constrains two things:
+
+- **Metric names and labels are a frozen contract.** See `AGENTS.md` for the
+  full rules; in short, a renamed series silently breaks strangers' dashboards.
+- **The instance-selector template variable is not named `instance`,** and cannot
+  be renamed. Every bookmarked URL carries the current name. The dashboard-linter
+  rule that wants `instance` is excluded in `.lint` rather than obeyed.

--- a/docs/grafana/dashboard-overview.json
+++ b/docs/grafana/dashboard-overview.json
@@ -50,6 +50,7 @@
   "description": "Compare all GPUs of one node side by side: current state, utilization, thermals, throttling and health per GPU. Companion to the Nvidia GPU Metrics dashboard (single-GPU detail, click a GPU in the table to drill down). Shows physical GPUs as reported by nvidia-smi, MIG instances are not broken out: rows are the parent GPUs, whose utilization is not reported in MIG mode and shows n/a. Based on the prometheus metrics from github.com/utkuozdemir/nvidia_gpu_exporter",
   "editable": false,
   "fiscalYearStartMonth": 0,
+  "gnetId": 25547,
   "graphTooltip": 1,
   "id": null,
   "links": [

--- a/hack/compose/README.md
+++ b/hack/compose/README.md
@@ -160,7 +160,8 @@ the full reference is the demo mode section in `docs/CONFIGURE.md`.
 
 The dashboards are authored in the Grafana UI and exported to
 `docs/grafana/dashboard.json` (single-GPU detail, grafana.com 14574) and
-`docs/grafana/dashboard-overview.json` (multi-GPU comparison). Those files
+`docs/grafana/dashboard-overview.json` (multi-GPU comparison, grafana.com
+25547). Those files
 select their data source through a template variable; `render-dashboard.sh`
 copies them into the provisioning directory, flipping `editable` on and
 preselecting the NVML data source (the published artifacts themselves stay

--- a/install/systemd/nvidia_gpu_exporter.service
+++ b/install/systemd/nvidia_gpu_exporter.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Nvidia GPU Exporter
+Wants=network-online.target
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
Three commits.

The first adds AGENTS.md, a guide for humans and agents working in this repository, covering the three collection backends and the invariants between them, the capture corpus and how it drives the tests, the compatibility contract around exported metric names, and the chart and release pipeline. The Claude, Gemini and Copilot instruction files point at it. It also refreshes the documentation: the overview dashboard is published now, so the links point at it instead of its raw file; the dashboard query conventions move next to the dashboards; the metrics reference drops a full scrape recorded years ago in favour of its prose, short excerpts and a pointer at the integration test expectations; and the installation examples stop naming a concrete release. Describing the experimental backend as a superset of the default one is corrected, since its field vocabulary is a compiled catalog that defers fields with no verified mapping.

The second makes the systemd unit request the network target it already ordered itself after, so the ordering actually takes effect.

The third pins the scoop manifest to the static build, like every other publisher, so the flavour that needs cgo cannot reach it.

Worth rebasing or fast-forwarding rather than squashing, so the two fixes keep their own type in the generated changelog.