### PR TITLE
test: fuzz the parsers that read driver and user input

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 # Windows would otherwise break the whole suite).
 internal/captures/*.txt text eol=lf
 internal/integration/testdata/*.metrics text eol=lf
+
+# The fuzz seed corpora encode their values as Go string literals, so a CRLF
+# conversion would silently change the input each entry replays.
+internal/*/testdata/fuzz/**  text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,20 @@ Consequences to keep in mind before changing anything here:
 - The GPU-hardware parity test is behind a build tag and never runs in CI, but CI compiles it, so it cannot rot between the rare sessions where real hardware is available.
 - The nvml backend's drift tests check its catalog and its required driver symbols against the recorded captures, so a driver that renames or withdraws something is caught offline.
 
+### Fuzzing
+
+The corpus covers the driver output that has been seen; fuzz targets cover the output that has not.
+That gap is real here, because the exec backend parses whatever a driver, a platform or a user's wrapper command prints, and a panic in a parser takes the whole exporter down.
+
+Every fuzz target asserts a property rather than just the absence of a panic, and the properties are the contracts callers already rely on: a parsed table is safe to index by column, a transformed value is finite, a discovered field name survives being joined into a query, a derived metric name is registrable.
+`task test:fuzz` drives the search; `task test` replays the seed corpora, so a fixed bug stays fixed without anyone running a fuzzer.
+Targets live in `fuzz_test.go` next to the package they cover, or `fuzz_internal_test.go` when they need unexported access, which is the repo's convention for internal-package tests and what the `testpackage` linter allows.
+
+Two rules keep the targets honest, both learned by getting them wrong first:
+
+- Assert at the layer that owns the invariant, not the layer below it. A metric name is only required to be registrable where all the names are built together, because that is where a collision can be seen and where a single bad descriptor would otherwise fail every scrape.
+- Constrain a target to the input domain the code actually receives. Handing the fake's projection an invocation shape the fake never routes there produces failures that describe the test, not the code.
+
 ## Metrics and their compatibility contract
 
 Exported metric names are a public contract, and breaking one is the most expensive mistake available in this repo.
@@ -133,6 +147,12 @@ Some specifics that regularly surprise people:
   The MIG attribution labels on the per-process metrics are the precedent to follow.
 - Fields that report a state rather than a number are mapped to numbers.
   An unavailable value is not exported at all; an unrecognized value is also not exported, but is logged, because guessing at a brand-new driver state is worse than a visible gap.
+- A derived metric name that is unusable costs the whole scrape, not one series, because the exporter registers as a single collector on every scrape and the registry rejects a bad descriptor wholesale.
+  So a field whose returned name yields an empty name, or a name another field or one of the exporter's own families already owns, is dropped with a logged error instead.
+  When several fields contend for one name, *all* of them are dropped: which field owns a derived name is not knowable here, and publishing one field's reading under a contested name would put a wrong value on an established series.
+  The fixed family names live in one list in `internal/exporter`, pinned by a test against what the exporter actually describes, so a new family cannot be added without reserving its name.
+- Every field list, whether the user wrote it or auto-detection discovered it, is deduplicated and has the identity fields appended before it is queried.
+  Cells are assigned to fields positionally, so a duplicate would be queried twice and emit two samples for one series, failing the whole scrape.
 
 `docs/METRICS.md` carries the reference and the per-family semantics; keep it in sync when the surface changes.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,6 +84,42 @@ tasks:
       - task: stage
         vars: {TARGET: unit-tests}
 
+  # `task test` already replays every fuzz target's seed corpus, which is where
+  # the regression value sits. This drives the actual search instead, one target
+  # at a time because -fuzz only ever fuzzes one.
+  #
+  # It bind-mounts the working tree the way fmt does, rather than running as a
+  # stage: a discovered failure is written to testdata/fuzz/ and has to survive
+  # into the tree, which a stage that copies the sources cannot do. The cache
+  # volume also keeps the generated corpus between runs, so successive sessions
+  # build on each other's coverage instead of starting cold.
+  test:fuzz:
+    desc: 'search for new fuzz failures (FUZZTIME=30s per target)'
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+      FUZZ: >-
+        docker run --rm -u "$(id -u):$(id -g)"
+        -e GOFLAGS=-mod=mod -e HOME=/tmp
+        -e GOCACHE=/tmp/go-build -e GOMODCACHE=/tmp/go-mod
+        -v nvidia-gpu-exporter-fmt-cache:/tmp
+        -v "$PWD":/src -w /src nvidia-gpu-exporter-tools:local
+    cmds:
+      - >-
+        docker buildx build -f hack/dev.Dockerfile
+        --build-arg GO_VERSION="$(sed -n 's/^go //p' go.mod)"
+        --target fmt --load --tag nvidia-gpu-exporter-tools:local .
+      - |
+        set -eu
+        for pkg in $({{.FUZZ}} go list ./...); do
+          # a listing failure means the package does not compile, which has to
+          # surface rather than read as "no fuzz targets here"
+          listed="$({{.FUZZ}} go test -list 'Fuzz' "$pkg")"
+          for target in $(printf '%s\n' "$listed" | grep '^Fuzz' || true); do
+            echo "==> $pkg $target ({{.FUZZTIME}})"
+            {{.FUZZ}} go test "$pkg" -run '^$' -fuzz "^${target}\$" -fuzztime '{{.FUZZTIME}}'
+          done
+        done
+
   chart:docs:
     desc: regenerate the chart README from the values.yaml comments
     cmds:

--- a/internal/app/fuzz_internal_test.go
+++ b/internal/app/fuzz_internal_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// FuzzValidateMetricsPath asserts what validateMetricsPath exists for: an
+// accepted telemetry path must be registrable on the mux beside the exporter's
+// own routes without panicking, and must not shadow them. Route registration
+// panics are startup crashes, and a shadowed health route is a silent outage.
+func FuzzValidateMetricsPath(f *testing.F) {
+	f.Add("/metrics")
+	f.Add("/-/healthy")
+	f.Add("/debug/pprof/x")
+	f.Add("/a b")
+	f.Fuzz(func(t *testing.T, metricsPath string) {
+		if err := validateMetricsPath(metricsPath); err != nil {
+			return
+		}
+
+		mux := http.NewServeMux()
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("accepted path %q panics route registration: %v", metricsPath, r)
+				}
+			}()
+
+			mux.Handle("GET /{$}", http.NotFoundHandler())
+			mux.Handle("GET "+metricsPath, http.NotFoundHandler())
+			mux.HandleFunc("GET /-/healthy", healthHandler("Healthy"))
+			mux.HandleFunc("GET /-/ready", healthHandler("Ready"))
+			registerPprof(mux)
+		}()
+
+		// the accepted path must not swallow a reserved route
+		for _, reserved := range []string{"/-/healthy", "/-/ready", "/debug/pprof/", "/debug/pprof/profile"} {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://x"+reserved, nil)
+			if err != nil {
+				continue
+			}
+
+			if _, pattern := mux.Handler(req); pattern == "GET "+metricsPath {
+				t.Fatalf("accepted path %q captures the reserved route %q", metricsPath, reserved)
+			}
+		}
+	})
+}

--- a/internal/capture/fuzz_test.go
+++ b/internal/capture/fuzz_test.go
@@ -1,0 +1,44 @@
+package capture_test
+
+import (
+	"testing"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/capture"
+)
+
+const seedCapture = "################################################################################\n" +
+	"# machine: test\n" +
+	"################################################################################\n" +
+	"\nsome metadata\n\n" +
+	"################################################################################\n" +
+	"# idle :: query-gpu (csv, what the exporter parses)\n" +
+	"# $ nvidia-smi --query-gpu=uuid,name --format=csv\n" +
+	"################################################################################\n" +
+	"\nuuid, name\nGPU-abc, Tesla T4\n\n"
+
+func FuzzParse(f *testing.F) {
+	f.Add(seedCapture)
+	f.Add("")
+	f.Fuzz(func(t *testing.T, content string) {
+		capt, err := capture.Parse(content)
+		if err != nil {
+			return
+		}
+
+		for index, section := range capt.Sections {
+			// State and Label are how every consumer addresses a section; an
+			// empty state makes a section unaddressable by Find.
+			if section.State == "" {
+				t.Fatalf("section %d parsed with an empty state", index)
+			}
+
+			// Every parsed section must be reachable through the accessor the
+			// fake and the tests use. A section that parses but cannot be
+			// looked up is a capture that silently serves nothing.
+			if capt.Find(section.State, section.Label) == nil {
+				t.Fatalf("section %d (%q :: %q) parsed but Find cannot reach it",
+					index, section.State, section.Label)
+			}
+		}
+	})
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -145,7 +147,8 @@ func New(
 	exitCodeMetric ExitCodeMetric,
 	logger *slog.Logger,
 ) *GPUExporter {
-	qFieldToMetricInfoMap := BuildQFieldToMetricInfoMap(prefix, fields.Returned, logger)
+	qFieldToMetricInfoMap := BuildQFieldToMetricInfoMap(
+		prefix, fields.Returned, reservedMetricNames(prefix, exitCodeMetric), logger)
 
 	// cuda_version rides gpu_info but is not a query field: it comes from the
 	// collection's extras, so it is appended after the resolved info fields
@@ -772,42 +775,46 @@ func (e *GPUExporter) renderRow(metricCh chan<- prometheus.Metric, row nvidiasmi
 	e.sendMetric(metricCh, infoMetric)
 
 	for _, currentCell := range row.Cells {
-		metricInfo := e.qFieldToMetricInfoMap[currentCell.QField]
-
-		num, numErr := nvidiasmi.TransformFieldValue(
-			currentCell.QField, currentCell.RawValue, metricInfo.ValueMultiplier)
-		if numErr != nil {
-			switch {
-			case errors.Is(numErr, nvidiasmi.ErrAbsentValue):
-				// expected unavailable reading (e.g. an unsupported field), skip quietly
-			case nvidiasmi.IsEnumMappedField(currentCell.QField):
-				// an enum field returned a value we do not map: never guess a number,
-				// but surface it so a new/unexpected state is not silently invisible
-				e.logger.Warn("skipping metric: unrecognized enum value", "query_field_name",
-					currentCell.QField, "raw_value", currentCell.RawValue)
-			default:
-				e.logger.Debug("failed to transform raw value", "err", numErr, "query_field_name",
-					currentCell.QField, "raw_value", currentCell.RawValue)
-			}
-
-			continue
-		}
-
-		metric, metricErr := prometheus.NewConstMetric(
-			metricInfo.desc,
-			metricInfo.MType,
-			num,
-			uuid,
-		)
-		if metricErr != nil {
-			e.logger.Error("failed to create metric", "err", metricErr, "query_field_name",
-				currentCell.QField, "raw_value", currentCell.RawValue)
-
-			continue
-		}
-
-		e.sendMetric(metricCh, metric)
+		e.renderCell(metricCh, currentCell, uuid)
 	}
+}
+
+// renderCell emits one query field's metric for one GPU. A cell no descriptor
+// was built for is skipped: BuildQFieldToMetricInfoMap reported it once at
+// startup, and there is nothing to emit it under.
+func (e *GPUExporter) renderCell(metricCh chan<- prometheus.Metric, cell nvidiasmi.Cell, uuid string) {
+	metricInfo, described := e.qFieldToMetricInfoMap[cell.QField]
+	if !described {
+		return
+	}
+
+	num, numErr := nvidiasmi.TransformFieldValue(cell.QField, cell.RawValue, metricInfo.ValueMultiplier)
+	if numErr != nil {
+		switch {
+		case errors.Is(numErr, nvidiasmi.ErrAbsentValue):
+			// expected unavailable reading (e.g. an unsupported field), skip quietly
+		case nvidiasmi.IsEnumMappedField(cell.QField):
+			// an enum field returned a value we do not map: never guess a number,
+			// but surface it so a new/unexpected state is not silently invisible
+			e.logger.Warn("skipping metric: unrecognized enum value", "query_field_name",
+				cell.QField, "raw_value", cell.RawValue)
+		default:
+			e.logger.Debug("failed to transform raw value", "err", numErr, "query_field_name",
+				cell.QField, "raw_value", cell.RawValue)
+		}
+
+		return
+	}
+
+	metric, metricErr := prometheus.NewConstMetric(metricInfo.desc, metricInfo.MType, num, uuid)
+	if metricErr != nil {
+		e.logger.Error("failed to create metric", "err", metricErr, "query_field_name",
+			cell.QField, "raw_value", cell.RawValue)
+
+		return
+	}
+
+	e.sendMetric(metricCh, metric)
 }
 
 // sendMetric delivers unconditionally: the Prometheus registry drains the
@@ -829,14 +836,121 @@ type MetricInfo struct {
 	ValueMultiplier float64
 }
 
+// fixedMetricNames are the metric names the exporter owns outside the query
+// field schema, without the prefix. They are listed rather than derived because
+// they are built across several constructors; TestReservedMetricNamesCoverAll
+// pins the list against what the exporter actually describes, so a new family
+// cannot be added without appearing here.
+var fixedMetricNames = []string{
+	// health
+	"failed_scrapes_total", "last_collect_success",
+	"last_collect_success_timestamp_seconds", "last_collect_duration_seconds",
+	// identity
+	"gpu_info",
+	// per-process
+	"compute_app_info", "compute_app_used_memory_bytes", "compute_apps",
+	"compute_apps_last_collect_success",
+	// nvml extras
+	"pcie_throughput_tx_bytes_per_second", "pcie_throughput_rx_bytes_per_second",
+	"energy_joules_total",
+	"mig_info", "mig_memory_total_bytes", "mig_memory_used_bytes",
+	"mig_memory_free_bytes", "mig_memory_reserved_bytes",
+	"mig_graphics_activity_ratio", "mig_sm_activity_ratio", "mig_sm_occupancy_ratio",
+	"mig_tensor_activity_ratio",
+	"mig_pcie_throughput_tx_bytes_per_second", "mig_pcie_throughput_rx_bytes_per_second",
+	// XID
+	"xid_errors_total", "xid_last_timestamp_seconds",
+}
+
+// reservedMetricNames returns the fully-qualified names no query field may
+// claim. Every family is reserved regardless of whether its feature is on, so
+// enabling one later cannot turn a working configuration into a failing one.
+func reservedMetricNames(prefix string, exitCodeMetric ExitCodeMetric) map[string]struct{} {
+	names := make(map[string]struct{}, len(fixedMetricNames)+2)
+
+	for _, name := range fixedMetricNames {
+		names[prometheus.BuildFQName(prefix, "", name)] = struct{}{}
+	}
+
+	// both backends' collection status names, so switching backend cannot
+	// newly collide either
+	for _, metric := range []ExitCodeMetric{ExecExitCodeMetric, NVMLReturnCodeMetric, exitCodeMetric} {
+		names[prometheus.BuildFQName(prefix, "", metric.Name)] = struct{}{}
+	}
+
+	return names
+}
+
+// BuildQFieldToMetricInfoMap builds the per-field metric descriptors. A field
+// whose returned name yields no usable metric name, one another field already
+// claimed, or one reserved by a family the exporter owns, is left out: the whole
+// exporter is registered as one collector on every scrape, so a single
+// unusable or conflicting descriptor would fail every scrape wholesale instead
+// of costing one series.
 func BuildQFieldToMetricInfoMap(
 	prefix string,
 	qFieldtoRFieldMap map[nvidiasmi.QField]nvidiasmi.RField,
+	reserved map[string]struct{},
 	logger *slog.Logger,
 ) map[nvidiasmi.QField]MetricInfo {
-	result := make(map[nvidiasmi.QField]MetricInfo)
-	for qField, rField := range qFieldtoRFieldMap {
-		result[qField] = BuildMetricInfo(prefix, rField, logger)
+	// Sorted, so the outcome never depends on map iteration order.
+	qFields := slices.Sorted(maps.Keys(qFieldtoRFieldMap))
+
+	// derived once per field, so the guards below and the descriptor can never
+	// disagree about the name
+	type derived struct {
+		fqName     string
+		multiplier float64
+	}
+
+	names := make(map[nvidiasmi.QField]derived, len(qFields))
+	claimants := make(map[string][]nvidiasmi.QField, len(qFields))
+
+	for _, qField := range qFields {
+		fqName, multiplier := BuildFQNameAndMultiplier(prefix, qFieldtoRFieldMap[qField], logger)
+		names[qField] = derived{fqName: fqName, multiplier: multiplier}
+		claimants[fqName] = append(claimants[fqName], qField)
+	}
+
+	result := make(map[nvidiasmi.QField]MetricInfo, len(qFields))
+
+	for _, qField := range qFields {
+		rField := qFieldtoRFieldMap[qField]
+
+		fqName := names[qField].fqName
+		if fqName == "" {
+			logger.Error("skipping metric: returned field yields no metric name",
+				"query_field_name", qField, "rfield_name", rField)
+
+			continue
+		}
+
+		if _, isReserved := reserved[fqName]; isReserved {
+			logger.Error("skipping metric: returned field maps to a metric name the exporter owns, "+
+				"please report it in the project's issue tracker",
+				"metric_name", fqName, "query_field_name", qField, "rfield_name", rField)
+
+			continue
+		}
+
+		// Every claimant of a contested name is dropped, not just the losers.
+		// Which query field "owns" a derived name is not something this can
+		// know, and publishing one field's reading under a name another field
+		// also claims would put a wrong value on an established series. An
+		// absent metric is a visible gap; a plausible wrong one is not.
+		if others := claimants[fqName]; len(others) > 1 {
+			logger.Error("skipping metric: several returned fields map to the same metric name, "+
+				"please report it in the project's issue tracker",
+				"metric_name", fqName, "query_field_names", others)
+
+			continue
+		}
+
+		result[qField] = MetricInfo{
+			desc:            prometheus.NewDesc(fqName, string(rField), []string{uuidLabel}, nil),
+			MType:           prometheus.GaugeValue,
+			ValueMultiplier: names[qField].multiplier,
+		}
 	}
 
 	return result

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -164,6 +164,7 @@ func TestBuildQFieldToMetricInfoMap(t *testing.T) {
 	qFieldToMetricInfoMap := exporter.BuildQFieldToMetricInfoMap(
 		"prefix",
 		map[nvidiasmi.QField]nvidiasmi.RField{"aaa": "AAA", "bbb": "BBB"},
+		nil,
 		logger,
 	)
 

--- a/internal/exporter/fuzz_internal_test.go
+++ b/internal/exporter/fuzz_internal_test.go
@@ -1,0 +1,59 @@
+package exporter
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/collect"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+// emptySource serves a snapshot with no reading, which is enough to register.
+type emptySource struct{}
+
+func (emptySource) Latest(context.Context) collect.Snapshot { return collect.Snapshot{} }
+
+// FuzzExporterRegisters asserts the property the whole metric surface depends
+// on: whatever returned field names a driver hands back, the exporter registers
+// as one collector. Registration happens per scrape against a fresh registry,
+// so a descriptor the registry rejects answers every scrape with an error
+// rather than costing a single series. The exporter is built and registered
+// whole, with every feature on, because that is what production does and
+// because a query field can collide with a family the exporter owns, not just
+// with another query field.
+func FuzzExporterRegisters(f *testing.F) {
+	f.Add("utilization.gpu [%]", "memory.total [MiB]")
+	f.Add("power.draw [W]", "clocks.current.sm [MHz]")
+	f.Add("", "x")
+	f.Add("foo.bar", "foo_bar")
+	f.Add("x [W]", "x_watts")
+	f.Add("gpu.info", "failed_scrapes_total")
+	f.Add("energy_joules_total", "xid_errors_total")
+	f.Fuzz(func(t *testing.T, first, second string) {
+		returned := map[nvidiasmi.QField]nvidiasmi.RField{
+			"first":  nvidiasmi.RField(first),
+			"second": nvidiasmi.RField(second),
+		}
+
+		fields := nvidiasmi.ResolvedFields{
+			Query:    []nvidiasmi.QField{"first", "second"},
+			Returned: returned,
+			Info:     []nvidiasmi.InfoField{{QField: nvidiasmi.UUIDQField, Label: "uuid"}},
+		}
+
+		features := Features{
+			ComputeApps: true, ComputeAppMIGLabels: true, PCIeThroughput: true,
+			Energy: true, MIG: true, XIDEvents: true,
+		}
+
+		exp := New(context.Background(), DefaultPrefix, fields, emptySource{},
+			features, nil, NVMLReturnCodeMetric, slog.New(slog.DiscardHandler))
+
+		if err := prometheus.NewRegistry().Register(exp); err != nil {
+			t.Fatalf("returned fields %q and %q make the exporter unregistrable: %v", first, second, err)
+		}
+	})
+}

--- a/internal/exporter/reserved_internal_test.go
+++ b/internal/exporter/reserved_internal_test.go
@@ -1,0 +1,58 @@
+package exporter
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+var fqNameInDesc = regexp.MustCompile(`fqName: "([^"]*)"`)
+
+// TestReservedMetricNamesCoverAll pins fixedMetricNames against what the
+// exporter actually describes with every feature on. It is what keeps the list
+// from rotting: a new metric family added without a matching entry would let a
+// returned field claim its name and make every scrape fail to register.
+func TestReservedMetricNamesCoverAll(t *testing.T) {
+	t.Parallel()
+
+	fields := nvidiasmi.ResolvedFields{
+		Info: []nvidiasmi.InfoField{{QField: nvidiasmi.UUIDQField, Label: "uuid"}},
+	}
+
+	features := Features{
+		ComputeApps: true, ComputeAppMIGLabels: true, PCIeThroughput: true,
+		Energy: true, MIG: true, XIDEvents: true,
+	}
+
+	for _, exitCodeMetric := range []ExitCodeMetric{ExecExitCodeMetric, NVMLReturnCodeMetric} {
+		exp := New(context.Background(), DefaultPrefix, fields, emptySource{},
+			features, nil, exitCodeMetric, slog.New(slog.DiscardHandler))
+
+		reserved := reservedMetricNames(DefaultPrefix, exitCodeMetric)
+
+		descCh := make(chan *prometheus.Desc, 128)
+
+		go func() {
+			exp.Describe(descCh)
+			close(descCh)
+		}()
+
+		for desc := range descCh {
+			match := fqNameInDesc.FindStringSubmatch(desc.String())
+			if match == nil {
+				t.Fatalf("could not read the metric name out of %s", desc)
+			}
+
+			if _, ok := reserved[match[1]]; !ok {
+				t.Errorf("metric %q is described but not reserved: add it to fixedMetricNames, "+
+					"or a returned field of the same name would make every scrape fail to register",
+					match[1])
+			}
+		}
+	}
+}

--- a/internal/exporter/testdata/fuzz/FuzzBuildQFieldToMetricInfoMap/colliding-returned-fields
+++ b/internal/exporter/testdata/fuzz/FuzzBuildQFieldToMetricInfoMap/colliding-returned-fields
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("foo.bar")
+string("foo_bar")

--- a/internal/exporter/testdata/fuzz/FuzzBuildQFieldToMetricInfoMap/empty-returned-field
+++ b/internal/exporter/testdata/fuzz/FuzzBuildQFieldToMetricInfoMap/empty-returned-field
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("")
+string("name")

--- a/internal/fakesmi/fluctuate.go
+++ b/internal/fakesmi/fluctuate.go
@@ -174,7 +174,10 @@ var numericPrefix = regexp.MustCompile(`^[+-]?\d+(\.\d+)?`)
 // caller. A tail containing digits is also refused: it means the cell is not
 // the "<number><unit>" shape (an exponent form the exporter rejects, a
 // timestamp, a second number), and rewriting it could turn a cell the
-// exporter drops into one it accepts.
+// exporter drops into one it accepts. A tail starting with "x" is refused for
+// the same reason: the cell is a hex value (the exporter reads "0x..." as hex,
+// digits in the tail or not), and rewriting its numeric prefix would change the
+// value's base rather than its magnitude.
 func parseNumericCell(cell string) (numericCell, bool) {
 	token := numericPrefix.FindString(cell)
 	if token == "" {
@@ -183,6 +186,10 @@ func parseNumericCell(cell string) (numericCell, bool) {
 
 	suffix := cell[len(token):]
 	if strings.ContainsAny(suffix, "0123456789") {
+		return numericCell{}, false
+	}
+
+	if strings.HasPrefix(strings.ToLower(suffix), "x") {
 		return numericCell{}, false
 	}
 

--- a/internal/fakesmi/fuzz_internal_test.go
+++ b/internal/fakesmi/fuzz_internal_test.go
@@ -1,0 +1,252 @@
+package fakesmi
+
+import (
+	"log/slog"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/capture"
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+// FuzzSplitRow asserts splitRow's contract: it either fails, or returns
+// exactly want cells. project() indexes the result by recorded column, so a
+// short result is an index panic one caller away.
+func FuzzSplitRow(f *testing.F) {
+	f.Add("GPU-abc, 123, python, 40960 MiB", 4, 2)
+	f.Add("a, b", 2, -1)
+	f.Fuzz(func(t *testing.T, row string, want, freeTextColumn int) {
+		// real query-gpu captures carry 200+ columns, so the bound has to be
+		// well above that to cover the shape the fake actually replays
+		if want < 1 || want > 512 || freeTextColumn >= want || freeTextColumn < -1 {
+			return
+		}
+
+		cells, err := splitRow(row, want, freeTextColumn)
+		if err != nil {
+			return
+		}
+
+		if len(cells) != want {
+			t.Fatalf("returned %d cells, want %d", len(cells), want)
+		}
+	})
+}
+
+// FuzzFluctuateStaysParseable is the differential property the fluctuator's own
+// doc comment claims: a cell it decides to rewrite must still be a cell the
+// exporter's transform accepts. If a rewrite made a value unparseable, demo and
+// compose runs would silently lose series.
+func FuzzFluctuateStaysParseable(f *testing.F) {
+	f.Add("38 %", int64(1))
+	f.Add("39.32 W", int64(2))
+	f.Add("[N/A]", int64(3))
+	f.Add("214 MiB", int64(4))
+	f.Fuzz(func(t *testing.T, cell string, seed int64) {
+		parsed, ok := parseNumericCell(cell)
+		if !ok {
+			return
+		}
+
+		// the exporter must accept the captured cell in the first place,
+		// otherwise there is no series to preserve
+		if _, err := nvidiasmi.TransformRawValue(cell, 1); err != nil {
+			return
+		}
+
+		rewritten := parsed.format(newFluctuator(seed).jitter("utilization.gpu", parsed))
+
+		value, err := nvidiasmi.TransformRawValue(rewritten, 1)
+		if err != nil {
+			t.Fatalf("jittered %q into %q, which the exporter rejects: %v", cell, rewritten, err)
+		}
+
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			t.Fatalf("jittered %q into %q, transformed to %v", cell, rewritten, value)
+		}
+	})
+}
+
+// FuzzProjectGPUQuery is the differential property the whole
+// developing-without-a-GPU story rests on: whatever a contributed capture
+// records, the GPU table the fake projects out of it is one the exporter's own
+// CSV parser accepts, with one row per recorded row per simulated GPU. The
+// command is assembled from the fuzzed field list rather than fuzzed whole,
+// because answer() only ever routes the two real query shapes into project().
+func FuzzProjectGPUQuery(f *testing.F) {
+	f.Add("uuid,name", "uuid, name\nGPU-abc, Tesla T4", uint16(0x3), 1)
+	f.Add("uuid,name,memory.used", "uuid, name, memory.used [MiB]\nGPU-abc, Tesla T4, 214 MiB", uint16(0x4), 3)
+	f.Fuzz(func(t *testing.T, fields, body string, requestMask uint16, gpus int) {
+		if gpus < 1 || gpus > 8 {
+			return
+		}
+
+		// The request is derived from the recorded field list rather than
+		// fuzzed independently: an unrelated request is rejected before the
+		// projection runs, so fuzzing it separately would spend most execs
+		// never reaching the code under test.
+		request := requestFrom(fields, requestMask)
+		if request == "" {
+			return
+		}
+
+		section := &capture.Section{
+			State:   "idle",
+			Label:   "query-gpu (csv",
+			Command: "nvidia-smi --query-gpu=" + fields + " --format=csv",
+			Body:    body,
+		}
+
+		output, err := project(section, request, newFuzzConfig(t, gpus))
+		if err != nil {
+			return
+		}
+
+		table, parseErr := nvidiasmi.ParseCSVIntoTable(output, toQFields(trimmedNames(request)))
+		if parseErr != nil {
+			t.Fatalf("projected output the exporter cannot parse: %v\noutput:\n%q", parseErr, output)
+		}
+
+		assertRowsPreserved(t, output, body, gpus, len(table.Rows))
+	})
+}
+
+// assertRowsPreserved checks that the projection carries one row per recorded
+// row per simulated GPU. The parser trims blank lines off both ends, so the
+// count is only meaningful when the projection has none. Rather than dropping
+// that part of the domain, the condition is decided on the input: a body whose
+// every cell is non-empty cannot legitimately project a blank line, so a blank
+// line there is itself the bug.
+func assertRowsPreserved(t *testing.T, output, body string, gpus, parsedRows int) {
+	t.Helper()
+
+	blank := hasBlankLine(output)
+
+	if allCellsNonEmpty(body) && blank {
+		t.Fatalf("projected a blank line from a body with no empty cell:\n%q", output)
+	}
+
+	if blank {
+		return
+	}
+
+	recordedRows := len(strings.Split(body, "\n")) - 1
+	if want := gpus * recordedRows; parsedRows != want {
+		t.Fatalf("projected %d rows, want %d (%d GPUs x %d recorded rows)",
+			parsedRows, want, gpus, recordedRows)
+	}
+}
+
+// hasBlankLine reports whether any line of output is empty once trimmed.
+func hasBlankLine(output string) bool {
+	for line := range strings.SplitSeq(output, "\n") {
+		if strings.TrimSpace(line) == "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// trimmedNames splits a comma-separated field list and trims each name.
+func trimmedNames(raw string) []string {
+	names := strings.Split(raw, ",")
+	for i := range names {
+		names[i] = strings.TrimSpace(names[i])
+	}
+
+	return names
+}
+
+// FuzzProjectComputeAppsQuery is the same property for the per-process query,
+// whose recorded field set the exporter always requests in full. Its process
+// name column may carry commas of its own, which is the one place the fake's
+// CSV shape and the exporter's parser have to agree on something non-trivial.
+func FuzzProjectComputeAppsQuery(f *testing.F) {
+	f.Add("gpu_uuid, pid, process_name, used_gpu_memory\nGPU-abc, 1, python, 4 MiB", 1)
+	f.Add("gpu_uuid, pid, process_name, used_gpu_memory\nGPU-abc, 1, a,b, 4 MiB", 2)
+	f.Fuzz(func(t *testing.T, body string, gpus int) {
+		if gpus < 1 || gpus > 8 {
+			return
+		}
+
+		const fields = "gpu_uuid,pid,process_name,used_gpu_memory"
+
+		section := &capture.Section{
+			State:   "idle",
+			Label:   "query-compute-apps",
+			Command: "nvidia-smi --query-compute-apps=" + fields + " --format=csv",
+			Body:    body,
+		}
+
+		output, err := project(section, fields, newFuzzConfig(t, gpus))
+		if err != nil {
+			return
+		}
+
+		if _, parseErr := nvidiasmi.ParseComputeApps(output, discardLogger); parseErr != nil {
+			t.Fatalf("projected output the exporter cannot parse: %v\noutput:\n%q", parseErr, output)
+		}
+	})
+}
+
+// newFuzzConfig builds the fullest replay configuration: multi-GPU identity
+// rewriting and fluctuation both on, so a projection has to survive every
+// transform stage.
+func newFuzzConfig(t *testing.T, gpus int) *config {
+	t.Helper()
+
+	identities, err := buildIdentities(gpus, nil)
+	if err != nil {
+		t.Fatalf("failed to build %d identities: %v", gpus, err)
+	}
+
+	overrides := make([]map[string]valueGen, gpus)
+	for i := range overrides {
+		overrides[i] = map[string]valueGen{}
+	}
+
+	return &config{gpus: identities, overrides: overrides, fluct: newFluctuator(1)}
+}
+
+// requestFrom picks a non-empty subset of a recorded field list, selected by
+// the bits of mask, preserving the recorded order.
+func requestFrom(fields string, mask uint16) string {
+	names := strings.Split(fields, ",")
+
+	picked := make([]string, 0, len(names))
+
+	for i, name := range names {
+		if i < 16 && mask&(1<<uint(i)) != 0 {
+			picked = append(picked, name)
+		}
+	}
+
+	return strings.Join(picked, ",")
+}
+
+// allCellsNonEmpty reports whether every comma-separated cell of every line of
+// body carries something once trimmed.
+func allCellsNonEmpty(body string) bool {
+	for line := range strings.SplitSeq(body, "\n") {
+		for cell := range strings.SplitSeq(line, ",") {
+			if strings.TrimSpace(cell) == "" {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+var discardLogger = slog.New(slog.DiscardHandler)
+
+func toQFields(names []string) []nvidiasmi.QField {
+	out := make([]nvidiasmi.QField, len(names))
+	for i, name := range names {
+		out[i] = nvidiasmi.QField(name)
+	}
+
+	return out
+}

--- a/internal/fakesmi/project.go
+++ b/internal/fakesmi/project.go
@@ -169,7 +169,17 @@ func recordedFields(command string) ([]string, error) {
 	for token := range strings.FieldsSeq(command) {
 		_, value, isQuery := strings.Cut(token, "=")
 		if isQuery && strings.HasPrefix(token, "--query-") && !strings.HasPrefix(token, "--format") {
-			return strings.Split(value, ","), nil
+			fields := strings.Split(value, ",")
+
+			// an unnamed column cannot be requested or projected, and would
+			// render as a blank cell the exporter silently drops
+			for _, field := range fields {
+				if strings.TrimSpace(field) == "" {
+					return nil, fmt.Errorf("recorded command %q has an empty field name", command)
+				}
+			}
+
+			return fields, nil
 		}
 	}
 

--- a/internal/fakesmi/testdata/fuzz/FuzzFluctuateStaysParseable/hex-shaped-cell
+++ b/internal/fakesmi/testdata/fuzz/FuzzFluctuateStaysParseable/hex-shaped-cell
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("+0x")
+int64(1)

--- a/internal/nvidiasmi/computeapps.go
+++ b/internal/nvidiasmi/computeapps.go
@@ -128,10 +128,21 @@ func parseComputeAppRow(line string, logger *slog.Logger) (ComputeApp, bool) {
 		return ComputeApp{}, false
 	}
 
+	// The uuid is what joins the per-process series to their GPU. Without one
+	// the row cannot be attributed, and several such rows would collapse onto
+	// one label set and fail the whole scrape as duplicates.
+	uuid := NormalizeUUID(fields[0])
+	if uuid == "" {
+		logger.Warn("skipping compute apps row with no gpu uuid",
+			"pid", pid, "row", strings.TrimSpace(line))
+
+		return ComputeApp{}, false
+	}
+
 	name := strings.TrimSpace(strings.Join(fields[2:len(fields)-1], ","))
 
 	return ComputeApp{
-		GPUUUID:     NormalizeUUID(fields[0]),
+		GPUUUID:     uuid,
 		PID:         pid,
 		ProcessName: name,
 		UsedMemory:  strings.TrimSpace(fields[len(fields)-1]),

--- a/internal/nvidiasmi/csv.go
+++ b/internal/nvidiasmi/csv.go
@@ -31,6 +31,19 @@ func ParseCSVIntoTable(queryResult string, qFields []QField) (Table, error) {
 	numCols := len(qFields)
 	numRows := len(valuesLines)
 
+	// The header must line up with what was asked for before anything is
+	// indexed by column. Checking it up front rather than per row also covers
+	// the header-only case: callers map the returned names back by query-field
+	// position, so a mismatch that survives here is an out-of-range access
+	// one caller away.
+	if numCols != len(rFields) {
+		return Table{}, fmt.Errorf(
+			"field count mismatch: query fields: %d, returned fields: %d",
+			numCols,
+			len(rFields),
+		)
+	}
+
 	rows := make([]Row, numRows)
 
 	qFieldToCells := make(map[QField][]Cell)
@@ -39,37 +52,16 @@ func ParseCSVIntoTable(queryResult string, qFields []QField) (Table, error) {
 	}
 
 	for rowIndex, valuesLine := range valuesLines {
-		qFieldToCell := make(map[QField]Cell, numCols)
-		cells := make([]Cell, numCols)
-		rawValues := parseCSVLine(valuesLine)
-
-		if len(qFields) != len(rFields) {
-			return Table{}, fmt.Errorf(
-				"field count mismatch: query fields: %d, returned fields: %d",
-				len(qFields),
-				len(rFields),
-			)
+		row, err := parseCSVRow(valuesLine, qFields, rFields)
+		if err != nil {
+			return Table{}, fmt.Errorf("row %d: %w", rowIndex+1, err)
 		}
 
-		for colIndex, rawValue := range rawValues {
-			currentQField := qFields[colIndex]
-			currentRField := rFields[colIndex]
-			tableCell := Cell{
-				QField:   currentQField,
-				RField:   currentRField,
-				RawValue: rawValue,
-			}
-			qFieldToCell[currentQField] = tableCell
-			cells[colIndex] = tableCell
-			qFieldToCells[currentQField][rowIndex] = tableCell
+		for colIndex, cell := range row.Cells {
+			qFieldToCells[qFields[colIndex]][rowIndex] = cell
 		}
 
-		tableRow := Row{
-			QFieldToCells: qFieldToCell,
-			Cells:         cells,
-		}
-
-		rows[rowIndex] = tableRow
+		rows[rowIndex] = row
 	}
 
 	return Table{
@@ -77,6 +69,40 @@ func ParseCSVIntoTable(queryResult string, qFields []QField) (Table, error) {
 		RFields:       rFields,
 		QFieldToCells: qFieldToCells,
 	}, nil
+}
+
+// parseCSVRow splits one data line into cells, one per query field.
+func parseCSVRow(valuesLine string, qFields []QField, rFields []RField) (Row, error) {
+	numCols := len(qFields)
+	rawValues := parseCSVLine(valuesLine)
+
+	// A row that does not match the header has no defined column mapping: this
+	// output has no quoting, so a value containing a comma is indistinguishable
+	// from an extra column. Failing the collection reports no GPU data, which
+	// is the contract; guessing would export values under the wrong metrics.
+	if len(rawValues) != numCols {
+		return Row{}, fmt.Errorf(
+			"has %d columns, want %d: %q",
+			len(rawValues),
+			numCols,
+			strings.TrimSpace(valuesLine),
+		)
+	}
+
+	qFieldToCell := make(map[QField]Cell, numCols)
+	cells := make([]Cell, numCols)
+
+	for colIndex, rawValue := range rawValues {
+		cell := Cell{
+			QField:   qFields[colIndex],
+			RField:   rFields[colIndex],
+			RawValue: rawValue,
+		}
+		qFieldToCell[cell.QField] = cell
+		cells[colIndex] = cell
+	}
+
+	return Row{QFieldToCells: qFieldToCell, Cells: cells}, nil
 }
 
 func parseCSVLine(line string) []string {

--- a/internal/nvidiasmi/fields.go
+++ b/internal/nvidiasmi/fields.go
@@ -222,12 +222,25 @@ func ParseAutoQFields(
 	return fields, nil
 }
 
+// ExtractQFields extracts the queryable field names from --help-query-gpu
+// output. A name carrying a comma or a line break is dropped: the query joins
+// the names with commas, so such a name would silently turn into two columns
+// the returned header cannot account for.
 func ExtractQFields(text string) []QField {
 	found := fieldRegex.FindAllStringSubmatch(text, -1)
 
-	fields := make([]QField, len(found))
-	for i, ss := range found {
-		fields[i] = QField(ss[1])
+	fields := make([]QField, 0, len(found))
+
+	for _, ss := range found {
+		if strings.ContainsAny(ss[1], ",\r\n") {
+			continue
+		}
+
+		fields = append(fields, QField(ss[1]))
+	}
+
+	if len(fields) == 0 {
+		return nil
 	}
 
 	return fields

--- a/internal/nvidiasmi/fuzz_test.go
+++ b/internal/nvidiasmi/fuzz_test.go
@@ -1,0 +1,307 @@
+package nvidiasmi_test
+
+import (
+	"log/slog"
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/utkuozdemir/nvidia_gpu_exporter/internal/nvidiasmi"
+)
+
+var discard = slog.New(slog.DiscardHandler)
+
+// cudaVersionShape is the shape ParseCudaVersion promises to return, restated
+// here so the assertion does not lean on the implementation's own pattern.
+var cudaVersionShape = regexp.MustCompile(`^[0-9]+\.[0-9]+$`)
+
+func toQFields(raw string) []nvidiasmi.QField {
+	names := strings.Split(raw, ",")
+
+	qFields := make([]nvidiasmi.QField, len(names))
+	for i, name := range names {
+		qFields[i] = nvidiasmi.QField(name)
+	}
+
+	return qFields
+}
+
+// FuzzParseCSVIntoTable covers the exporter's hottest untrusted input: the CSV
+// nvidia-smi prints, whose shape varies by driver, platform and GPU, and which
+// a custom command can replace entirely. A table that parses must be safe to
+// index by column, since that is exactly what every caller does with it.
+func FuzzParseCSVIntoTable(f *testing.F) {
+	f.Add("name, uuid\nTesla T4, GPU-abc\n", "name,uuid")
+	f.Add("utilization.gpu [%]\n38 %\n", "utilization.gpu")
+	f.Add("", "")
+	// a row wider than the header, and one narrower: both used to be accepted
+	f.Add("name, uuid\nTesla T4, GPU-abc, extra\n", "name,uuid")
+	f.Add("name, uuid\nTesla T4\n", "name,uuid")
+	// a header that disagrees with the request and no data rows to catch it
+	f.Add("name, uuid", "name,uuid,index")
+	f.Fuzz(func(t *testing.T, output, fieldsRaw string) {
+		qFields := toQFields(fieldsRaw)
+
+		table, err := nvidiasmi.ParseCSVIntoTable(output, qFields)
+		if err != nil {
+			return
+		}
+
+		// callers map the returned names back by query-field position
+		if len(table.RFields) != len(qFields) {
+			t.Fatalf("accepted a table with %d returned fields for %d query fields",
+				len(table.RFields), len(qFields))
+		}
+
+		for rowIndex := range table.Rows {
+			assertRowConsistent(t, table, qFields, output, rowIndex)
+		}
+	})
+}
+
+// assertRowConsistent checks that one parsed row is addressable the way every
+// caller addresses it: one cell per query field, each cell carrying its own
+// column's query and returned field, the by-field lookups agreeing with the
+// positional slice, and the values being that line's own. A violation here
+// silently exports one field's reading under another field's metric.
+func assertRowConsistent(
+	t *testing.T,
+	table nvidiasmi.Table,
+	qFields []nvidiasmi.QField,
+	output string,
+	rowIndex int,
+) {
+	t.Helper()
+
+	row := table.Rows[rowIndex]
+
+	if len(row.Cells) != len(qFields) {
+		t.Fatalf("row %d has %d cells, want %d", rowIndex, len(row.Cells), len(qFields))
+	}
+
+	for col, cell := range row.Cells {
+		if cell.QField != qFields[col] {
+			t.Fatalf("row %d column %d carries query field %q, want %q",
+				rowIndex, col, cell.QField, qFields[col])
+		}
+
+		if cell.RField != table.RFields[col] {
+			t.Fatalf("row %d column %d carries returned field %q, want %q",
+				rowIndex, col, cell.RField, table.RFields[col])
+		}
+
+		// a duplicated field makes the by-field lookups ambiguous by
+		// construction, so they are only checked for unique ones
+		if !seenOnce(qFields, cell.QField) {
+			continue
+		}
+
+		if got := row.QFieldToCells[cell.QField]; got != cell {
+			t.Fatalf("row %d: by-field lookup of %q gives %+v, want %+v",
+				rowIndex, cell.QField, got, cell)
+		}
+
+		if got := table.QFieldToCells[cell.QField][rowIndex]; got != cell {
+			t.Fatalf("row %d: table lookup of %q gives %+v, want %+v",
+				rowIndex, cell.QField, got, cell)
+		}
+	}
+
+	rejoined := make([]string, 0, len(row.Cells))
+	for _, cell := range row.Cells {
+		rejoined = append(rejoined, cell.RawValue)
+	}
+
+	if got, want := strings.Join(rejoined, ","), trimmedCells(dataLine(output, rowIndex)); got != want {
+		t.Fatalf("row %d parsed to %q, want %q", rowIndex, got, want)
+	}
+}
+
+// seenOnce reports whether value appears exactly once in values.
+func seenOnce[T comparable](values []T, value T) bool {
+	count := 0
+
+	for _, candidate := range values {
+		if candidate == value {
+			count++
+		}
+	}
+
+	return count == 1
+}
+
+// dataLine returns the index-th data line of a CSV payload, the way the parser
+// splits it.
+func dataLine(output string, index int) string {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	return lines[index+1]
+}
+
+// trimmedCells splits a line on commas and trims each cell, matching how the
+// parser stores raw values.
+func trimmedCells(line string) string {
+	cells := strings.Split(line, ",")
+	for i := range cells {
+		cells[i] = strings.TrimSpace(cells[i])
+	}
+
+	return strings.Join(cells, ",")
+}
+
+// FuzzTransformRawValue covers the value side of the same input. Every cell a
+// driver prints reaches this, and whatever comes out becomes a metric value, so
+// a value that is not a number must be reported as an error rather than
+// exported as one.
+func FuzzTransformRawValue(f *testing.F) {
+	f.Add("38 %", 0.01)
+	f.Add("0x1F", 1.0)
+	f.Add("[N/A]", 1.0)
+	f.Add("Enabled", 1.0)
+	// finite on its own, infinite once scaled into bytes
+	f.Add("179769313486231570000000000000000000000000000000000000000000000000000"+
+		"0000000000000000000000000000000000000000000000000000000000000000000000"+
+		"0000000000000000000000000000000000000000000000000000000000000000000000"+
+		"00000000000000000000000000000000000000000000000000000000000000000 MiB", 1048576.0)
+	f.Add("2", math.MaxFloat64)
+	f.Fuzz(func(t *testing.T, raw string, multiplier float64) {
+		if math.IsNaN(multiplier) || math.IsInf(multiplier, 0) {
+			return
+		}
+
+		value, err := nvidiasmi.TransformRawValue(raw, multiplier)
+		if err != nil {
+			return
+		}
+
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			t.Fatalf("transformed %q to a non-finite value %v", raw, value)
+		}
+	})
+}
+
+// FuzzParseComputeApps covers the per-process query, whose process name column
+// carries workload-controlled text that drivers do not always sanitize.
+func FuzzParseComputeApps(f *testing.F) {
+	f.Add("gpu_uuid, pid, process_name, used_gpu_memory [MiB]\nGPU-abc, 123, python, 40960 MiB\n")
+	f.Add("gpu_uuid, pid, process_name, used_gpu_memory [MiB]\nGPU-abc, 123, a,b,c, [N/A]\n")
+	// a row with no uuid to attribute it to
+	f.Add("gpu_uuid, pid, process_name, used_gpu_memory [MiB]\n, 123, python, 40960 MiB\n")
+	// two rows differing only in a uuid neither of them has
+	f.Add("gpu_uuid, pid, process_name, used_gpu_memory [MiB]\n" +
+		", 1, python, 1 MiB\n, 1, python, 2 MiB\n")
+	f.Fuzz(func(t *testing.T, output string) {
+		apps, err := nvidiasmi.ParseComputeApps(output, discard)
+		if err != nil {
+			return
+		}
+
+		for _, app := range apps {
+			// the pid becomes a metric label; a row whose pid is unusable is
+			// meant to be skipped, not exported
+			if app.PID == "" || strings.ContainsAny(app.PID, "\n\r") {
+				t.Fatalf("kept a row with an unusable pid %q", app.PID)
+			}
+
+			// the uuid is what joins a process to its GPU; without one the
+			// series cannot be attributed, and several such rows collapse
+			// onto the same label set
+			if app.GPUUUID == "" {
+				t.Fatalf("kept a row with no gpu uuid: pid %q", app.PID)
+			}
+
+			// The row is parsed from the outside in, with the process name
+			// rejoined from whatever is left in the middle. Reassembling the
+			// four fields must reproduce some input line's cells, or a column
+			// shifted and the memory reading is being labelled as a process
+			// name.
+			rejoined := strings.Join([]string{
+				app.GPUUUID, app.PID, app.ProcessName, app.UsedMemory,
+			}, ",")
+
+			if !containsRejoinedRow(output, rejoined) {
+				t.Fatalf("parsed a row to %q, which is not in the input", rejoined)
+			}
+		}
+	})
+}
+
+// containsRejoinedRow reports whether any data line of output reassembles to
+// row, with the cells trimmed and the uuid normalized the way the parser does.
+func containsRejoinedRow(output, row string) bool {
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		cells := strings.Split(line, ",")
+		if len(cells) < 4 {
+			continue
+		}
+
+		// the free-text process name keeps the commas between the fixed cells
+		rejoined := strings.Join([]string{
+			nvidiasmi.NormalizeUUID(cells[0]),
+			strings.TrimSpace(cells[1]),
+			strings.TrimSpace(strings.Join(cells[2:len(cells)-1], ",")),
+			strings.TrimSpace(cells[len(cells)-1]),
+		}, ",")
+
+		if rejoined == row {
+			return true
+		}
+	}
+
+	return false
+}
+
+// FuzzSplitCommand covers the --nvidia-smi-command value, the one input a user
+// writes by hand. Its result is handed straight to exec, so an accepted command
+// must produce a usable argument vector.
+func FuzzSplitCommand(f *testing.F) {
+	f.Add("nvidia-smi")
+	f.Add(`"C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe"`)
+	f.Add("sudo nvidia-smi")
+	f.Fuzz(func(t *testing.T, command string) {
+		parts, err := nvidiasmi.SplitCommand(command)
+		if err != nil {
+			return
+		}
+
+		if len(parts) == 0 || parts[0] == "" {
+			t.Fatalf("returned an unusable argument vector %q for %q", parts, command)
+		}
+	})
+}
+
+// FuzzParseCudaVersion covers the --version output, whose lines drivers have
+// already renamed once. Anything that is not a version number has to be
+// dropped rather than exported as the cuda_version label.
+func FuzzParseCudaVersion(f *testing.F) {
+	f.Add("NVIDIA-SMI version : 590.48\nCUDA Version    : 13.1\n")
+	f.Add(`CUDA version : Deprecated, see "CUDA UMD version" instead` + "\nCUDA UMD version : 13.1\n")
+	f.Fuzz(func(t *testing.T, output string) {
+		version := nvidiasmi.ParseCudaVersion(output)
+		if version == "" {
+			return
+		}
+
+		if !cudaVersionShape.MatchString(version) {
+			t.Fatalf("returned %q, which is not a version number", version)
+		}
+	})
+}
+
+// FuzzExtractQFields covers auto-detection against --help-query-gpu output. A
+// discovered name is joined into the query with commas, so a name carrying a
+// separator would silently turn one column into two.
+func FuzzExtractQFields(f *testing.F) {
+	f.Add("\n\n\"timestamp\"\nThe timestamp.\n\n\"uuid\"\nThe uuid.\n")
+	// a discovered name carrying the separator the query joins names with
+	f.Add("\n\n\"uuid,name\"\nTwo fields in one name.\n")
+	f.Add("\n\n\"uuid\nname\"\nA name with a line break.\n")
+	f.Fuzz(func(t *testing.T, help string) {
+		for _, field := range nvidiasmi.ExtractQFields(help) {
+			if strings.ContainsAny(string(field), ",\n\r") {
+				t.Fatalf("discovered an unusable field name %q", field)
+			}
+		}
+	})
+}

--- a/internal/nvidiasmi/resolve.go
+++ b/internal/nvidiasmi/resolve.go
@@ -60,12 +60,7 @@ func ResolveFields(
 ) (ResolvedFields, error) {
 	qFieldsSeparated := strings.Split(qFieldsRaw, ",")
 
-	qFields := toQFieldSlice(qFieldsSeparated)
-	for _, infoField := range infoFields {
-		qFields = append(qFields, infoField.QField)
-	}
-
-	qFields = removeDuplicates(qFields)
+	qFields := withRequiredFields(toQFieldSlice(qFieldsSeparated))
 
 	auto := len(qFieldsSeparated) == 1 && qFieldsSeparated[0] == qFieldsAuto
 	if auto {
@@ -80,7 +75,12 @@ func ResolveFields(
 			return builtinResolvedFields(qFieldsExcludeRaw, logger), nil
 		}
 
-		qFields = parsed
+		// The discovered list goes through the same normalization as an
+		// explicit one. A field listed twice would otherwise be queried twice
+		// and emit two samples for one series, failing the whole scrape, and a
+		// list missing an identity field would leave the gpu_info labels it
+		// claims empty.
+		qFields = withRequiredFields(parsed)
 	}
 
 	qFields = filterExcludedQFields(qFields, qFieldsExcludeRaw, logger)
@@ -225,6 +225,19 @@ func withOptionalTimeout(ctx context.Context, d time.Duration) (context.Context,
 	return context.WithTimeout(ctx, d)
 }
 
+// withRequiredFields appends the identity fields backing the gpu_info metric
+// and drops duplicates, keeping first-seen order. Every field list, explicit or
+// discovered, passes through here: the query assigns cells positionally, so a
+// duplicate is two cells for one metric, and a missing identity field is a
+// gpu_info label with nothing behind it.
+func withRequiredFields(qFields []QField) []QField {
+	for _, infoField := range infoFields {
+		qFields = append(qFields, infoField.QField)
+	}
+
+	return removeDuplicates(qFields)
+}
+
 func removeDuplicates[T comparable](fields []T) []T {
 	valMap := make(map[T]struct{})
 
@@ -259,14 +272,11 @@ func ResolveFromCatalog(
 	var qFields []QField
 
 	if auto {
+		// the catalog is compiled in and known to be duplicate-free and to
+		// carry the identity fields, unlike a discovered list
 		qFields = slices.Clone(order)
 	} else {
-		qFields = toQFieldSlice(qFieldsSeparated)
-		for _, infoField := range infoFields {
-			qFields = append(qFields, infoField.QField)
-		}
-
-		qFields = removeDuplicates(qFields)
+		qFields = withRequiredFields(toQFieldSlice(qFieldsSeparated))
 	}
 
 	qFields = filterExcludedQFields(qFields, qFieldsExcludeRaw, logger)

--- a/internal/nvidiasmi/resolve_test.go
+++ b/internal/nvidiasmi/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os/exec"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,4 +109,62 @@ func TestResolveFieldsExplicitUnknownFieldStillFails(t *testing.T) {
 	)
 
 	require.ErrorContains(t, err, "brand_new.field")
+}
+
+// TestResolveFieldsAutoNormalizesDiscoveredList covers a --help-query-gpu
+// output that lists a field twice and omits the identity fields. The query
+// assigns cells positionally, so a duplicate would be queried twice and emit
+// two samples for one series, failing the whole scrape, and a missing identity
+// field would leave the gpu_info label it claims with nothing behind it.
+func TestResolveFieldsAutoNormalizesDiscoveredList(t *testing.T) {
+	t.Parallel()
+
+	helpText := "List of valid properties:\n\n\"name\"\n\n\"name\"\n\n\"temperature.gpu\"\n"
+
+	run := func(cmd *exec.Cmd) error {
+		if slices.Contains(cmd.Args, "--help-query-gpu") {
+			_, _ = cmd.Stdout.Write([]byte(helpText))
+
+			return nil
+		}
+
+		// echo a header matching whatever was requested, plus one data row
+		for _, arg := range cmd.Args {
+			fields, ok := strings.CutPrefix(arg, "--query-gpu=")
+			if !ok {
+				continue
+			}
+
+			names := strings.Split(fields, ",")
+			values := make([]string, len(names))
+
+			for i := range names {
+				values[i] = "1"
+			}
+
+			_, _ = cmd.Stdout.Write([]byte(strings.Join(names, ", ") + "\n" +
+				strings.Join(values, ", ") + "\n"))
+		}
+
+		return nil
+	}
+
+	resolved, err := nvidiasmi.ResolveFields(
+		t.Context(), "nvidia-smi", nvidiasmi.DefaultQField, "", time.Second, run, slogt.New(t),
+	)
+	require.NoError(t, err)
+
+	seen := map[nvidiasmi.QField]int{}
+	for _, qField := range resolved.Query {
+		seen[qField]++
+	}
+
+	for qField, count := range seen {
+		assert.Equalf(t, 1, count, "query field %q appears %d times", qField, count)
+	}
+
+	for _, infoField := range resolved.Info {
+		assert.Containsf(t, resolved.Query, infoField.QField,
+			"identity field %q is claimed by gpu_info but never queried", infoField.QField)
+	}
 }

--- a/internal/nvidiasmi/testdata/fuzz/FuzzParseCSVIntoTable/header-only-mismatch
+++ b/internal/nvidiasmi/testdata/fuzz/FuzzParseCSVIntoTable/header-only-mismatch
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("name, uuid")
+string("name,uuid,index")

--- a/internal/nvidiasmi/testdata/fuzz/FuzzParseCSVIntoTable/ragged-data-row
+++ b/internal/nvidiasmi/testdata/fuzz/FuzzParseCSVIntoTable/ragged-data-row
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("name, uuid\nTesla T4, GPU-abc, extra\n")
+string("name,uuid")

--- a/internal/nvidiasmi/transform.go
+++ b/internal/nvidiasmi/transform.go
@@ -3,6 +3,7 @@ package nvidiasmi
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -135,5 +136,15 @@ func parseSanitizedValueWithBestEffort(
 		return -1, fmt.Errorf("failed to parse float %q: %w", allNums[0], err)
 	}
 
-	return parsed * valueMultiplier, nil
+	scaled := parsed * valueMultiplier
+
+	// A reading large enough to overflow once scaled into its base unit is not
+	// a measurement. Reporting it as infinity would poison every rate and
+	// average computed over the series, so it is dropped like any other
+	// unusable value.
+	if math.IsInf(scaled, 0) || math.IsNaN(scaled) {
+		return -1, fmt.Errorf("value %q does not scale to a finite number", sanitizedValue)
+	}
+
+	return scaled, nil
 }


### PR DESCRIPTION
The capture corpus covers the nvidia-smi output that has been seen on real machines. This adds fuzz targets for the output that has not, which matters because the exec backend parses whatever a driver, a platform or a user's wrapper command prints, and a panic in a parser takes the whole exporter down rather than costing one reading.

Every target asserts a property the callers already rely on instead of just the absence of a panic: a parsed table is addressable by column and carries each line's own values, a transformed value is finite, a discovered field name survives being joined back into a query, a per-process row reassembles to the line it came from, the exporter registers as a collector, and the fake's projected output is something the exporter's own parser accepts. The last one is a differential check between the two halves of the developing-without-a-GPU story.

The search found these defects, all fixed here, each pinned by a seed corpus entry that fails if the fix is reverted:

- A data row with more columns than the header crashed the exporter. The output has no quoting, so an extra column and a value containing a comma are indistinguishable, and the collection now fails cleanly instead of indexing past the end of the field list. Reconstructing the value the way the per-process parser does is not possible here: that parser has a fixed four-field schema with one known free-text column, while this field list is arbitrary and has no designated free-text column, so guessing would export readings under the wrong metrics.
- A header that disagreed with the requested field list slipped through whenever the query returned no rows, because the check only ran inside the row loop. That crashed at startup while resolving the field mapping. The check moved ahead of the loop, where it covers the header-only case too.
- Auto-detection could discover a field name carrying a comma, which silently split into two columns the returned header could not account for. Such names are dropped.
- A discovered field list was used without the normalization an explicit list gets. A field listed twice was queried twice and emitted two samples for one series, failing every scrape, and a list missing an identity field left the gpu_info label it claims with nothing behind it. Both lists now go through the same normalization.
- A returned field name that yields an empty metric name, or one that collides, produced a descriptor the registry rejects. Since the exporter is registered per scrape, that answered every scrape with an error and only logged the reason. Collisions with the families the exporter owns were missed entirely, and picking a winner among contending fields would have published one field's reading under a name another field also claims, putting a wrong value on an established series. Every contender is now dropped, the exporter's own names are reserved, and rendering skips a field with no descriptor.
- A reading large enough to overflow once scaled into its base unit was exported as infinity, which would poison every rate and average computed over the series.
- A per-process row with no GPU uuid was kept, though it cannot be attributed to a GPU, and several such rows collapse onto one label set and fail the scrape as duplicates.

The fake gets two fixes on the same theme: it no longer rewrites a hex-valued cell, whose base its jitter would change rather than its magnitude, and it rejects a recorded command with an unnamed column.

task test replays the seed corpora, so the regressions are covered without anyone running a fuzzer. task test:fuzz drives the actual search through the same bind-mounted toolchain container the formatters use, so a discovered failure lands in the working tree and the generated corpus survives between runs.
