### PR TITLE
fix: stop a missing driver entry point from killing the exporter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,39 +44,17 @@ jobs:
         uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
-      - name: Check go.mod tidiness
-        run: go mod tidy --diff
-      - name: Run linters
-        uses: golangci/golangci-lint-action@v9.3.0
-        with:
-          # renovate: depName=golangci/golangci-lint datasource=github-releases
-          version: v2.12.2
-          args: --timeout=3m0s
-          install-mode: goinstall
       - name: Set up Task
         uses: arduino/setup-task@v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install asset linters
-        run: |
-          # renovate: depName=markdownlint-cli datasource=npm
-          npm install --global markdownlint-cli@0.49.1
-          # renovate: depName=mvdan.cc/sh/v3 datasource=go
-          go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
-          # "go install" does not work on the dashboard-linter module (it has
-          # replace directives), so install the release binary. The version is
-          # a variable so renovate updates every occurrence in the URL at once.
-          # renovate: depName=grafana/dashboard-linter datasource=github-releases
-          DASHBOARD_LINTER_VERSION=0.2.0
-          curl -sSfL "https://github.com/grafana/dashboard-linter/releases/download/v${DASHBOARD_LINTER_VERSION}/dashboard-linter_${DASHBOARD_LINTER_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$(go env GOPATH)/bin" dashboard-linter
-      - name: Lint markdown and shell scripts
-        run: task lint:assets
-      - name: Lint the Grafana dashboard
-        run: task lint:dashboard
+      # every linter, at the versions pinned in hack/dev.Dockerfile, in the same
+      # containers a developer gets locally. Nothing is installed here, so CI
+      # and a workstation cannot drift apart.
+      - name: Lint
+        run: task lint
       - name: Run tests
         run: go test -v -race -coverpkg=./... -coverprofile ./coverage.out -covermode=atomic -timeout 20m ./...
-      - name: Compile the GPU-tagged parity test # never runs in CI, must not rot between GPU box sessions
-        run: go test -run '^$' -tags gpu ./internal/integration/
       - name: Print coverage results
         run: go tool cover -func ./coverage.out
       - name: Send coverage
@@ -119,6 +97,7 @@ jobs:
         run: hack/alerts/verify.sh
       - name: Check that the chart README is current
         run: |
+          # renovate: depName=jnorwood/helm-docs datasource=docker
           docker run --rm -v "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.14.2
           git diff --exit-code charts/
       - name: Create kind cluster

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -37,7 +37,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/\\.github\\/workflows\\/.*/",
-        "/Taskfile\\.yml/"
+        "/Taskfile\\.yml/",
+        "/hack\\/dev\\.Dockerfile/"
       ],
       "matchStrings": [
         "# renovate: depName=(?<depName>[^\\s]+)( datasource=(?<datasource>[^\\s]+))?( registryUrl=(?<registryUrl>\\S+))?\\n[^\\n]*?(?<currentValue>v?\\d+\\.\\d+\\.\\d+(-[\\S]+)?)"
@@ -49,7 +50,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/go.mod/",
-        "/\\.github\\/workflows\\/.*/"
+        "/\\.github\\/workflows\\/.*/",
+        "/hack\\/dev\\.Dockerfile/"
       ],
       "matchStrings": [
         "(#|\\/\\/) renovate: go\\n[^\\n]*?(?<currentValue>v?\\d+\\.\\d+(\\.\\d+(-[\\S]+)?)?)"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,53 +1,113 @@
 version: "3"
 
+# Every check runs in the toolchain image built from hack/dev.Dockerfile, one
+# stage per check, so the host needs only docker and task and CI runs the exact
+# same tool versions. It is also the only way the checks see the whole tree:
+# much of internal/nvmlnative is behind a `linux && cgo` build tag, which a host
+# toolchain on macOS excludes from the build entirely, so a host linter reports
+# success without having read those files at all.
+#
+# The Go version comes from go.mod, so the toolchain cannot drift from what the
+# module declares.
+
 tasks:
   fmt:
-    desc: format code
+    desc: format code and scripts
     cmds:
-      - go mod tidy
-      - go fix ./...
-      - golangci-lint run --fix ./...
-      - golangci-lint fmt ./...
-      - git ls-files '*.sh' | xargs shfmt -w -i 2 -ci -sr
+      # the formatters write in place, so the working tree is bind-mounted
+      # rather than exported from a stage: the stage has no sources of its own.
+      # The container runs as the invoking user so nothing comes back
+      # root-owned, and a named volume keeps the Go and linter caches between
+      # runs instead of recompiling the world every time.
+      - >-
+        docker buildx build -f hack/dev.Dockerfile
+        --build-arg GO_VERSION="$(sed -n 's/^go //p' go.mod)"
+        --target fmt --load --tag nvidia-gpu-exporter-tools:local .
+      - "{{.FMT}} sh -c 'go mod tidy && go fix ./...'"
+      # unfixable findings are reported by lint, not by fmt
+      - "{{.FMT}} golangci-lint run --fix --issues-exit-code 0 ./..."
+      - "{{.FMT}} golangci-lint fmt ./..."
+      # tracked files only: a bare find would also rewrite scratch directories
+      # and any other worktree checked out under this one
+      - git ls-files '*.sh' | xargs {{.FMT}} shfmt -w -i 2 -ci -sr
+    vars:
+      FMT: >-
+        docker run --rm -u "$(id -u):$(id -g)"
+        -e GOFLAGS=-mod=mod -e HOME=/tmp
+        -e GOCACHE=/tmp/go-build -e GOMODCACHE=/tmp/go-mod
+        -e GOLANGCI_LINT_CACHE=/tmp/golangci-lint
+        -v nvidia-gpu-exporter-fmt-cache:/tmp
+        -v "$PWD":/src -w /src nvidia-gpu-exporter-tools:local
 
   lint:
-    desc: lint everything (code, docs, scripts, dashboard, release config)
+    desc: lint everything (code, docs, scripts, dashboards, release config)
     cmds:
       - task: lint:go
       - task: lint:assets
       - task: lint:dashboard
-      - goreleaser check
+      - task: lint:release
 
   lint:go:
-    desc: lint go code and module tidiness (what CI covers via golangci)
+    desc: lint go code and module tidiness
     cmds:
-      - go mod tidy --diff
-      - golangci-lint run ./...
+      - task: stage
+        vars: {TARGET: lint-go-mod-tidy}
+      - task: stage
+        vars: {TARGET: lint-golangci-lint}
+      # never runs without a GPU, but it must keep compiling
+      - task: stage
+        vars: {TARGET: lint-gpu-tagged-test}
 
-  # runs in CI as its own step; lints tracked files only, so local scratch
-  # space and generated output stay out of scope, and dot-directories like
-  # .github are covered (filesystem globs would skip them)
   lint:assets:
     desc: lint markdown and shell scripts
     cmds:
-      - git ls-files '*.md' | xargs markdownlint
-      - git ls-files '*.sh' | xargs shellcheck
-      - git ls-files '*.sh' | xargs shfmt -d -i 2 -ci -sr
+      - task: stage
+        vars: {TARGET: lint-markdown}
+      - task: stage
+        vars: {TARGET: lint-shell}
 
-  # needs the dashboard-linter binary from the grafana/dashboard-linter
-  # releases page ("go install" does not work on it, the module carries
-  # replace directives). Rule exclusions live in docs/grafana/.lint.
   lint:dashboard:
     desc: lint the Grafana dashboards against grafana.com best practices
     cmds:
-      - dashboard-linter lint --strict docs/grafana/dashboard.json
-      - dashboard-linter lint --strict docs/grafana/dashboard-overview.json
+      - task: stage
+        vars: {TARGET: lint-dashboard}
+
+  lint:release:
+    desc: validate the release configuration
+    cmds:
+      - task: stage
+        vars: {TARGET: lint-goreleaser}
+
+  test:
+    desc: run the unit and integration tests
+    cmds:
+      - task: stage
+        vars: {TARGET: unit-tests}
+
+  chart:docs:
+    desc: regenerate the chart README from the values.yaml comments
+    cmds:
+      # renovate: depName=jnorwood/helm-docs datasource=docker
+      - docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/helm-docs jnorwood/helm-docs:v1.14.2
+
+  # builds one check stage; every check goes through here so the build
+  # invocation exists in exactly one place
+  stage:
+    internal: true
+    cmds:
+      - >-
+        docker buildx build -f hack/dev.Dockerfile
+        --build-arg GO_VERSION="$(sed -n 's/^go //p' go.mod)"
+        --target {{.TARGET}} .
 
   release:
     desc: release
     vars:
       NEXT:
-        sh: svu next
+        # renovate: depName=caarlos0/svu datasource=docker
+        # run from the primary checkout: a linked worktree's .git points at a
+        # common directory outside this mount
+        sh: docker run --rm -v "$PWD":/src -w /src caarlos0/svu:3.4.1 next
     cmds:
       - git tag -a {{.NEXT}} -m "{{.NEXT}}"
       - echo {{.NEXT}}

--- a/hack/dev.Dockerfile
+++ b/hack/dev.Dockerfile
@@ -1,0 +1,139 @@
+# syntax=docker/dockerfile:1.19
+#
+# The development and CI toolchain, one stage per check.
+#
+# Every tool this repository lints, formats or tests with lives here, pinned, so
+# a fresh clone needs only docker and task on the host and CI runs the exact
+# same versions instead of installing its own. The Taskfile drives the stages
+# through `docker buildx build --target`.
+#
+# Two properties matter and are easy to lose:
+#
+#   - Cache shape. Tools arrive as released binaries rather than compiled from
+#     source, so no check waits on a toolchain build. The module graph is
+#     downloaded in a stage that does not sit downstream of the tools, so
+#     bumping a linter does not re-download it. The Go build and module caches
+#     are shared BuildKit caches keyed per repository.
+#   - Linux. Large parts of internal/nvmlnative are behind a `linux && cgo`
+#     build tag, so a host toolchain on macOS excludes them from the build
+#     entirely and lints nothing at all. Running the checks here is the only way
+#     the code CI sees is the code checked locally.
+#
+# GO_VERSION has no default on purpose: the Taskfile passes the version go.mod
+# declares, so the toolchain cannot drift from the module.
+
+ARG GO_VERSION
+# renovate: depName=golangci/golangci-lint datasource=github-releases
+ARG GOLANGCI_LINT_VERSION=2.12.2
+# renovate: depName=mvdan/sh datasource=github-releases
+ARG SHFMT_VERSION=3.13.1
+# renovate: depName=grafana/dashboard-linter datasource=github-releases
+ARG DASHBOARD_LINTER_VERSION=0.2.0
+# renovate: depName=markdownlint-cli datasource=npm
+ARG MARKDOWNLINT_VERSION=0.49.1
+# renovate: depName=node datasource=docker
+ARG NODE_VERSION=24.18.0
+# renovate: depName=koalaman/shellcheck datasource=docker
+ARG SHELLCHECK_VERSION=v0.11.0
+# renovate: depName=goreleaser/goreleaser datasource=docker
+ARG GORELEASER_VERSION=v2.17.0
+
+FROM koalaman/shellcheck:${SHELLCHECK_VERSION} AS shellcheck-bin
+FROM goreleaser/goreleaser:${GORELEASER_VERSION} AS goreleaser-bin
+
+# released binaries, fetched rather than compiled, so no check waits on a
+# toolchain build. The downloads are a linear chain: bumping an earlier tool
+# re-fetches the later ones, which is a few seconds and not worth a stage per
+# tool.
+FROM alpine:3 AS tools
+RUN apk add --no-cache curl tar git
+ARG TARGETARCH
+ARG GOLANGCI_LINT_VERSION
+RUN curl -sSfL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=1 "golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${TARGETARCH}/golangci-lint"
+ARG SHFMT_VERSION
+RUN curl -sSfL -o /usr/local/bin/shfmt "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${TARGETARCH}" \
+    && chmod +x /usr/local/bin/shfmt
+ARG DASHBOARD_LINTER_VERSION
+RUN curl -sSfL "https://github.com/grafana/dashboard-linter/releases/download/v${DASHBOARD_LINTER_VERSION}/dashboard-linter_${DASHBOARD_LINTER_VERSION}_linux_${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin dashboard-linter
+COPY --from=shellcheck-bin /bin/shellcheck /usr/local/bin/shellcheck
+COPY --from=goreleaser-bin /usr/bin/goreleaser /usr/local/bin/goreleaser
+
+# the Go toolchain and the module graph. Deliberately NOT downstream of `tools`:
+# a linter bump must not re-download the modules.
+FROM golang:${GO_VERSION} AS deps
+ENV CGO_ENABLED=1
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build,id=nvidia_gpu_exporter/go-build \
+    --mount=type=cache,target=/go/pkg,id=nvidia_gpu_exporter/go-pkg \
+    go mod download
+
+# only the Go tree: a docs, dashboard or packaging edit must not rerun the Go
+# checks
+FROM deps AS base
+COPY cmd ./cmd
+COPY internal ./internal
+
+FROM base AS lint-golangci-lint
+COPY .golangci.yml ./
+COPY --from=tools /usr/local/bin/golangci-lint /usr/local/bin/
+RUN --mount=type=cache,target=/root/.cache/go-build,id=nvidia_gpu_exporter/go-build \
+    --mount=type=cache,target=/go/pkg,id=nvidia_gpu_exporter/go-pkg \
+    --mount=type=cache,target=/root/.cache/golangci-lint,id=nvidia_gpu_exporter/golangci-lint \
+    golangci-lint run --timeout=5m ./...
+
+FROM base AS lint-go-mod-tidy
+RUN --mount=type=cache,target=/root/.cache/go-build,id=nvidia_gpu_exporter/go-build \
+    --mount=type=cache,target=/go/pkg,id=nvidia_gpu_exporter/go-pkg \
+    go mod tidy --diff
+
+FROM base AS unit-tests
+RUN --mount=type=cache,target=/root/.cache/go-build,id=nvidia_gpu_exporter/go-build \
+    --mount=type=cache,target=/go/pkg,id=nvidia_gpu_exporter/go-pkg \
+    go test -race -coverpkg=./... -coverprofile=/tmp/coverage.out -covermode=atomic -timeout 20m ./...
+
+# the GPU-tagged parity test never runs without hardware, but it must keep
+# compiling so it cannot rot between the rare sessions where a GPU exists
+FROM base AS lint-gpu-tagged-test
+RUN --mount=type=cache,target=/root/.cache/go-build,id=nvidia_gpu_exporter/go-build \
+    --mount=type=cache,target=/go/pkg,id=nvidia_gpu_exporter/go-pkg \
+    go test -run '^$' -tags gpu ./internal/integration/
+
+FROM node:${NODE_VERSION}-alpine AS lint-markdown
+ARG MARKDOWNLINT_VERSION
+RUN npm install --global markdownlint-cli@${MARKDOWNLINT_VERSION}
+WORKDIR /src
+COPY . .
+# --dot: without it the tracked markdown under .github/ is skipped entirely
+RUN markdownlint --dot .
+
+FROM tools AS lint-shell
+WORKDIR /src
+COPY . .
+RUN find . -name '*.sh' -print0 | xargs -0 shellcheck
+RUN find . -name '*.sh' -print0 | xargs -0 shfmt -d -i 2 -ci -sr
+
+# only the dashboards, so unrelated edits leave this cached
+FROM tools AS lint-dashboard
+WORKDIR /src
+COPY docs/grafana ./docs/grafana
+RUN dashboard-linter lint --strict docs/grafana/dashboard.json
+RUN dashboard-linter lint --strict docs/grafana/dashboard-overview.json
+
+# goreleaser refuses to run outside a repository with a remote, but it only
+# reads the config. A synthetic repository satisfies it, which keeps .git out of
+# the build context entirely: .git changes on every commit and would otherwise
+# invalidate every stage that copies the tree.
+FROM tools AS lint-goreleaser
+WORKDIR /src
+COPY .goreleaser.yml ./
+RUN git init -q . \
+    && git remote add origin https://github.com/utkuozdemir/nvidia_gpu_exporter.git \
+    && goreleaser check
+
+# the formatters run against a bind-mounted working tree rather than a stage
+# export, so this stage carries the tools and the Go toolchain but no sources
+FROM deps AS fmt
+COPY --from=tools /usr/local/bin/golangci-lint /usr/local/bin/shfmt /usr/local/bin/

--- a/hack/dev.Dockerfile.dockerignore
+++ b/hack/dev.Dockerfile.dockerignore
@@ -1,0 +1,26 @@
+# Context rules for hack/dev.Dockerfile only. BuildKit prefers a
+# <dockerfile>.dockerignore over the root one, so the release images keep their
+# own, much narrower context untouched.
+#
+# The difference that matters: the root .dockerignore drops *.md, because the
+# release images only ever copy a binary. The checks here lint the markdown, so
+# it has to stay.
+#
+# .git is excluded: it changes on every commit and would invalidate every stage
+# that copies the tree. The goreleaser check synthesizes a repository instead.
+.git
+dist
+_work
+hack/compose/grafana/data
+hack/compose/grafana/dashboards
+hack/compose/prometheus/data
+hack/alerts/rendered
+# local, uncommitted state: gitignored, so it was never lint input before
+*.local.md
+*.override.md
+.idea
+.vscode
+.claude
+.DS_Store
+*.patch
+*.diff

--- a/internal/nvmlnative/availability_nvml.go
+++ b/internal/nvmlnative/availability_nvml.go
@@ -4,6 +4,7 @@ package nvmlnative
 
 import (
 	"log/slog"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -58,13 +59,7 @@ func (a *availability) has(symbol string) bool {
 // selects at load time: it probes the newer spellings and falls back to the
 // classic one, so the call is safe as long as any of them resolves.
 func (a *availability) hasAny(symbols ...string) bool {
-	for _, symbol := range symbols {
-		if a.has(symbol) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(symbols, a.has)
 }
 
 // hasAll reports whether every one of the given entry points is exported. It

--- a/internal/nvmlnative/availability_nvml.go
+++ b/internal/nvmlnative/availability_nvml.go
@@ -1,0 +1,132 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import (
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// availability is an immutable snapshot of which driver-library exports were
+// present the last time NVML was initialized. It is replaced wholesale on
+// re-initialization rather than mutated, so readers outside the collection
+// lock (the XID watcher) always observe a coherent set.
+//
+// The zero value reports everything as absent, which is the safe direction: a
+// backend that somehow reached collection without probing serves no series
+// instead of crashing.
+type availability struct {
+	present map[string]bool
+	missing []string
+}
+
+// probeSymbols resolves every guarded export once. lookup reports nil when the
+// driver library exports the name. It must be called after NVML has loaded,
+// since the lookup is refused while the library is closed.
+func probeSymbols(lookup func(string) error, symbols []string) *availability {
+	avail := &availability{present: make(map[string]bool, len(symbols))}
+
+	for _, symbol := range symbols {
+		ok := lookup(symbol) == nil
+		avail.present[symbol] = ok
+
+		if !ok {
+			avail.missing = append(avail.missing, symbol)
+		}
+	}
+
+	sort.Strings(avail.missing)
+
+	return avail
+}
+
+// has reports whether the driver library exports the given entry point.
+func (a *availability) has(symbol string) bool {
+	if a == nil {
+		return false
+	}
+
+	return a.present[symbol]
+}
+
+// hasAny reports whether the driver library exports at least one of the given
+// entry points. It exists for the handful of calls whose version go-nvml
+// selects at load time: it probes the newer spellings and falls back to the
+// classic one, so the call is safe as long as any of them resolves.
+func (a *availability) hasAny(symbols ...string) bool {
+	for _, symbol := range symbols {
+		if a.has(symbol) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasAll reports whether every one of the given entry points is exported. It
+// exists for families that acquire and release a resource through separate
+// calls, where a partially present set is worse than an absent one.
+func (a *availability) hasAll(symbols ...string) bool {
+	for _, symbol := range symbols {
+		if !a.has(symbol) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// log reports the exports this driver does not provide, once per NVML
+// generation. This is the diagnostic that turns "some series are missing" into
+// an answerable bug report, so it names every symbol rather than a count.
+func (a *availability) log(logger *slog.Logger) {
+	if a == nil || len(a.missing) == 0 {
+		return
+	}
+
+	logger.Info("driver library does not export some entry points, "+
+		"the metrics they serve stay absent",
+		"count", len(a.missing), "symbols", strings.Join(a.missing, ","))
+}
+
+// retString describes an NVML status without asking the driver. go-nvml's
+// Return.String routes through the library's own nvmlErrorString once it is
+// loaded, which puts a driver call on exactly the paths that run when the
+// driver is already misbehaving, and makes error reporting itself capable of
+// killing the process. The numeric status is enough for a log line.
+func retString(ret nvml.Return) string {
+	if name, ok := returnNames[ret]; ok {
+		return name
+	}
+
+	return "NVML status " + strconv.Itoa(int(ret))
+}
+
+//nolint:gochecknoglobals // lookup table for the statuses this backend acts on
+var returnNames = map[nvml.Return]string{
+	nvml.SUCCESS:                       "SUCCESS",
+	nvml.ERROR_UNINITIALIZED:           "ERROR_UNINITIALIZED",
+	nvml.ERROR_INVALID_ARGUMENT:        "ERROR_INVALID_ARGUMENT",
+	nvml.ERROR_NOT_SUPPORTED:           "ERROR_NOT_SUPPORTED",
+	nvml.ERROR_NO_PERMISSION:           "ERROR_NO_PERMISSION",
+	nvml.ERROR_NOT_FOUND:               "ERROR_NOT_FOUND",
+	nvml.ERROR_INSUFFICIENT_SIZE:       "ERROR_INSUFFICIENT_SIZE",
+	nvml.ERROR_DRIVER_NOT_LOADED:       "ERROR_DRIVER_NOT_LOADED",
+	nvml.ERROR_TIMEOUT:                 "ERROR_TIMEOUT",
+	nvml.ERROR_IRQ_ISSUE:               "ERROR_IRQ_ISSUE",
+	nvml.ERROR_LIBRARY_NOT_FOUND:       "ERROR_LIBRARY_NOT_FOUND",
+	nvml.ERROR_FUNCTION_NOT_FOUND:      "ERROR_FUNCTION_NOT_FOUND",
+	nvml.ERROR_CORRUPTED_INFOROM:       "ERROR_CORRUPTED_INFOROM",
+	nvml.ERROR_GPU_IS_LOST:             "ERROR_GPU_IS_LOST",
+	nvml.ERROR_RESET_REQUIRED:          "ERROR_RESET_REQUIRED",
+	nvml.ERROR_OPERATING_SYSTEM:        "ERROR_OPERATING_SYSTEM",
+	nvml.ERROR_LIB_RM_VERSION_MISMATCH: "ERROR_LIB_RM_VERSION_MISMATCH",
+	nvml.ERROR_IN_USE:                  "ERROR_IN_USE",
+	nvml.ERROR_MEMORY:                  "ERROR_MEMORY",
+	nvml.ERROR_NO_DATA:                 "ERROR_NO_DATA",
+	nvml.ERROR_UNKNOWN:                 "ERROR_UNKNOWN",
+}

--- a/internal/nvmlnative/backend_nvml.go
+++ b/internal/nvmlnative/backend_nvml.go
@@ -93,9 +93,13 @@ type Backend struct {
 	// extrasWarned makes a persistent extras failure visible exactly once
 	// per family, mirroring permLogged/fnfLogged.
 	extrasWarned map[string]bool
-	// symbolsPresent caches driver-library symbol probes (constant for the
-	// process lifetime). Guarded by mu like the rest of the cycle state.
+	// symbolsPresent caches ad-hoc driver-library symbol probes. Guarded by
+	// mu like the rest of the cycle state.
 	symbolsPresent map[string]bool
+	// avail is the guarded-export snapshot for the current NVML generation.
+	// It is replaced wholesale on re-initialization rather than mutated, and
+	// read atomically because the XID watcher reads it without holding mu.
+	avail atomic.Pointer[availability]
 	// gpm retains one activity sample per GPU instance across cycles, so
 	// utilization can be computed over the inter-collection window. Guarded
 	// by mu like the rest of the cycle state; every sample is freed before
@@ -133,19 +137,59 @@ func New(logger *slog.Logger) (*Backend, error) {
 func newWithAPI(api nvmlAPI, logger *slog.Logger) (*Backend, error) {
 	backend := &Backend{api: api, now: time.Now, logger: logger}
 	if ret := backend.api.init(); ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to initialize NVML: %s", ret.String())
+		return nil, fmt.Errorf("failed to initialize NVML: %s", retString(ret))
 	}
 
 	backend.initialized = true
 	backend.generation.Store(1)
 	backend.genLive.Store(true)
+	backend.refreshAvailability()
+
+	// uuid labels every per-GPU series, so an absent one does not degrade a
+	// single field: it gives every GPU the same identity and collapses their
+	// series into one. There is nothing to serve in that state, so refuse to
+	// start rather than publish a corrupt scrape.
+	if !backend.avail.Load().has("nvmlDeviceGetUUID") {
+		backend.api.shutdown()
+
+		return nil, errors.New("driver library does not export nvmlDeviceGetUUID, " +
+			"which every GPU metric is labeled by")
+	}
 
 	return backend, nil
+}
+
+// refreshAvailability re-probes the guarded exports. It runs after every
+// successful initialization, not once per process: the backend re-opens NVML
+// during lifecycle recovery, which is exactly when the driver may have been
+// upgraded underneath it and the export set may differ.
+func (b *Backend) refreshAvailability() {
+	// the ad-hoc probe cache belongs to the previous library generation
+	b.symbolsPresent = nil
+
+	avail := probeSymbols(b.api.lookupSymbol, guardedSymbols)
+	b.avail.Store(avail)
+	avail.log(b.logger)
+}
+
+// device wraps a driver device handle so that every entry point it exposes is
+// guarded by the current availability snapshot.
+func (b *Backend) device(index int) (device, nvml.Return) {
+	dev, ret := b.api.deviceByIndex(index)
+	if ret != nvml.SUCCESS {
+		return nil, ret
+	}
+
+	return guardedDevice{dev: dev, avail: b.avail.Load()}, ret
 }
 
 // DriverVersion reports the installed driver version, used to pick the
 // driver-appropriate field spellings during resolution.
 func (b *Backend) DriverVersion() string {
+	if !b.avail.Load().has("nvmlSystemGetDriverVersion") {
+		return ""
+	}
+
 	version, ret := b.api.driverVersion()
 	if ret != nvml.SUCCESS {
 		return ""
@@ -311,11 +355,16 @@ func (b *Backend) collectTable(
 	if !b.initialized {
 		if ret := b.api.init(); ret != nvml.SUCCESS {
 			return nil, int(ret), &collect.FatalError{
-				Err: fmt.Errorf("failed to re-initialize NVML: %s", ret.String()),
+				Err: fmt.Errorf("failed to re-initialize NVML: %s", retString(ret)),
 			}
 		}
 
 		b.logger.Info("re-initialized NVML after a lifecycle error")
+
+		// the library was re-opened, and a driver can be replaced underneath a
+		// running process, so the export set is re-established here rather than
+		// carried over from the previous generation
+		b.refreshAvailability()
 
 		b.initialized = true
 		b.generation.Add(1)
@@ -338,7 +387,10 @@ func (b *Backend) collectTable(
 	// reading appears in every row, keeping rows mutually consistent
 	shared := sharedValues{timestamp: time.Now().Format(timestampLayout)}
 
-	driverVersion, ret := b.api.driverVersion()
+	driverVersion, ret := "", nvml.ERROR_FUNCTION_NOT_FOUND
+	if b.avail.Load().has("nvmlSystemGetDriverVersion") {
+		driverVersion, ret = b.api.driverVersion()
+	}
 	shared.driverVersion, shared.driverVersionRet = driverVersion, ret
 	shared.count, shared.countRet = count, nvml.SUCCESS
 
@@ -352,7 +404,7 @@ func (b *Backend) collectTable(
 			return nil, -1, fmt.Errorf("collection interrupted: %w", err)
 		}
 
-		dev, ret := b.api.deviceByIndex(deviceIdx)
+		dev, ret := b.device(deviceIdx)
 		if ret != nvml.SUCCESS {
 			return nil, int(ret), b.lifecycle(ret, fmt.Errorf("failed to get device %d", deviceIdx))
 		}
@@ -401,7 +453,7 @@ func (b *Backend) collectTable(
 // the backend for re-initialization and are wrapped as fatal for
 // shutdown-on-error; anything else is a plain failed collection.
 func (b *Backend) lifecycle(ret nvml.Return, err error) error {
-	err = fmt.Errorf("%w: %s", err, ret.String())
+	err = fmt.Errorf("%w: %s", err, retString(ret))
 
 	if isLifecycleError(ret) {
 		b.markLost()
@@ -496,6 +548,8 @@ func (b *Backend) tryRecover() {
 
 	b.logger.Info("re-initialized NVML after a lifecycle error (event watcher recovery)")
 
+	b.refreshAvailability()
+
 	b.initialized = true
 	b.generation.Add(1)
 	b.genLive.Store(true)
@@ -508,7 +562,7 @@ type lifecycleRetError struct {
 }
 
 func (e *lifecycleRetError) Error() string {
-	return "device collection hit a lifecycle error: " + e.ret.String()
+	return "device collection hit a lifecycle error: " + retString(e.ret)
 }
 
 // sharedValues are once-per-cycle readings injected into every device row.
@@ -629,7 +683,7 @@ const edppMultiplierFieldID = 274
 //nolint:funlen,maintidx,cyclop,gocognit,gocyclo,goconst // deliberately one linear pass mirroring the catalog order
 func (b *Backend) collectDevice(
 	ctx context.Context,
-	dev nvml.Device,
+	dev device,
 	shared sharedValues,
 	reqs plan,
 ) (map[nvidiasmi.QField]string, error) {
@@ -769,7 +823,12 @@ func (b *Backend) collectDevice(
 
 	if reqs.want("inforom.checksum_validation") {
 		// "valid" is capture-verified; the corruption spelling is not
-		ret := b.api.validateInforom(dev)
+		// seam-level call, so it carries its own guard rather than riding the
+		// guarded device surface
+		ret := nvml.ERROR_FUNCTION_NOT_FOUND
+		if b.avail.Load().has("nvmlDeviceValidateInforom") {
+			ret = b.api.validateInforom(dev.raw())
+		}
 		coll.set("inforom.checksum_validation", ret, func() string { return "valid" })
 	}
 
@@ -1043,7 +1102,7 @@ func (b *Backend) collectDevice(
 	}
 
 	if reqs.want("c2c.mode") {
-		c2c, ret := dev.GetC2cModeInfoV().V1()
+		c2c, ret := dev.GetC2cModeInfoV1()
 		coll.set("c2c.mode", ret, func() string { return onOff(c2c.IsC2cEnabled != 0) })
 	}
 
@@ -1096,7 +1155,7 @@ func (b *Backend) collectDevice(
 // The field-ID choices are trace-verified against nvidia-smi's own calls.
 //
 //nolint:cyclop,funlen // one linear pass over the batched entries and their outcomes
-func (b *Backend) collectFieldValues(dev nvml.Device, coll *devCollector, reqs plan) {
+func (b *Backend) collectFieldValues(dev device, coll *devCollector, reqs plan) {
 	entries := []struct {
 		field  nvidiasmi.QField
 		id     uint32
@@ -1222,7 +1281,7 @@ func decodeFieldValue(fv nvml.FieldValue) (float64, bool) {
 	}
 }
 
-func collectEccCounters(dev nvml.Device, coll *devCollector, reqs plan) {
+func collectEccCounters(dev device, coll *devCollector, reqs plan) {
 	locations := map[string]nvml.MemoryLocation{
 		"device_memory":  nvml.MEMORY_LOCATION_DEVICE_MEMORY,
 		"dram":           nvml.MEMORY_LOCATION_DRAM,
@@ -1263,7 +1322,7 @@ func collectEccCounters(dev nvml.Device, coll *devCollector, reqs plan) {
 	}
 }
 
-func collectSramEcc(dev nvml.Device, coll *devCollector, reqs plan) {
+func collectSramEcc(dev device, coll *devCollector, reqs plan) {
 	sramFields := []nvidiasmi.QField{
 		"ecc.errors.uncorrected.volatile.sram.parity", "ecc.errors.uncorrected.volatile.sram.secded",
 		"ecc.errors.uncorrected.aggregate.sram.parity", "ecc.errors.uncorrected.aggregate.sram.secded",
@@ -1298,7 +1357,7 @@ func collectSramEcc(dev nvml.Device, coll *devCollector, reqs plan) {
 // collectFabric fills the fabric.* fields. When there is no fabric (state 0
 // or the call fails), every field prints the bare N/A token
 // (capture-verified). Lifecycle-class failures still poison the cycle.
-func collectFabric(dev nvml.Device, coll *devCollector, reqs plan) {
+func collectFabric(dev device, coll *devCollector, reqs plan) {
 	fabricFields := []nvidiasmi.QField{
 		"fabric.state", "fabric.status", "fabric.cliqueId", "fabric.clusterUuid",
 	}
@@ -1306,7 +1365,7 @@ func collectFabric(dev nvml.Device, coll *devCollector, reqs plan) {
 		return
 	}
 
-	info, ret := dev.GetGpuFabricInfoV().V2()
+	info, ret := dev.GetGpuFabricInfoV2()
 	if ret != nvml.SUCCESS || info.State == 0 {
 		coll.classify("fabric.state", ret)
 
@@ -1334,7 +1393,7 @@ func collectFabric(dev nvml.Device, coll *devCollector, reqs plan) {
 	coll.values["fabric.clusterUuid"] = uuidBytes(info.ClusterUuid)
 }
 
-func collectPlatform(dev nvml.Device, coll *devCollector, reqs plan) {
+func collectPlatform(dev device, coll *devCollector, reqs plan) {
 	if !reqs.want("platform.chassis_serial_number", "platform.slot_number", "platform.tray_index",
 		"platform.host_id", "platform.peer_type", "platform.module_id", "platform.gpu_fabric_guid") {
 		return
@@ -1383,7 +1442,7 @@ func (b *Backend) collectComputeApps(ctx context.Context) ([]nvidiasmi.ComputeAp
 			return nil, fmt.Errorf("per-process collection interrupted: %w", err)
 		}
 
-		dev, ret := b.api.deviceByIndex(deviceIdx)
+		dev, ret := b.device(deviceIdx)
 		if ret != nvml.SUCCESS {
 			return nil, b.softLifecycle(ret, fmt.Errorf("failed to get device %d", deviceIdx))
 		}
@@ -1398,8 +1457,14 @@ func (b *Backend) collectComputeApps(ctx context.Context) ([]nvidiasmi.ComputeAp
 			return nil, b.softLifecycle(ret, fmt.Errorf("failed to list processes of device %d", deviceIdx))
 		}
 
+		nameAvailable := b.avail.Load().has("nvmlSystemGetProcessName")
+
 		for _, proc := range procs {
-			name, nret := b.api.processName(int(proc.Pid))
+			name, nret := "", nvml.ERROR_FUNCTION_NOT_FOUND
+			if nameAvailable {
+				name, nret = b.api.processName(int(proc.Pid))
+			}
+
 			if nret != nvml.SUCCESS {
 				name = tok(nret)
 			}
@@ -1433,7 +1498,7 @@ func (b *Backend) softLifecycle(ret nvml.Return, err error) error {
 		b.markLost()
 	}
 
-	return fmt.Errorf("%w: %s", err, ret.String())
+	return fmt.Errorf("%w: %s", err, retString(ret))
 }
 
 // pcieThroughputKBMultiplier converts the driver's PCIe throughput reading
@@ -1459,7 +1524,10 @@ func (b *Backend) collectExtras(ctx context.Context, opts CollectOptions) collec
 		return extras
 	}
 
-	version, ret := b.api.cudaDriverVersion()
+	version, ret := 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	if b.avail.Load().has("nvmlSystemGetCudaDriverVersion") {
+		version, ret = b.api.cudaDriverVersion()
+	}
 
 	switch {
 	case ret == nvml.SUCCESS:
@@ -1515,7 +1583,7 @@ func (b *Backend) collectDeviceExtras(
 	extras *collect.Extras,
 	seenGIs map[string]bool,
 ) bool {
-	dev, ret := b.api.deviceByIndex(deviceIdx)
+	dev, ret := b.device(deviceIdx)
 	if ret != nvml.SUCCESS {
 		return b.extrasFailure("extras", "failed to get a device for the extra metrics", ret)
 	}
@@ -1545,7 +1613,7 @@ func (b *Backend) collectDeviceExtras(
 // collectEnergy appends one device's cumulative energy reading. A device
 // that cannot report it (pre-Volta) is skipped silently; other persistent
 // failures are logged once. Reports whether extras collection may continue.
-func (b *Backend) collectEnergy(dev nvml.Device, uuid string, extras *collect.Extras) bool {
+func (b *Backend) collectEnergy(dev device, uuid string, extras *collect.Extras) bool {
 	millijoules, ret := dev.GetTotalEnergyConsumption()
 
 	//nolint:exhaustive // every other return is a plain failure
@@ -1568,7 +1636,7 @@ func (b *Backend) collectEnergy(dev nvml.Device, uuid string, extras *collect.Ex
 // simultaneous pair. Reports whether extras collection may continue.
 func (b *Backend) collectPcie(
 	ctx context.Context,
-	dev nvml.Device,
+	dev device,
 	uuid string,
 	extras *collect.Extras,
 ) bool {
@@ -1647,5 +1715,5 @@ func (b *Backend) warnOnce(family, msg string, ret nvml.Return) {
 
 	b.extrasWarned[family] = true
 
-	b.logger.Warn(msg, "family", family, "nvml_return", ret.String())
+	b.logger.Warn(msg, "family", family, "nvml_return", retString(ret))
 }

--- a/internal/nvmlnative/backend_nvml.go
+++ b/internal/nvmlnative/backend_nvml.go
@@ -150,37 +150,13 @@ func newWithAPI(api nvmlAPI, logger *slog.Logger) (*Backend, error) {
 	// series into one. There is nothing to serve in that state, so refuse to
 	// start rather than publish a corrupt scrape.
 	if !backend.avail.Load().has("nvmlDeviceGetUUID") {
-		backend.api.shutdown()
+		_ = backend.api.shutdown()
 
 		return nil, errors.New("driver library does not export nvmlDeviceGetUUID, " +
 			"which every GPU metric is labeled by")
 	}
 
 	return backend, nil
-}
-
-// refreshAvailability re-probes the guarded exports. It runs after every
-// successful initialization, not once per process: the backend re-opens NVML
-// during lifecycle recovery, which is exactly when the driver may have been
-// upgraded underneath it and the export set may differ.
-func (b *Backend) refreshAvailability() {
-	// the ad-hoc probe cache belongs to the previous library generation
-	b.symbolsPresent = nil
-
-	avail := probeSymbols(b.api.lookupSymbol, guardedSymbols)
-	b.avail.Store(avail)
-	avail.log(b.logger)
-}
-
-// device wraps a driver device handle so that every entry point it exposes is
-// guarded by the current availability snapshot.
-func (b *Backend) device(index int) (device, nvml.Return) {
-	dev, ret := b.api.deviceByIndex(index)
-	if ret != nvml.SUCCESS {
-		return nil, ret
-	}
-
-	return guardedDevice{dev: dev, avail: b.avail.Load()}, ret
 }
 
 // DriverVersion reports the installed driver version, used to pick the
@@ -391,6 +367,7 @@ func (b *Backend) collectTable(
 	if b.avail.Load().has("nvmlSystemGetDriverVersion") {
 		driverVersion, ret = b.api.driverVersion()
 	}
+
 	shared.driverVersion, shared.driverVersionRet = driverVersion, ret
 	shared.count, shared.countRet = count, nvml.SUCCESS
 
@@ -829,6 +806,7 @@ func (b *Backend) collectDevice(
 		if b.avail.Load().has("nvmlDeviceValidateInforom") {
 			ret = b.api.validateInforom(dev.raw())
 		}
+
 		coll.set("inforom.checksum_validation", ret, func() string { return "valid" })
 	}
 
@@ -1716,4 +1694,32 @@ func (b *Backend) warnOnce(family, msg string, ret nvml.Return) {
 	b.extrasWarned[family] = true
 
 	b.logger.Warn(msg, "family", family, "nvml_return", retString(ret))
+}
+
+// refreshAvailability re-probes the guarded exports. It runs after every
+// successful initialization, not once per process: the backend re-opens NVML
+// during lifecycle recovery, which is exactly when the driver may have been
+// upgraded underneath it and the export set may differ.
+func (b *Backend) refreshAvailability() {
+	// the ad-hoc probe cache belongs to the previous library generation
+	b.symbolsPresent = nil
+
+	avail := probeSymbols(b.api.lookupSymbol, guardedSymbols)
+	b.avail.Store(avail)
+	avail.log(b.logger)
+}
+
+// device wraps a driver device handle so that every entry point it exposes is
+// guarded by the current availability snapshot.
+//
+// code must never receive a raw handle.
+//
+//nolint:ireturn // handing back the guarded interface is the point: collector
+func (b *Backend) device(index int) (device, nvml.Return) {
+	dev, ret := b.api.deviceByIndex(index)
+	if ret != nvml.SUCCESS {
+		return nil, ret
+	}
+
+	return guardedDevice{dev: dev, avail: b.avail.Load()}, ret
 }

--- a/internal/nvmlnative/guard_nvml.go
+++ b/internal/nvmlnative/guard_nvml.go
@@ -14,12 +14,14 @@ import "github.com/NVIDIA/go-nvml/pkg/nvml"
 //
 // Adding a getter here is what forces its symbol to be declared: the compiler
 // rejects a collector call that this interface does not carry.
+//
+//nolint:interfacebloat // the method set mirrors go-nvml's Device interface
 type device interface {
 	GetAccountingBufferSize() (int, nvml.Return)
 	GetAccountingMode() (nvml.EnableState, nvml.Return)
 	GetAddressingMode() (nvml.DeviceAddressingMode, nvml.Return)
 	GetC2cModeInfoV1() (nvml.C2cModeInfo_v1, nvml.Return)
-	GetClockInfo(nvml.ClockType) (uint32, nvml.Return)
+	GetClockInfo(clockType nvml.ClockType) (uint32, nvml.Return)
 	GetComputeInstanceId() (int, nvml.Return)
 	GetComputeMode() (nvml.ComputeMode, nvml.Return)
 	GetComputeRunningProcesses() ([]nvml.ProcessInfo, nvml.Return)
@@ -38,7 +40,7 @@ type device interface {
 	GetEncoderUtilization() (uint32, uint32, nvml.Return)
 	GetEnforcedPowerLimit() (uint32, nvml.Return)
 	GetFanSpeed() (uint32, nvml.Return)
-	GetFieldValues([]nvml.FieldValue) nvml.Return
+	GetFieldValues(values []nvml.FieldValue) nvml.Return
 	GetGpuFabricInfoV2() (nvml.GpuFabricInfo_v2, nvml.Return)
 	GetGpuInstanceId() (int, nvml.Return)
 	GetGpuMaxPcieLinkGeneration() (int, nvml.Return)
@@ -47,20 +49,24 @@ type device interface {
 	GetHostname_v1() (string, nvml.Return)
 	GetIndex() (int, nvml.Return)
 	GetInforomImageVersion() (string, nvml.Return)
-	GetInforomVersion(nvml.InforomObject) (string, nvml.Return)
+	GetInforomVersion(object nvml.InforomObject) (string, nvml.Return)
 	GetJpgUtilization() (uint32, uint32, nvml.Return)
 	GetMarginTemperature() (nvml.MarginTemperature, nvml.Return)
-	GetMaxClockInfo(nvml.ClockType) (uint32, nvml.Return)
+	GetMaxClockInfo(clockType nvml.ClockType) (uint32, nvml.Return)
 	GetMaxMigDeviceCount() (int, nvml.Return)
 	GetMaxPcieLinkGeneration() (int, nvml.Return)
 	GetMaxPcieLinkWidth() (int, nvml.Return)
-	GetMemoryErrorCounter(nvml.MemoryErrorType, nvml.EccCounterType, nvml.MemoryLocation) (uint64, nvml.Return)
+	GetMemoryErrorCounter(
+		errorType nvml.MemoryErrorType,
+		counterType nvml.EccCounterType,
+		location nvml.MemoryLocation,
+	) (uint64, nvml.Return)
 	GetMemoryInfo_v2() (nvml.Memory_v2, nvml.Return)
-	GetMigDeviceHandleByIndex(int) (device, nvml.Return)
+	GetMigDeviceHandleByIndex(index int) (device, nvml.Return)
 	GetMigMode() (int, int, nvml.Return)
 	GetName() (string, nvml.Return)
 	GetOfaUtilization() (uint32, uint32, nvml.Return)
-	GetPcieThroughput(nvml.PcieUtilCounter) (uint32, nvml.Return)
+	GetPcieThroughput(counter nvml.PcieUtilCounter) (uint32, nvml.Return)
 	GetPciInfoExt() (nvml.PciInfoExt, nvml.Return)
 	GetPerformanceState() (nvml.Pstates, nvml.Return)
 	GetPersistenceMode() (nvml.EnableState, nvml.Return)
@@ -71,20 +77,20 @@ type device interface {
 	GetPowerUsage() (uint32, nvml.Return)
 	GetRemappedRows() (int, int, bool, bool, nvml.Return)
 	GetRemappedRows_v2() (nvml.RemappedRowsInfo_v2, nvml.Return)
-	GetRetiredPages(nvml.PageRetirementCause) ([]uint64, nvml.Return)
+	GetRetiredPages(cause nvml.PageRetirementCause) ([]uint64, nvml.Return)
 	GetRetiredPagesPendingStatus() (nvml.EnableState, nvml.Return)
 	GetRowRemapperHistogram() (nvml.RowRemapperHistogramValues, nvml.Return)
 	GetSerial() (string, nvml.Return)
 	GetSramEccErrorStatus() (nvml.EccSramErrorStatus, nvml.Return)
 	GetSupportedClocksEventReasons() (uint64, nvml.Return)
-	GetTemperature(nvml.TemperatureSensors) (uint32, nvml.Return)
-	GetTotalEccErrors(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return)
+	GetTemperature(sensor nvml.TemperatureSensors) (uint32, nvml.Return)
+	GetTotalEccErrors(errorType nvml.MemoryErrorType, counterType nvml.EccCounterType) (uint64, nvml.Return)
 	GetTotalEnergyConsumption() (uint64, nvml.Return)
 	GetUtilizationRates() (nvml.Utilization, nvml.Return)
 	GetUUID() (string, nvml.Return)
 	GetVbiosVersion() (string, nvml.Return)
 	GpmQueryDeviceSupport() (nvml.GpmSupport, nvml.Return)
-	RegisterEvents(uint64, nvml.EventSet) nvml.Return
+	RegisterEvents(eventTypes uint64, set nvml.EventSet) nvml.Return
 
 	// raw exposes the underlying handle for the few places that must match
 	// identities go-nvml hands back to us (the XID watcher keys events by the
@@ -98,8 +104,6 @@ type guardedDevice struct {
 	dev   nvml.Device
 	avail *availability
 }
-
-func (g guardedDevice) raw() nvml.Device { return g.dev }
 
 func (g guardedDevice) GetAccountingBufferSize() (int, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetAccountingBufferSize") {
@@ -147,6 +151,7 @@ func (g guardedDevice) GetClockInfo(p0 nvml.ClockType) (uint32, nvml.Return) {
 	return g.dev.GetClockInfo(p0)
 }
 
+//nolint:revive // the name must match go-nvml's Device interface to delegate
 func (g guardedDevice) GetComputeInstanceId() (int, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetComputeInstanceId") {
 		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
@@ -252,8 +257,10 @@ func (g guardedDevice) GetDisplayMode() (nvml.EnableState, nvml.Return) {
 
 func (g guardedDevice) GetDramEncryptionMode() (nvml.DramEncryptionInfo, nvml.DramEncryptionInfo, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetDramEncryptionMode") {
-		var z0 nvml.DramEncryptionInfo
-		var z1 nvml.DramEncryptionInfo
+		var (
+			z0 nvml.DramEncryptionInfo
+			z1 nvml.DramEncryptionInfo
+		)
 
 		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
 	}
@@ -267,8 +274,10 @@ func (g guardedDevice) GetDriverModel() (nvml.DriverModel, nvml.DriverModel, nvm
 	// already safe against a driver that lacks the newer one. Hard-probing a
 	// single spelling here would be wrong.
 	if !g.avail.hasAny("nvmlDeviceGetDriverModel", "nvmlDeviceGetDriverModel_v2") {
-		var z0 nvml.DriverModel
-		var z1 nvml.DriverModel
+		var (
+			z0 nvml.DriverModel
+			z1 nvml.DriverModel
+		)
 
 		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
 	}
@@ -278,8 +287,10 @@ func (g guardedDevice) GetDriverModel() (nvml.DriverModel, nvml.DriverModel, nvm
 
 func (g guardedDevice) GetEccMode() (nvml.EnableState, nvml.EnableState, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetEccMode") {
-		var z0 nvml.EnableState
-		var z1 nvml.EnableState
+		var (
+			z0 nvml.EnableState
+			z1 nvml.EnableState
+		)
 
 		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
 	}
@@ -337,6 +348,7 @@ func (g guardedDevice) GetGpuFabricInfoV2() (nvml.GpuFabricInfo_v2, nvml.Return)
 	return g.dev.GetGpuFabricInfoV().V2()
 }
 
+//nolint:revive // the name must match go-nvml's Device interface to delegate
 func (g guardedDevice) GetGpuInstanceId() (int, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetGpuInstanceId") {
 		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
@@ -355,8 +367,10 @@ func (g guardedDevice) GetGpuMaxPcieLinkGeneration() (int, nvml.Return) {
 
 func (g guardedDevice) GetGpuOperationMode() (nvml.GpuOperationMode, nvml.GpuOperationMode, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetGpuOperationMode") {
-		var z0 nvml.GpuOperationMode
-		var z1 nvml.GpuOperationMode
+		var (
+			z0 nvml.GpuOperationMode
+			z1 nvml.GpuOperationMode
+		)
 
 		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
 	}
@@ -372,6 +386,7 @@ func (g guardedDevice) GetGspFirmwareMode() (bool, bool, nvml.Return) {
 	return g.dev.GetGspFirmwareMode()
 }
 
+//nolint:revive // the name must match go-nvml's Device interface to delegate
 func (g guardedDevice) GetHostname_v1() (string, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetHostname_v1") {
 		return "", nvml.ERROR_FUNCTION_NOT_FOUND
@@ -466,6 +481,7 @@ func (g guardedDevice) GetMemoryErrorCounter(
 	return g.dev.GetMemoryErrorCounter(p0, p1, p2)
 }
 
+//nolint:revive // the name must match go-nvml's Device interface to delegate
 func (g guardedDevice) GetMemoryInfo_v2() (nvml.Memory_v2, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetMemoryInfo_v2") {
 		var z0 nvml.Memory_v2
@@ -476,6 +492,7 @@ func (g guardedDevice) GetMemoryInfo_v2() (nvml.Memory_v2, nvml.Return) {
 	return g.dev.GetMemoryInfo_v2()
 }
 
+//nolint:ireturn // a MIG handle must arrive wrapped, never raw
 func (g guardedDevice) GetMigDeviceHandleByIndex(p0 int) (device, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetMigDeviceHandleByIndex") {
 		return nil, nvml.ERROR_FUNCTION_NOT_FOUND
@@ -601,6 +618,7 @@ func (g guardedDevice) GetRemappedRows() (int, int, bool, bool, nvml.Return) {
 	return g.dev.GetRemappedRows()
 }
 
+//nolint:revive // the name must match go-nvml's Device interface to delegate
 func (g guardedDevice) GetRemappedRows_v2() (nvml.RemappedRowsInfo_v2, nvml.Return) {
 	if !g.avail.has("nvmlDeviceGetRemappedRows_v2") {
 		var z0 nvml.RemappedRowsInfo_v2
@@ -732,3 +750,9 @@ func (g guardedDevice) RegisterEvents(p0 uint64, p1 nvml.EventSet) nvml.Return {
 
 	return g.dev.RegisterEvents(p0, p1)
 }
+
+// raw exposes the underlying handle for identity matching only. It must never
+// be used to make a call.
+//
+//nolint:ireturn // hands back go-nvml's own interface type by definition
+func (g guardedDevice) raw() nvml.Device { return g.dev }

--- a/internal/nvmlnative/guard_nvml.go
+++ b/internal/nvmlnative/guard_nvml.go
@@ -1,0 +1,734 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import "github.com/NVIDIA/go-nvml/pkg/nvml"
+
+// device is the narrow NVML surface this package uses. Collector code depends
+// on this interface and never on nvml.Device directly, so that every entry
+// point passes through the availability guard below. A getter whose export the
+// driver library does not provide crashes the process when called (the cgo
+// binding is resolved lazily by the loader and has no way to report failure),
+// so the guard answers with ERROR_FUNCTION_NOT_FOUND without entering cgo. The
+// existing collector paths already render that return as an absent series.
+//
+// Adding a getter here is what forces its symbol to be declared: the compiler
+// rejects a collector call that this interface does not carry.
+type device interface {
+	GetAccountingBufferSize() (int, nvml.Return)
+	GetAccountingMode() (nvml.EnableState, nvml.Return)
+	GetAddressingMode() (nvml.DeviceAddressingMode, nvml.Return)
+	GetC2cModeInfoV1() (nvml.C2cModeInfo_v1, nvml.Return)
+	GetClockInfo(nvml.ClockType) (uint32, nvml.Return)
+	GetComputeInstanceId() (int, nvml.Return)
+	GetComputeMode() (nvml.ComputeMode, nvml.Return)
+	GetComputeRunningProcesses() ([]nvml.ProcessInfo, nvml.Return)
+	GetConfComputeProtectedMemoryUsage() (nvml.Memory, nvml.Return)
+	GetCudaComputeCapability() (int, int, nvml.Return)
+	GetCurrentClocksEventReasons() (uint64, nvml.Return)
+	GetCurrPcieLinkGeneration() (int, nvml.Return)
+	GetCurrPcieLinkWidth() (int, nvml.Return)
+	GetDecoderUtilization() (uint32, uint32, nvml.Return)
+	GetDisplayActive() (nvml.EnableState, nvml.Return)
+	GetDisplayMode() (nvml.EnableState, nvml.Return)
+	GetDramEncryptionMode() (nvml.DramEncryptionInfo, nvml.DramEncryptionInfo, nvml.Return)
+	GetDriverModel() (nvml.DriverModel, nvml.DriverModel, nvml.Return)
+	GetEccMode() (nvml.EnableState, nvml.EnableState, nvml.Return)
+	GetEncoderStats() (int, uint32, uint32, nvml.Return)
+	GetEncoderUtilization() (uint32, uint32, nvml.Return)
+	GetEnforcedPowerLimit() (uint32, nvml.Return)
+	GetFanSpeed() (uint32, nvml.Return)
+	GetFieldValues([]nvml.FieldValue) nvml.Return
+	GetGpuFabricInfoV2() (nvml.GpuFabricInfo_v2, nvml.Return)
+	GetGpuInstanceId() (int, nvml.Return)
+	GetGpuMaxPcieLinkGeneration() (int, nvml.Return)
+	GetGpuOperationMode() (nvml.GpuOperationMode, nvml.GpuOperationMode, nvml.Return)
+	GetGspFirmwareMode() (bool, bool, nvml.Return)
+	GetHostname_v1() (string, nvml.Return)
+	GetIndex() (int, nvml.Return)
+	GetInforomImageVersion() (string, nvml.Return)
+	GetInforomVersion(nvml.InforomObject) (string, nvml.Return)
+	GetJpgUtilization() (uint32, uint32, nvml.Return)
+	GetMarginTemperature() (nvml.MarginTemperature, nvml.Return)
+	GetMaxClockInfo(nvml.ClockType) (uint32, nvml.Return)
+	GetMaxMigDeviceCount() (int, nvml.Return)
+	GetMaxPcieLinkGeneration() (int, nvml.Return)
+	GetMaxPcieLinkWidth() (int, nvml.Return)
+	GetMemoryErrorCounter(nvml.MemoryErrorType, nvml.EccCounterType, nvml.MemoryLocation) (uint64, nvml.Return)
+	GetMemoryInfo_v2() (nvml.Memory_v2, nvml.Return)
+	GetMigDeviceHandleByIndex(int) (device, nvml.Return)
+	GetMigMode() (int, int, nvml.Return)
+	GetName() (string, nvml.Return)
+	GetOfaUtilization() (uint32, uint32, nvml.Return)
+	GetPcieThroughput(nvml.PcieUtilCounter) (uint32, nvml.Return)
+	GetPciInfoExt() (nvml.PciInfoExt, nvml.Return)
+	GetPerformanceState() (nvml.Pstates, nvml.Return)
+	GetPersistenceMode() (nvml.EnableState, nvml.Return)
+	GetPlatformInfo() (nvml.PlatformInfo, nvml.Return)
+	GetPowerManagementDefaultLimit() (uint32, nvml.Return)
+	GetPowerManagementLimit() (uint32, nvml.Return)
+	GetPowerManagementLimitConstraints() (uint32, uint32, nvml.Return)
+	GetPowerUsage() (uint32, nvml.Return)
+	GetRemappedRows() (int, int, bool, bool, nvml.Return)
+	GetRemappedRows_v2() (nvml.RemappedRowsInfo_v2, nvml.Return)
+	GetRetiredPages(nvml.PageRetirementCause) ([]uint64, nvml.Return)
+	GetRetiredPagesPendingStatus() (nvml.EnableState, nvml.Return)
+	GetRowRemapperHistogram() (nvml.RowRemapperHistogramValues, nvml.Return)
+	GetSerial() (string, nvml.Return)
+	GetSramEccErrorStatus() (nvml.EccSramErrorStatus, nvml.Return)
+	GetSupportedClocksEventReasons() (uint64, nvml.Return)
+	GetTemperature(nvml.TemperatureSensors) (uint32, nvml.Return)
+	GetTotalEccErrors(nvml.MemoryErrorType, nvml.EccCounterType) (uint64, nvml.Return)
+	GetTotalEnergyConsumption() (uint64, nvml.Return)
+	GetUtilizationRates() (nvml.Utilization, nvml.Return)
+	GetUUID() (string, nvml.Return)
+	GetVbiosVersion() (string, nvml.Return)
+	GpmQueryDeviceSupport() (nvml.GpmSupport, nvml.Return)
+	RegisterEvents(uint64, nvml.EventSet) nvml.Return
+
+	// raw exposes the underlying handle for the few places that must match
+	// identities go-nvml hands back to us (the XID watcher keys events by the
+	// device it registered). It must never be used to make a call.
+	raw() nvml.Device
+}
+
+// guardedDevice wraps a driver device handle with the symbol availability
+// snapshot taken when NVML was initialized.
+type guardedDevice struct {
+	dev   nvml.Device
+	avail *availability
+}
+
+func (g guardedDevice) raw() nvml.Device { return g.dev }
+
+func (g guardedDevice) GetAccountingBufferSize() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetAccountingBufferSize") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetAccountingBufferSize()
+}
+
+func (g guardedDevice) GetAccountingMode() (nvml.EnableState, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetAccountingMode") {
+		var z0 nvml.EnableState
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetAccountingMode()
+}
+
+func (g guardedDevice) GetAddressingMode() (nvml.DeviceAddressingMode, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetAddressingMode") {
+		var z0 nvml.DeviceAddressingMode
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetAddressingMode()
+}
+
+func (g guardedDevice) GetC2cModeInfoV1() (nvml.C2cModeInfo_v1, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetC2cModeInfoV") {
+		var z0 nvml.C2cModeInfo_v1
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetC2cModeInfoV().V1()
+}
+
+func (g guardedDevice) GetClockInfo(p0 nvml.ClockType) (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetClockInfo") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetClockInfo(p0)
+}
+
+func (g guardedDevice) GetComputeInstanceId() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetComputeInstanceId") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetComputeInstanceId()
+}
+
+func (g guardedDevice) GetComputeMode() (nvml.ComputeMode, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetComputeMode") {
+		var z0 nvml.ComputeMode
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetComputeMode()
+}
+
+func (g guardedDevice) GetComputeRunningProcesses() ([]nvml.ProcessInfo, nvml.Return) {
+	// go-nvml selects the version of this entry point itself: it dlsym-probes
+	// for the newer spellings at load time and falls back to v1, so the call is
+	// already safe against a driver that lacks the newer one. Hard-probing a
+	// single spelling here would be wrong.
+	if !g.avail.hasAny("nvmlDeviceGetComputeRunningProcesses",
+		"nvmlDeviceGetComputeRunningProcesses_v2", "nvmlDeviceGetComputeRunningProcesses_v3") {
+		var z0 []nvml.ProcessInfo
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetComputeRunningProcesses()
+}
+
+func (g guardedDevice) GetConfComputeProtectedMemoryUsage() (nvml.Memory, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetConfComputeProtectedMemoryUsage") {
+		var z0 nvml.Memory
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetConfComputeProtectedMemoryUsage()
+}
+
+func (g guardedDevice) GetCudaComputeCapability() (int, int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetCudaComputeCapability") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetCudaComputeCapability()
+}
+
+func (g guardedDevice) GetCurrentClocksEventReasons() (uint64, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetCurrentClocksEventReasons") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetCurrentClocksEventReasons()
+}
+
+func (g guardedDevice) GetCurrPcieLinkGeneration() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetCurrPcieLinkGeneration") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetCurrPcieLinkGeneration()
+}
+
+func (g guardedDevice) GetCurrPcieLinkWidth() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetCurrPcieLinkWidth") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetCurrPcieLinkWidth()
+}
+
+func (g guardedDevice) GetDecoderUtilization() (uint32, uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetDecoderUtilization") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetDecoderUtilization()
+}
+
+func (g guardedDevice) GetDisplayActive() (nvml.EnableState, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetDisplayActive") {
+		var z0 nvml.EnableState
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetDisplayActive()
+}
+
+func (g guardedDevice) GetDisplayMode() (nvml.EnableState, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetDisplayMode") {
+		var z0 nvml.EnableState
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetDisplayMode()
+}
+
+func (g guardedDevice) GetDramEncryptionMode() (nvml.DramEncryptionInfo, nvml.DramEncryptionInfo, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetDramEncryptionMode") {
+		var z0 nvml.DramEncryptionInfo
+		var z1 nvml.DramEncryptionInfo
+
+		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetDramEncryptionMode()
+}
+
+func (g guardedDevice) GetDriverModel() (nvml.DriverModel, nvml.DriverModel, nvml.Return) {
+	// go-nvml selects the version of this entry point itself: it dlsym-probes
+	// for the newer spellings at load time and falls back to v1, so the call is
+	// already safe against a driver that lacks the newer one. Hard-probing a
+	// single spelling here would be wrong.
+	if !g.avail.hasAny("nvmlDeviceGetDriverModel", "nvmlDeviceGetDriverModel_v2") {
+		var z0 nvml.DriverModel
+		var z1 nvml.DriverModel
+
+		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetDriverModel()
+}
+
+func (g guardedDevice) GetEccMode() (nvml.EnableState, nvml.EnableState, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetEccMode") {
+		var z0 nvml.EnableState
+		var z1 nvml.EnableState
+
+		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetEccMode()
+}
+
+func (g guardedDevice) GetEncoderStats() (int, uint32, uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetEncoderStats") {
+		return 0, 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetEncoderStats()
+}
+
+func (g guardedDevice) GetEncoderUtilization() (uint32, uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetEncoderUtilization") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetEncoderUtilization()
+}
+
+func (g guardedDevice) GetEnforcedPowerLimit() (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetEnforcedPowerLimit") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetEnforcedPowerLimit()
+}
+
+func (g guardedDevice) GetFanSpeed() (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetFanSpeed") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetFanSpeed()
+}
+
+func (g guardedDevice) GetFieldValues(p0 []nvml.FieldValue) nvml.Return {
+	if !g.avail.has("nvmlDeviceGetFieldValues") {
+		return nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetFieldValues(p0)
+}
+
+func (g guardedDevice) GetGpuFabricInfoV2() (nvml.GpuFabricInfo_v2, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetGpuFabricInfoV") {
+		var z0 nvml.GpuFabricInfo_v2
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetGpuFabricInfoV().V2()
+}
+
+func (g guardedDevice) GetGpuInstanceId() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetGpuInstanceId") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetGpuInstanceId()
+}
+
+func (g guardedDevice) GetGpuMaxPcieLinkGeneration() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetGpuMaxPcieLinkGeneration") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetGpuMaxPcieLinkGeneration()
+}
+
+func (g guardedDevice) GetGpuOperationMode() (nvml.GpuOperationMode, nvml.GpuOperationMode, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetGpuOperationMode") {
+		var z0 nvml.GpuOperationMode
+		var z1 nvml.GpuOperationMode
+
+		return z0, z1, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetGpuOperationMode()
+}
+
+func (g guardedDevice) GetGspFirmwareMode() (bool, bool, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetGspFirmwareMode") {
+		return false, false, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetGspFirmwareMode()
+}
+
+func (g guardedDevice) GetHostname_v1() (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetHostname_v1") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetHostname_v1()
+}
+
+func (g guardedDevice) GetIndex() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetIndex") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetIndex()
+}
+
+func (g guardedDevice) GetInforomImageVersion() (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetInforomImageVersion") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetInforomImageVersion()
+}
+
+func (g guardedDevice) GetInforomVersion(p0 nvml.InforomObject) (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetInforomVersion") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetInforomVersion(p0)
+}
+
+func (g guardedDevice) GetJpgUtilization() (uint32, uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetJpgUtilization") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetJpgUtilization()
+}
+
+func (g guardedDevice) GetMarginTemperature() (nvml.MarginTemperature, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMarginTemperature") {
+		var z0 nvml.MarginTemperature
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMarginTemperature()
+}
+
+func (g guardedDevice) GetMaxClockInfo(p0 nvml.ClockType) (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMaxClockInfo") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMaxClockInfo(p0)
+}
+
+func (g guardedDevice) GetMaxMigDeviceCount() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMaxMigDeviceCount") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMaxMigDeviceCount()
+}
+
+func (g guardedDevice) GetMaxPcieLinkGeneration() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMaxPcieLinkGeneration") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMaxPcieLinkGeneration()
+}
+
+func (g guardedDevice) GetMaxPcieLinkWidth() (int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMaxPcieLinkWidth") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMaxPcieLinkWidth()
+}
+
+func (g guardedDevice) GetMemoryErrorCounter(
+	p0 nvml.MemoryErrorType,
+	p1 nvml.EccCounterType,
+	p2 nvml.MemoryLocation,
+) (uint64, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMemoryErrorCounter") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMemoryErrorCounter(p0, p1, p2)
+}
+
+func (g guardedDevice) GetMemoryInfo_v2() (nvml.Memory_v2, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMemoryInfo_v2") {
+		var z0 nvml.Memory_v2
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMemoryInfo_v2()
+}
+
+func (g guardedDevice) GetMigDeviceHandleByIndex(p0 int) (device, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMigDeviceHandleByIndex") {
+		return nil, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	mig, ret := g.dev.GetMigDeviceHandleByIndex(p0)
+	if ret != nvml.SUCCESS {
+		return nil, ret
+	}
+
+	return guardedDevice{dev: mig, avail: g.avail}, ret
+}
+
+func (g guardedDevice) GetMigMode() (int, int, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetMigMode") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetMigMode()
+}
+
+func (g guardedDevice) GetName() (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetName") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetName()
+}
+
+func (g guardedDevice) GetOfaUtilization() (uint32, uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetOfaUtilization") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetOfaUtilization()
+}
+
+func (g guardedDevice) GetPcieThroughput(p0 nvml.PcieUtilCounter) (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPcieThroughput") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPcieThroughput(p0)
+}
+
+func (g guardedDevice) GetPciInfoExt() (nvml.PciInfoExt, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPciInfoExt") {
+		var z0 nvml.PciInfoExt
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPciInfoExt()
+}
+
+func (g guardedDevice) GetPerformanceState() (nvml.Pstates, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPerformanceState") {
+		var z0 nvml.Pstates
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPerformanceState()
+}
+
+func (g guardedDevice) GetPersistenceMode() (nvml.EnableState, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPersistenceMode") {
+		var z0 nvml.EnableState
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPersistenceMode()
+}
+
+func (g guardedDevice) GetPlatformInfo() (nvml.PlatformInfo, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPlatformInfo") {
+		var z0 nvml.PlatformInfo
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPlatformInfo()
+}
+
+func (g guardedDevice) GetPowerManagementDefaultLimit() (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPowerManagementDefaultLimit") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPowerManagementDefaultLimit()
+}
+
+func (g guardedDevice) GetPowerManagementLimit() (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPowerManagementLimit") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPowerManagementLimit()
+}
+
+func (g guardedDevice) GetPowerManagementLimitConstraints() (uint32, uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPowerManagementLimitConstraints") {
+		return 0, 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPowerManagementLimitConstraints()
+}
+
+func (g guardedDevice) GetPowerUsage() (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetPowerUsage") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetPowerUsage()
+}
+
+func (g guardedDevice) GetRemappedRows() (int, int, bool, bool, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetRemappedRows") {
+		return 0, 0, false, false, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetRemappedRows()
+}
+
+func (g guardedDevice) GetRemappedRows_v2() (nvml.RemappedRowsInfo_v2, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetRemappedRows_v2") {
+		var z0 nvml.RemappedRowsInfo_v2
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetRemappedRows_v2()
+}
+
+func (g guardedDevice) GetRetiredPages(p0 nvml.PageRetirementCause) ([]uint64, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetRetiredPages") {
+		return nil, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetRetiredPages(p0)
+}
+
+func (g guardedDevice) GetRetiredPagesPendingStatus() (nvml.EnableState, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetRetiredPagesPendingStatus") {
+		var z0 nvml.EnableState
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetRetiredPagesPendingStatus()
+}
+
+func (g guardedDevice) GetRowRemapperHistogram() (nvml.RowRemapperHistogramValues, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetRowRemapperHistogram") {
+		var z0 nvml.RowRemapperHistogramValues
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetRowRemapperHistogram()
+}
+
+func (g guardedDevice) GetSerial() (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetSerial") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetSerial()
+}
+
+func (g guardedDevice) GetSramEccErrorStatus() (nvml.EccSramErrorStatus, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetSramEccErrorStatus") {
+		var z0 nvml.EccSramErrorStatus
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetSramEccErrorStatus()
+}
+
+func (g guardedDevice) GetSupportedClocksEventReasons() (uint64, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetSupportedClocksEventReasons") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetSupportedClocksEventReasons()
+}
+
+func (g guardedDevice) GetTemperature(p0 nvml.TemperatureSensors) (uint32, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetTemperature") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetTemperature(p0)
+}
+
+func (g guardedDevice) GetTotalEccErrors(p0 nvml.MemoryErrorType, p1 nvml.EccCounterType) (uint64, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetTotalEccErrors") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetTotalEccErrors(p0, p1)
+}
+
+func (g guardedDevice) GetTotalEnergyConsumption() (uint64, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetTotalEnergyConsumption") {
+		return 0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetTotalEnergyConsumption()
+}
+
+func (g guardedDevice) GetUtilizationRates() (nvml.Utilization, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetUtilizationRates") {
+		var z0 nvml.Utilization
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetUtilizationRates()
+}
+
+func (g guardedDevice) GetUUID() (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetUUID") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetUUID()
+}
+
+func (g guardedDevice) GetVbiosVersion() (string, nvml.Return) {
+	if !g.avail.has("nvmlDeviceGetVbiosVersion") {
+		return "", nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GetVbiosVersion()
+}
+
+func (g guardedDevice) GpmQueryDeviceSupport() (nvml.GpmSupport, nvml.Return) {
+	if !g.avail.has("nvmlGpmQueryDeviceSupport") {
+		var z0 nvml.GpmSupport
+
+		return z0, nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.GpmQueryDeviceSupport()
+}
+
+func (g guardedDevice) RegisterEvents(p0 uint64, p1 nvml.EventSet) nvml.Return {
+	if !g.avail.has("nvmlDeviceRegisterEvents") {
+		return nvml.ERROR_FUNCTION_NOT_FOUND
+	}
+
+	return g.dev.RegisterEvents(p0, p1)
+}

--- a/internal/nvmlnative/guard_nvml_internal_test.go
+++ b/internal/nvmlnative/guard_nvml_internal_test.go
@@ -1,0 +1,198 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/neilotoole/slogt/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectionMakesNoCallWhenNoSymbolIsAvailable is the fail-closed proof for
+// the whole guard. A driver library that exports none of the entry points must
+// produce a scrape that reaches zero NVML getters.
+//
+// The device mock is deliberately bare: go-nvml's generated mock panics on any
+// method whose stub is nil, so *reaching* any getter fails the test loudly.
+// Completing the collection is therefore evidence that the guard blocked every
+// call, and unlike a static analysis it understands loops, batched calls and
+// getters shared between the field, MIG, per-process and XID paths.
+func TestCollectionMakesNoCallWhenNoSymbolIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	// the only stub: uuid, which every per-GPU series is labeled by. Every
+	// other getter is nil, so reaching one panics the mock and fails the test.
+	bare := &mock.Device{ //nolint:exhaustruct // bare on purpose: any other call panics
+		GetUUIDFunc: func() (string, nvml.Return) { return "GPU-1", nvml.SUCCESS },
+	}
+
+	fake := &fakeAPI{devices: []nvml.Device{bare}}
+
+	api := fake.api()
+	// uuid is a startup requirement, so it stays available; everything else is
+	// absent, which is the case the guard has to survive
+	api.lookupSymbol = func(name string) error {
+		if name == "nvmlDeviceGetUUID" {
+			return nil
+		}
+
+		return errors.New("symbol not found")
+	}
+
+	backend, err := newWithAPI(api, slogt.New(t))
+	require.NoError(t, err)
+
+	fields := resolveFields(t, "AUTO")
+
+	opts := CollectOptions{ComputeApps: true, PCIeThroughput: true, Energy: true, MIG: true}
+
+	// must not panic: every getter is unavailable, so none may be reached
+	reading, _, err := backend.QueryFunc(fields, opts)(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, reading.Table)
+}
+
+// TestGuardedSymbolsMatchTheGuard keeps the probed symbol list in lockstep with
+// the adapter. Every symbol the adapter checks must be probed at startup, and
+// every probed symbol must be checked by something, so neither list can rot
+// into a guard that is never armed or a probe that protects nothing.
+func TestGuardedSymbolsMatchTheGuard(t *testing.T) {
+	t.Parallel()
+
+	var source []byte
+
+	for _, name := range []string{
+		"guard_nvml.go", "backend_nvml.go", "mig_nvml.go", "xid_nvml.go",
+	} {
+		part, err := os.ReadFile(name)
+		require.NoError(t, err)
+
+		source = append(source, part...)
+	}
+
+	// every NVML symbol name the adapter mentions, however the call is wrapped
+	referenced := map[string]bool{}
+	for _, match := range regexp.MustCompile(`"(nvml[A-Z][A-Za-z0-9_]+)"`).FindAllStringSubmatch(string(source), -1) {
+		referenced[match[1]] = true
+	}
+
+	probed := map[string]bool{}
+	for _, symbol := range guardedSymbols {
+		probed[symbol] = true
+	}
+
+	for symbol := range referenced {
+		assert.True(t, probed[symbol],
+			"the adapter guards %s but guardedSymbols does not probe it,\n"+
+				"  so the guard is never armed: add it to guardsymbols_nvml.go", symbol)
+	}
+
+	for symbol := range probed {
+		// the seam-level guards live outside the adapter, so allow a probed
+		// symbol that no adapter method references
+		if referenced[symbol] || strings.HasSuffix(symbol, "ValidateInforom") {
+			continue
+		}
+
+		assert.Fail(t, "unused probe",
+			"guardedSymbols probes %s but nothing guards on it", symbol)
+	}
+}
+
+// TestCollectorDoesNotCallRawDeviceMethods enforces the boundary itself: only
+// the adapter may hold an nvml.Device and call methods on it. Collector code
+// must go through the guarded interface, so that a newly added getter cannot
+// reach the driver without a probe. This is the invariant that keeps the class
+// of bug closed rather than merely fixing the instances known today.
+func TestCollectorDoesNotCallRawDeviceMethods(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+
+	for _, entry := range entries {
+		name := entry.Name()
+		// the adapter is where raw handles legitimately live
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == "guard_nvml.go" {
+			continue
+		}
+
+		file, parseErr := parser.ParseFile(fset, name, nil, 0)
+		require.NoError(t, parseErr)
+
+		assertNoRawDeviceType(t, fset, file, name)
+	}
+}
+
+// assertNoRawDeviceType reports declarations outside the adapter that name
+// nvml.Device as a parameter, which would hand collector code an unguarded
+// handle. The seam struct and the raw-keyed XID map are the deliberate
+// exceptions, both documented at their definitions.
+func assertNoRawDeviceType(t *testing.T, fset *token.FileSet, file *ast.File, name string) {
+	t.Helper()
+
+	allowed := map[string]bool{
+		"nvmlAPI":     true, // the seam holds raw handles by design
+		"realNVML":    true,
+		"xidRegister": true, // events come back keyed by the raw handle
+		"recordXID":   true,
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		decl, ok := n.(*ast.FuncDecl)
+		if !ok || allowed[decl.Name.Name] {
+			return true
+		}
+
+		for _, param := range decl.Type.Params.List {
+			sel, isSel := param.Type.(*ast.SelectorExpr)
+			if !isSel || sel.Sel.Name != "Device" {
+				continue
+			}
+
+			assert.Fail(t, "raw device outside the adapter",
+				"%s: %s takes an nvml.Device; collector code must take the guarded "+
+					"device interface so every entry point is probed first",
+				fset.Position(decl.Pos()), decl.Name.Name)
+		}
+
+		return true
+	})
+
+	_ = name
+}
+
+// TestNewRefusesWithoutTheIdentityExport pins the one export that cannot
+// degrade. Without it every GPU reports the same uuid label and their series
+// collapse into one, so starting would publish a corrupt scrape.
+func TestNewRefusesWithoutTheIdentityExport(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAPI{devices: []nvml.Device{identityDevice()}}
+
+	api := fake.api()
+	api.lookupSymbol = func(name string) error {
+		if name == "nvmlDeviceGetUUID" {
+			return errors.New("symbol not found")
+		}
+
+		return nil
+	}
+
+	_, err := newWithAPI(api, slogt.New(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nvmlDeviceGetUUID")
+}

--- a/internal/nvmlnative/guardsymbols_nvml.go
+++ b/internal/nvmlnative/guardsymbols_nvml.go
@@ -1,0 +1,104 @@
+//go:build linux && cgo
+
+package nvmlnative
+
+// guardedSymbols are the exact driver-library exports the guarded device
+// surface binds, one per call site. They are the symbols probed at
+// initialization; anything absent makes its call answer
+// ERROR_FUNCTION_NOT_FOUND instead of entering cgo and crashing the process.
+//
+// These are the literal symbols go-nvml binds, derived from its generated
+// bindings, NOT the "any of these spellings" sets in nvmlSymbolRequirements.
+// Those exist for the capture-inventory drift test and are deliberately
+// broader: go-nvml compiles with NVML_NO_UNVERSIONED_FUNC_DEFS, so each cgo
+// wrapper binds one literal name and an alternative spelling being present
+// does not make the call safe.
+//
+// A test keeps this list in lockstep with the guard.
+//
+//nolint:gochecknoglobals // shared manifest, mirrors the guard
+var guardedSymbols = []string{
+	"nvmlDeviceGetAccountingBufferSize",
+	"nvmlDeviceGetAccountingMode",
+	"nvmlDeviceGetAddressingMode",
+	"nvmlDeviceGetC2cModeInfoV",
+	"nvmlDeviceGetClockInfo",
+	"nvmlDeviceGetComputeInstanceId",
+	"nvmlDeviceGetComputeMode",
+	"nvmlDeviceGetConfComputeProtectedMemoryUsage",
+	"nvmlDeviceGetCudaComputeCapability",
+	"nvmlDeviceGetCurrPcieLinkGeneration",
+	"nvmlDeviceGetCurrPcieLinkWidth",
+	"nvmlDeviceGetCurrentClocksEventReasons",
+	"nvmlDeviceGetDecoderUtilization",
+	"nvmlDeviceGetDisplayActive",
+	"nvmlDeviceGetDisplayMode",
+	"nvmlDeviceGetDramEncryptionMode",
+	"nvmlDeviceGetEccMode",
+	"nvmlDeviceGetEncoderStats",
+	"nvmlDeviceGetEncoderUtilization",
+	"nvmlDeviceGetEnforcedPowerLimit",
+	"nvmlDeviceGetFanSpeed",
+	"nvmlDeviceGetFieldValues",
+	"nvmlDeviceGetGpuFabricInfoV",
+	"nvmlDeviceGetGpuInstanceId",
+	"nvmlDeviceGetGpuMaxPcieLinkGeneration",
+	"nvmlDeviceGetGpuOperationMode",
+	"nvmlDeviceGetGspFirmwareMode",
+	"nvmlDeviceGetHostname_v1",
+	"nvmlDeviceGetIndex",
+	"nvmlDeviceGetInforomImageVersion",
+	"nvmlDeviceGetInforomVersion",
+	"nvmlDeviceGetJpgUtilization",
+	"nvmlDeviceGetMarginTemperature",
+	"nvmlDeviceGetMaxClockInfo",
+	"nvmlDeviceGetMaxMigDeviceCount",
+	"nvmlDeviceGetMaxPcieLinkGeneration",
+	"nvmlDeviceGetMaxPcieLinkWidth",
+	"nvmlDeviceGetMemoryErrorCounter",
+	"nvmlDeviceGetMemoryInfo_v2",
+	"nvmlDeviceGetMigDeviceHandleByIndex",
+	"nvmlDeviceGetMigMode",
+	"nvmlDeviceGetName",
+	"nvmlDeviceGetOfaUtilization",
+	"nvmlDeviceGetPciInfoExt",
+	"nvmlDeviceGetPcieThroughput",
+	"nvmlDeviceGetPerformanceState",
+	"nvmlDeviceGetPersistenceMode",
+	"nvmlDeviceGetPlatformInfo",
+	"nvmlDeviceGetPowerManagementDefaultLimit",
+	"nvmlDeviceGetPowerManagementLimit",
+	"nvmlDeviceGetPowerManagementLimitConstraints",
+	"nvmlDeviceGetPowerUsage",
+	"nvmlDeviceGetRemappedRows",
+	"nvmlDeviceGetRemappedRows_v2",
+	"nvmlDeviceGetRetiredPages",
+	"nvmlDeviceGetRetiredPagesPendingStatus",
+	"nvmlDeviceGetRowRemapperHistogram",
+	"nvmlDeviceGetSerial",
+	"nvmlDeviceGetSramEccErrorStatus",
+	"nvmlDeviceGetSupportedClocksEventReasons",
+	"nvmlDeviceGetTemperature",
+	"nvmlDeviceGetTotalEccErrors",
+	"nvmlDeviceGetTotalEnergyConsumption",
+	"nvmlDeviceGetUUID",
+	"nvmlDeviceGetUtilizationRates",
+	"nvmlDeviceGetVbiosVersion",
+	"nvmlDeviceValidateInforom",
+	"nvmlGpmSampleAlloc",
+	"nvmlGpmSampleFree",
+	"nvmlGpmMigSampleGet",
+	"nvmlGpmMetricsGet",
+	"nvmlEventSetCreate",
+	"nvmlEventSetFree",
+	"nvmlSystemGetProcessName",
+	"nvmlSystemGetDriverVersion",
+	"nvmlSystemGetCudaDriverVersion",
+	"nvmlDeviceGetDriverModel",
+	"nvmlDeviceGetDriverModel_v2",
+	"nvmlDeviceGetComputeRunningProcesses",
+	"nvmlDeviceGetComputeRunningProcesses_v2",
+	"nvmlDeviceGetComputeRunningProcesses_v3",
+	"nvmlDeviceRegisterEvents",
+	"nvmlGpmQueryDeviceSupport",
+}

--- a/internal/nvmlnative/mig_nvml.go
+++ b/internal/nvmlnative/mig_nvml.go
@@ -71,7 +71,7 @@ type migGroup struct {
 //
 //nolint:cyclop // one linear pass: mode gate, enumeration, GPM per instance
 func (b *Backend) collectMIG(
-	dev nvml.Device,
+	dev device,
 	parentUUID string,
 	extras *collect.Extras,
 	seenGIs map[string]bool,
@@ -102,6 +102,13 @@ func (b *Backend) collectMIG(
 	// get their retained samples mistaken for orphans
 	for _, group := range groups {
 		seenGIs[giKey(parentUUID, group.gi)] = true
+	}
+
+	// GPM is an all-or-nothing group: sampling allocates a handle that must be
+	// freed through a second export, so a driver providing only part of the set
+	// would either leak or crash on teardown.
+	if !b.gpmAvailable() {
+		return false
 	}
 
 	support, ret := dev.GpmQueryDeviceSupport()
@@ -151,7 +158,7 @@ func giKey(parentUUID string, gi int) string {
 //
 //nolint:cyclop,funlen // one linear enumeration pass with per-getter fallbacks
 func (b *Backend) enumerateMIG(
-	dev nvml.Device,
+	dev device,
 	parentUUID string,
 	extras *collect.Extras,
 ) ([]migGroup, bool) {
@@ -254,7 +261,7 @@ func (b *Backend) enumerateMIG(
 // whether extras collection may continue.
 //
 //nolint:cyclop // the retention guards are a linear rule set
-func (b *Backend) gpmUtilization(dev nvml.Device, key string, group migGroup) (*collect.MIGUtilization, bool) {
+func (b *Backend) gpmUtilization(dev device, key string, group migGroup) (*collect.MIGUtilization, bool) {
 	fingerprint := strings.Join(group.members, ",")
 	now := b.now()
 
@@ -281,7 +288,7 @@ func (b *Backend) gpmUtilization(dev nvml.Device, key string, group migGroup) (*
 		return nil, b.extrasFailure("mig-gpm", "cannot allocate a GPM sample", ret)
 	}
 
-	if ret := b.api.gpmMigSampleGet(dev, group.gi, sample); ret != nvml.SUCCESS {
+	if ret := b.api.gpmMigSampleGet(dev.raw(), group.gi, sample); ret != nvml.SUCCESS {
 		_ = b.api.gpmSampleFree(sample)
 
 		return nil, b.extrasFailure("mig-gpm", "cannot sample the GPU instance activity", ret)
@@ -405,7 +412,7 @@ func (b *Backend) dropOrphanGPMStates(seenGIs map[string]bool) {
 // ("NVIDIA H100 80GB HBM3 MIG 1g.10gb"), falling back to the full name when
 // the shape is unknown, or to the absent token when unreadable. The return
 // code is reported so the caller can classify lifecycle failures.
-func migProfile(mig nvml.Device) (string, nvml.Return) {
+func migProfile(mig device) (string, nvml.Return) {
 	name, ret := mig.GetName()
 	if ret != nvml.SUCCESS {
 		return tokenNotAvailable, ret
@@ -443,4 +450,16 @@ func migAppID(id uint32) string {
 	}
 
 	return strconv.FormatUint(uint64(id), 10)
+}
+
+// gpmAvailable reports whether the driver exports every GPM entry point the
+// sampling path uses. They are probed as a set because the family allocates a
+// sample through one export and releases it through another.
+func (b *Backend) gpmAvailable() bool {
+	return b.avail.Load().hasAll(
+		"nvmlGpmSampleAlloc",
+		"nvmlGpmSampleFree",
+		"nvmlGpmMigSampleGet",
+		"nvmlGpmMetricsGet",
+	)
 }

--- a/internal/nvmlnative/mig_nvml.go
+++ b/internal/nvmlnative/mig_nvml.go
@@ -68,8 +68,6 @@ type migGroup struct {
 // collectMIG gathers one parent device's MIG inventory, memory and GPM
 // utilization into extras. seenGIs records the GPM state keys touched this
 // cycle for orphan cleanup. Reports whether extras collection may continue.
-//
-//nolint:cyclop // one linear pass: mode gate, enumeration, GPM per instance
 func (b *Backend) collectMIG(
 	dev device,
 	parentUUID string,
@@ -111,6 +109,17 @@ func (b *Backend) collectMIG(
 		return false
 	}
 
+	return b.collectMIGUtilization(dev, parentUUID, extras, groups)
+}
+
+// collectMIGUtilization samples per-GPU-instance activity and stamps it onto
+// the instances enumerated for this parent.
+func (b *Backend) collectMIGUtilization(
+	dev device,
+	parentUUID string,
+	extras *collect.Extras,
+	groups []migGroup,
+) bool {
 	support, ret := dev.GpmQueryDeviceSupport()
 
 	switch {

--- a/internal/nvmlnative/symbols.go
+++ b/internal/nvmlnative/symbols.go
@@ -14,6 +14,19 @@ type symbolRequirement struct {
 
 //nolint:gochecknoglobals,goconst // shared requirement manifest; field names repeat by design
 var nvmlSymbolRequirements = []symbolRequirement{
+	{
+		// the guarded surface collapses the handler indirection: the adapter
+		// calls GetC2cModeInfoV().V1(), collector code calls this.
+		goCall: "GetC2cModeInfoV1",
+		anyOf:  []string{"nvmlDeviceGetC2cModeInfoV"},
+		serves: "c2c.mode",
+	},
+	{
+		// as above, for the fabric handler's V2.
+		goCall: "GetGpuFabricInfoV2",
+		anyOf:  []string{"nvmlDeviceGetGpuFabricInfoV"},
+		serves: "fabric.*",
+	},
 	{goCall: "init", anyOf: []string{"nvmlInit_v2", "nvmlInit"}, serves: "NVML initialization"},
 	{goCall: "shutdown", anyOf: []string{"nvmlShutdown"}, serves: "NVML shutdown"},
 	{

--- a/internal/nvmlnative/xid_nvml.go
+++ b/internal/nvmlnative/xid_nvml.go
@@ -180,13 +180,22 @@ func (b *Backend) xidRegister(warnings *xidWatcherLog) (nvml.EventSet, map[nvml.
 
 	generation := b.generation.Load()
 
+	// the event set is a resource group as well: it is created, waited on and
+	// freed through separate exports, so it is only safe to create when all of
+	// them are present.
+	if !b.avail.Load().hasAll(
+		"nvmlEventSetCreate", "nvmlEventSetFree", "nvmlDeviceRegisterEvents",
+	) {
+		return nil, nil, 0, false
+	}
+
 	set, ret := b.api.eventSetCreate()
 	if ret != nvml.SUCCESS {
 		if !warnings.createWarned {
 			warnings.createWarned = true
 
 			b.logger.Warn("cannot create an NVML event set, XID errors will not be counted",
-				"nvml_return", ret.String())
+				"nvml_return", retString(ret))
 		}
 
 		return nil, nil, 0, false
@@ -202,7 +211,7 @@ func (b *Backend) xidRegister(warnings *xidWatcherLog) (nvml.EventSet, map[nvml.
 	uuids := map[nvml.Device]string{}
 
 	for deviceIdx := range count {
-		dev, ret := b.api.deviceByIndex(deviceIdx)
+		dev, ret := b.device(deviceIdx)
 		if ret != nvml.SUCCESS {
 			continue
 		}
@@ -217,13 +226,13 @@ func (b *Backend) xidRegister(warnings *xidWatcherLog) (nvml.EventSet, map[nvml.
 				warnings.registerWarned = true
 
 				b.logger.Warn("cannot register for XID error events on a GPU",
-					"uuid", nvidiasmi.NormalizeUUID(uuid), "nvml_return", ret.String())
+					"uuid", nvidiasmi.NormalizeUUID(uuid), "nvml_return", retString(ret))
 			}
 
 			continue
 		}
 
-		uuids[dev] = nvidiasmi.NormalizeUUID(uuid)
+		uuids[dev.raw()] = nvidiasmi.NormalizeUUID(uuid)
 	}
 
 	if len(uuids) == 0 {
@@ -317,7 +326,7 @@ func (b *Backend) warnOnceXID(msg string, ret nvml.Return) {
 
 	b.xids.waitWarned = true
 
-	b.logger.Warn(msg, "nvml_return", ret.String())
+	b.logger.Warn(msg, "nvml_return", retString(ret))
 }
 
 // recordXID folds one received event into the accumulator.


### PR DESCRIPTION
A user running the experimental nvml backend on driver 570.153.02 reported the exporter dying on its first collection with `undefined symbol: nvmlDeviceGetAddressingMode`, after it had already logged that it was listening.

The bindings reference driver entry points directly and the loader resolves them lazily, at the first call. A driver that predates an entry point therefore does not answer with a function-not-found status: there is no way to return from a call that was never resolved, so the process is killed. The field in question is part of the automatically detected set, so this was a guaranteed crash for every user of that backend on a driver older than the one the field catalog was verified against, not an edge case.

The collector now reaches the driver only through a guarded surface. Every entry point it uses is probed when the library is initialized, and a call whose export is missing answers with a function-not-found status without entering the driver. The existing paths already render that status as an absent series, so such a driver now loses individual metrics instead of the whole exporter. The probe repeats on re-initialization, since a driver can be replaced underneath a running process, and the result is published as an immutable snapshot because the event watcher reads it outside the collection lock.

Families that acquire and release a resource through separate entry points are probed as a set, because a partially present family would leak or die on teardown. The identity getter is required at startup instead: every per-GPU series is labeled by it, so an absent one would give all GPUs the same identity and collapse their series, which is a corrupt scrape rather than a reduced one. Describing a driver status no longer calls the driver, which had put a driver call on the paths that run when the driver is already misbehaving.

The probed entry points are derived from what the bindings actually reference, not from the alternative spellings recorded for the capture drift tests. Those are deliberately broader and several of them do not exist at all, so probing them would report an entry point as usable while the real call still crashed. The few whose version the bindings select themselves keep that behavior and are probed as a set.

Three tests keep this from rotting: a scrape against a library exporting nothing must complete without reaching a single getter, the probed list and the guarded surface must agree, and collector code must not name a raw device handle so a newly added getter cannot reach the driver unprobed.